### PR TITLE
icon_style light

### DIFF
--- a/R/block-meta.R
+++ b/R/block-meta.R
@@ -145,6 +145,7 @@ blk_icon_data_uri <- function(icon_svg, color, size = 48,
 #' @param hex Hex color code
 #' @param alpha Alpha/opacity value between 0 and 1
 #' @keywords internal
+#' @noRd
 hex_to_rgba <- function(hex, alpha = 1.0) {
   # Remove # if present
   hex <- sub("^#", "", hex)

--- a/R/block-meta.R
+++ b/R/block-meta.R
@@ -90,28 +90,43 @@ blk_icon_data_uri <- function(icon_svg, color, size = 48,
 
   stopifnot(is_string(icon_svg), is_string(color), is.numeric(size))
 
+  # Get icon style preference (light or solid)
+  icon_style <- blockr_option("icon_style", "light")
+
   # Extract the path/content from the icon SVG
   # Icon SVG is typically: <svg ...><path d="..."/></svg>
   # We want just the inner content
   icon_content <- sub("^<svg[^>]*>", "", icon_svg)
   icon_content <- sub("</svg>$", "", icon_content)
 
-  # Create outer SVG with colored rounded rectangle and white icon
+  # Create outer SVG with colored rounded rectangle and icon
   icon_size <- size * 0.6  # Icon takes 60% of total size
   icon_offset <- size * 0.2  # Center the icon
   corner_radius <- size * 0.15  # 15% corner radius
+
+  # Determine icon fill and background opacity based on style
+  if (icon_style == "light") {
+    icon_fill <- color
+    bg_opacity <- 0.3
+  } else {
+    icon_fill <- "white"
+    bg_opacity <- 1.0
+  }
+
+  # Convert hex color to rgba with opacity
+  bg_color <- hex_to_rgba(color, bg_opacity)
 
   svg <- sprintf(
     "<svg xmlns=\"http://www.w3.org/2000/svg\"
         width=\"%d\" height=\"%d\" viewBox=\"0 0 %d %d\">
       <rect width=\"%d\" height=\"%d\" rx=\"%g\" ry=\"%g\" fill=\"%s\"/>
-      <g transform=\"translate(%g, %g)\" fill=\"white\">
+      <g transform=\"translate(%g, %g)\" fill=\"%s\">
         <svg width=\"%g\" height=\"%g\" viewBox=\"0 0 16 16\">%s</svg>
       </g>
     </svg>",
     size, size, size, size,
-    size, size, corner_radius, corner_radius, color,
-    icon_offset, icon_offset,
+    size, size, corner_radius, corner_radius, bg_color,
+    icon_offset, icon_offset, icon_fill,
     icon_size, icon_size, icon_content
   )
 
@@ -124,4 +139,20 @@ blk_icon_data_uri <- function(icon_svg, color, size = 48,
     "data:image/svg+xml;base64,%s",
     jsonlite::base64_enc(charToRaw(svg))
   )
+}
+
+#' Convert hex color to rgba with opacity
+#' @param hex Hex color code
+#' @param alpha Alpha/opacity value between 0 and 1
+#' @keywords internal
+hex_to_rgba <- function(hex, alpha = 1.0) {
+  # Remove # if present
+  hex <- sub("^#", "", hex)
+
+  # Convert hex to RGB
+  r <- strtoi(substr(hex, 1, 2), base = 16)
+  g <- strtoi(substr(hex, 3, 4), base = 16)
+  b <- strtoi(substr(hex, 5, 6), base = 16)
+
+  sprintf("rgba(%d, %d, %d, %g)", r, g, b, alpha)
 }


### PR DESCRIPTION
<img width="960" height="719" alt="image" src="https://github.com/user-attachments/assets/b4a3cdfa-ce7d-4d1c-a519-ee70d3f709d0" />

I think this looks a little more professional. 

This is `icon_style = "light"`, the new default. Restore old look with:
```r
options(blockr.icon_style = "solid")
```

Unfortunately, this also needs a tweak in blockr.dag.


