### PR TITLE
PoC: Get Group History from JS

### DIFF
--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -13,6 +13,7 @@ board_ui.dock_board <- function(id, x, ...) {
 
   tagList(
     show_hide_block_dep(),
+    track_active_group_dep(),
     off_canvas(
       id = NS(id, "blocks_offcanvas"),
       title = "Offcanvas blocks",


### PR DESCRIPTION
We could send it from JS if needed, seems not too complicated.

<img width="302" height="166" alt="image" src="https://github.com/user-attachments/assets/a538eb4a-bba5-4292-93cf-3fb4a8b4e432" />
