### PR TITLE
Style tweaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Imports:
     blockr.core (>= 0.1.1),
+    bsicons,
     shiny,
     shinyjs,
     bslib,

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -58,8 +58,8 @@ options_ui <- function(id, x, ...) {
   tagList(
     blockr_fab_dep(),
     tags$button(
-      class = "blockr-fab",
-      icon("gear"),
+      class = "blockr-edge-tab",
+      bsicons::bs_icon("chevron-left"),
       `data-bs-toggle` = "offcanvas",
       `data-bs-target` = paste0("#", offcanvas_id),
       `aria-controls` = offcanvas_id

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -360,17 +360,20 @@ update_blk_cond_observer <- function(conds, session = get_session()) {
       msgs <- NULL
 
       removeUI(
-        paste0("#", ns("errors_block"), " .alert")
+        paste0("#", ns("errors_block"), " > div")
       )
 
       if (length(cnds[["error"]])) {
         msgs <- tags$div(
-          class = sprintf("alert alert-danger"),
-          HTML(
-            cli::ansi_html(
-              paste(
-                unlist(cnds[["error"]]),
-                collapse = "\n"
+          class = "blockr-error",
+          bsicons::bs_icon("exclamation-circle", class = "blockr-error-icon"),
+          tags$span(
+            HTML(
+              cli::ansi_html(
+                paste(
+                  unlist(cnds[["error"]]),
+                  collapse = "<br>"
+                )
               )
             )
           )

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -7,8 +7,11 @@ edit_block_ui <- function(id, blk, blk_id, expr_ui, block_ui) {
     class = "card-body",
     div(
       class = "d-flex align-items-stretch gap-3",
-      # Icon element
-      blk_icon_data_uri(blk_info$icon, blk_info$color, 60, "inline"),
+      # Icon element with tooltip
+      span(
+        title = blk_info$description,
+        blk_icon_data_uri(blk_info$icon, blk_info$color, 46, "inline")
+      ),
       # Title section
       div(
         class = paste(
@@ -36,10 +39,35 @@ block_card_title <- function(block, id, info) {
   div(
     class = "flex-grow-1 pe-3",
     div(
-      class = "card-title mb-1",
-      style = "line-height: 1.3;",
+      class = "card-title mb-0",
+      style = "line-height: 1.0;",
       popover(
-        uiOutput(NS(id, "block_name_out"), inline = TRUE),
+        div(
+          title = "Click to rename",
+          class = "d-inline-flex align-items-center gap-2",
+          style = paste(
+            "padding: 4px 8px;",
+            "margin: -4px -8px;",
+            "border-radius: 4px;",
+            "cursor: pointer;",
+            "border: 2px dashed transparent;",
+            "transition: border-color 0.15s ease;"
+          ),
+          onmouseover = paste0(
+            "this.style.borderColor='#ddd';",
+            "this.querySelector('.edit-icon').style.opacity='1';"
+          ),
+          onmouseout = paste0(
+            "this.style.borderColor='transparent';",
+            "this.querySelector('.edit-icon').style.opacity='0';"
+          ),
+          uiOutput(NS(id, "block_name_out"), inline = TRUE),
+          icon(
+            "pen-to-square",
+            class = "edit-icon",
+            style = "opacity: 0; font-size: 0.7em; color: #bbb; transition: opacity 0.15s ease;"
+          )
+        ),
         title = "Provide a new title",
         textInput(
           NS(id, "block_name_in"),
@@ -49,21 +77,20 @@ block_card_title <- function(block, id, info) {
         )
       )
     ),
-    div(
-      class = "text-body-secondary small text-muted",
-      style = "line-height: 1.2;",
-      span(class(block)[1]),
-      tags$sup(
-        class = "ms-1",
-        tooltip(
-          icon("info-circle", style = "color: #9ca3af; font-size: 0.75em;"),
-          p(
-            icon("lightbulb"),
-            "How to use this block?",
-          ),
-          p(info$description, ".")
-        )
-      )
+    popover(
+      span(
+        class = "blockr-subtitle",
+        info$name
+      ),
+      # Title + package badge
+      div(
+        class = "d-flex align-items-center justify-content-between gap-2 mb-2",
+        tags$strong(info$name),
+        span(class = "badge-two-tone", info$package)
+      ),
+      # Description
+      p(class = "mb-0", info$description),
+      options = list(trigger = "hover")
     )
   )
 }
@@ -270,9 +297,9 @@ edit_block_server <- function(id, block_id, board, update, ...) {
       )
 
       output$block_name_out <- renderUI(
-        h3(
+        span(
           input$block_name_in,
-          tags$sup(icon("pencil-square", class = "fa-2xs"))
+          class = "blockr-title"
         )
       )
 

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -36,15 +36,22 @@ edit_block_ui <- function(id, blk, blk_id, expr_ui, block_ui) {
 }
 
 block_card_title <- function(block, id, info) {
+  ns <- NS(id)
+  input_id <- ns("block_name_in")
+
   div(
     class = "flex-grow-1 pe-3",
     div(
       class = "card-title mb-0",
       style = "line-height: 1.0;",
-      popover(
+      # Inline editable title container
+      div(
+        class = "blockr-inline-edit",
+        # Display mode - click to edit
         div(
+          id = ns("title_display"),
+          class = "blockr-title-display d-inline-flex align-items-center gap-2",
           title = "Click to rename",
-          class = "d-inline-flex align-items-center gap-2",
           style = paste(
             "padding: 4px 8px;",
             "margin: -4px -8px;",
@@ -61,7 +68,18 @@ block_card_title <- function(block, id, info) {
             "this.style.borderColor='transparent';",
             "this.querySelector('.edit-icon').style.opacity='0';"
           ),
-          uiOutput(NS(id, "block_name_out"), inline = TRUE),
+          onclick = sprintf(
+            paste0(
+              "this.style.display='none';",
+              "var editWrap = document.getElementById('%s');",
+              "editWrap.style.display='block';",
+              "var input = editWrap.querySelector('input');",
+              "input.focus();",
+              "input.select();"
+            ),
+            ns("title_edit")
+          ),
+          uiOutput(ns("block_name_out"), inline = TRUE),
           icon(
             "pen-to-square",
             class = "edit-icon",
@@ -73,12 +91,34 @@ block_card_title <- function(block, id, info) {
             )
           )
         ),
-        title = "Provide a new title",
-        textInput(
-          NS(id, "block_name_in"),
-          "Block name",
-          value = block_name(block),
-          updateOn = "blur"
+        # Edit mode - hidden by default
+        div(
+          id = ns("title_edit"),
+          class = "blockr-title-edit",
+          style = "display: none;",
+          textInput(
+            input_id,
+            label = NULL,
+            value = block_name(block)
+          ),
+          # JS to handle blur and enter key
+          tags$script(HTML(sprintf(
+            "$(document).ready(function() {
+              var input = $('#%s');
+              var display = $('#%s');
+              var editWrap = $('#%s');
+              input.on('blur', function() {
+                editWrap.hide();
+                display.css('display', 'flex');
+              });
+              input.on('keydown', function(e) {
+                if (e.key === 'Enter') {
+                  $(this).blur();
+                }
+              });
+            });",
+            input_id, ns("title_display"), ns("title_edit")
+          )))
         )
       )
     ),

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -242,7 +242,7 @@ block_card_content <- function(ns, expr_ui, block_ui) {
     ".accordion-body"
   )$addAttrs(
     style = paste0(
-      "background-color: white;",
+      "background-color: hsl(220, 3%, 98.5%);",
       "border-radius: 0;",
       "margin: 0 -16px 10px -16px;",
       "padding: 16px 16px 10px 16px;",

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -423,31 +423,27 @@ update_blk_cond_observer <- function(conds, session = get_session()) {
 create_issues_ui <- function(statuses, ns) {
 
   collapse_id <- ns("outputs_issues_collapse")
+  n_issues <- length(statuses)
+  issue_text <- paste(n_issues, if (n_issues == 1) "issue" else "issues")
 
   div(
     id = ns("outputs_issues"),
-    tags$button(
-      class = paste(
-        "btn btn-sm btn-outline-secondary",
-        "mt-2 mb-2 position-relative"
-      ),
-      type = "button",
+    class = "mt-3",
+    tags$div(
+      class = "d-flex align-items-center justify-content-between blockr-issues-toggle",
       `data-bs-toggle` = "collapse",
       `data-bs-target` = paste0("#", collapse_id),
       `aria-expanded` = "false",
       `aria-controls` = collapse_id,
-      "View issues",
-      span(
-        class = paste(
-          "position-absolute top-0 start-100",
-          "translate-middle badge rounded-pill bg-danger"
-        ),
-        length(statuses)
-      )
+      span(issue_text),
+      icon("chevron-down", class = "blockr-meta")
     ),
     collapse_container(
       id = collapse_id,
-      statuses
+      div(
+        class = "pt-2",
+        statuses
+      )
     )
   )
 }

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -242,7 +242,7 @@ block_card_content <- function(ns, expr_ui, block_ui) {
     ".accordion-body"
   )$addAttrs(
     style = paste0(
-      "background-color: hsl(220, 3%, 98.5%);",
+      "background-color: white;",
       "border-radius: 0;",
       "margin: 0 -16px 10px -16px;",
       "padding: 16px 16px 10px 16px;",

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -65,7 +65,12 @@ block_card_title <- function(block, id, info) {
           icon(
             "pen-to-square",
             class = "edit-icon",
-            style = "opacity: 0; font-size: 0.7em; color: #bbb; transition: opacity 0.15s ease;"
+            style = paste(
+              "opacity: 0;",
+              "font-size: 0.7em;",
+              "color: #bbb;",
+              "transition: opacity 0.15s ease;"
+            )
           )
         ),
         title = "Provide a new title",
@@ -196,7 +201,14 @@ block_card_content <- function(ns, expr_ui, block_ui) {
   )$find(
     ".accordion-body"
   )$addAttrs(
-    style = "background-color: var(--blockr-grey-200); border-radius: 8px; margin-bottom: 10px; padding-bottom: 10px; border: 1px solid var(--blockr-grey-300); box-shadow: var(--blockr-shadow);"
+    style = paste(
+      "background-color: var(--blockr-grey-200);",
+      "border-radius: 8px;",
+      "margin-bottom: 10px;",
+      "padding-bottom: 10px;",
+      "border: 1px solid var(--blockr-grey-300);",
+      "box-shadow: var(--blockr-shadow);"
+    )
   )$append(
     expr_ui
   )$allTags()
@@ -430,7 +442,10 @@ create_issues_ui <- function(statuses, ns) {
     id = ns("outputs_issues"),
     class = "mt-3",
     tags$div(
-      class = "d-flex align-items-center justify-content-between blockr-issues-toggle",
+      class = paste(
+        "d-flex align-items-center justify-content-between",
+        "blockr-issues-toggle"
+      ),
       `data-bs-toggle` = "collapse",
       `data-bs-target` = paste0("#", collapse_id),
       `aria-expanded` = "false",

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -195,6 +195,8 @@ block_card_content <- function(ns, expr_ui, block_ui) {
   )$reset(
   )$find(
     ".accordion-body"
+  )$addAttrs(
+    style = "background-color: var(--blockr-grey-200); border-radius: 8px; margin-bottom: 10px; padding-bottom: 10px; border: 1px solid var(--blockr-grey-300); box-shadow: var(--blockr-shadow);"
   )$append(
     expr_ui
   )$allTags()
@@ -215,6 +217,8 @@ block_card_content <- function(ns, expr_ui, block_ui) {
   )$reset(
   )$find(
     ".accordion-body"
+  )$addAttrs(
+    style = "padding: 0;"
   )$append(
     tagList(block_ui, div(id = ns("outputs_issues_wrapper")))
   )$allTags()

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -201,13 +201,13 @@ block_card_content <- function(ns, expr_ui, block_ui) {
   )$find(
     ".accordion-body"
   )$addAttrs(
-    style = paste(
-      "background-color: var(--blockr-grey-200);",
-      "border-radius: 8px;",
-      "margin-bottom: 10px;",
-      "padding-bottom: 10px;",
-      "border: 1px solid var(--blockr-grey-300);",
-      "box-shadow: var(--blockr-shadow);"
+    style = paste0(
+      "background-color: white;",
+      "border-radius: 0;",
+      "margin: 0 -16px 10px -16px;",
+      "padding: 16px 16px 10px 16px;",
+      "border-top: 1px solid var(--blockr-grey-300);",
+      "border-bottom: 1px solid var(--blockr-grey-300);"
     )
   )$append(
     expr_ui

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -107,14 +107,15 @@ block_card_toggles <- function(blk, ns) {
     inputId = ns("collapse_blk_sections"),
     status = "light",
     size = "sm",
-    choices = set_names(opts, paste0("<small>", opts, "</small>")),
+    choices = set_names(opts, c("Input", "Output")),
     individual = TRUE,
     selected = coal(attr(blk, "visible"), opts)
   )
 
-  # Remove the ms-auto class
-  section_toggles$attribs$class <- trimws(
-    gsub("form-group|ms-auto", "", section_toggles$attribs$class)
+  # Remove the ms-auto class, add blockr-section-toggle
+  section_toggles$attribs$class <- paste(
+    "blockr-section-toggle",
+    trimws(gsub("form-group|ms-auto", "", section_toggles$attribs$class))
   )
 
   section_toggles

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -110,6 +110,19 @@
   margin-top: 3px;
 }
 
+.blockr-issues-toggle {
+  cursor: pointer;
+  color: var(--blockr-color-text-meta);
+  font-size: var(--blockr-font-size-base);
+  padding: 8px 16px;
+  border-radius: 6px;
+  transition: background-color 0.15s ease;
+}
+
+.blockr-issues-toggle:hover {
+  background-color: var(--blockr-color-bg-hover);
+}
+
 /* Section toggle buttons (inputs/outputs) - matches dockview tabs */
 .blockr-section-toggle .btn.btn-light {
   background-color: var(--blockr-grey-200) !important;

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -274,3 +274,58 @@ h6, .h6 {
 small, .small {
   font-size: var(--blockr-font-size-sm);
 }
+
+/* ============================================
+   Tooltip & Popover Styling
+   ============================================ */
+.tooltip {
+  --bs-tooltip-bg: white;
+  --bs-tooltip-color: var(--blockr-color-text-secondary);
+  --bs-tooltip-opacity: 1;
+}
+
+.tooltip-inner {
+  font-size: var(--blockr-font-size-sm);
+  font-weight: var(--blockr-font-weight-normal);
+  padding: 8px 12px;
+  border-radius: 8px;
+  box-shadow: var(--blockr-shadow);
+  border: 1px solid var(--blockr-grey-300);
+  max-width: 250px;
+  text-align: left;
+}
+
+.tooltip-arrow::before {
+  border-top-color: white !important;
+  border-bottom-color: white !important;
+}
+
+/* Popover - light style matching tooltips */
+.popover {
+  --bs-popover-bg: white;
+  --bs-popover-border-color: var(--blockr-grey-300);
+  --bs-popover-body-color: var(--blockr-color-text-secondary);
+  border-radius: 8px;
+  box-shadow: var(--blockr-shadow);
+  max-width: 280px;
+}
+
+.popover-body {
+  font-size: var(--blockr-font-size-sm);
+  padding: 12px 14px;
+}
+
+.popover-header,
+.popover .btn-close {
+  display: none;
+}
+
+.popover-arrow::before {
+  border-top-color: var(--blockr-grey-300) !important;
+  border-bottom-color: var(--blockr-grey-300) !important;
+}
+
+.popover-arrow::after {
+  border-top-color: white !important;
+  border-bottom-color: white !important;
+}

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -85,14 +85,14 @@
   height: auto;
   width: auto;
   min-width: 150px;
-  border: 2px dashed #ddd;
-  border-radius: 4px;
+  border: 2px dashed #bbb;
+  border-radius: 8px;
   background: white;
   box-shadow: none;
 }
 
 .blockr-title-edit .form-control:focus {
-  border-color: #ccc;
+  border-color: #aaa;
   box-shadow: none;
   outline: none;
 }
@@ -212,11 +212,10 @@
   right: 0;
   top: 50%;
   transform: translateY(-50%);
-  width: 10px;
+  width: 14px;
   height: 80px;
-  background-color: white;
-  border: 1px solid var(--blockr-grey-300);
-  border-right: none;
+  background-color: #888;
+  border: none;
   border-radius: 8px 0 0 8px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -226,30 +225,30 @@
   justify-content: center;
   padding: 0;
   overflow: hidden;
-  box-shadow: -2px 0 6px rgba(0, 0, 0, 0.06);
+  box-shadow: -2px 0 6px rgba(0, 0, 0, 0.15);
 }
 
 /* Accent stripe on left edge */
 .blockr-edge-tab::before {
   content: '';
   position: absolute;
-  left: 3px;
+  left: 4px;
   top: 8px;
   bottom: 8px;
-  width: 3px;
-  background-color: var(--blockr-color-text-secondary);
+  width: 4px;
+  background-color: var(--blockr-grey-300);
   border-radius: 2px;
-  opacity: 0.6;
+  opacity: 1;
   transition: opacity 0.2s ease;
 }
 
 .blockr-edge-tab:hover {
   width: 28px;
-  background-color: white;
+  background-color: #777;
 }
 
 .blockr-edge-tab:hover::before {
-  opacity: 0.6;
+  background-color: var(--blockr-grey-300);
 }
 
 .blockr-edge-tab svg,
@@ -257,7 +256,7 @@
   opacity: 0;
   transition: opacity 0.2s ease;
   font-size: 14px;
-  color: var(--blockr-color-text-secondary);
+  color: #ccc;
 }
 
 .blockr-edge-tab:hover svg,

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -53,6 +53,47 @@
 }
 
 /* ============================================
+   Typography Classes
+   ============================================ */
+.blockr-title {
+  font-size: var(--blockr-font-size-title);
+  font-weight: var(--blockr-font-weight-semibold);
+  color: var(--blockr-color-text-primary);
+  margin: 0;
+}
+
+.blockr-subtitle {
+  font-size: var(--blockr-font-size-sm);
+  font-weight: var(--blockr-font-weight-normal);
+  color: var(--blockr-color-text-muted);
+  margin-left: 3px;
+}
+
+.blockr-section-header {
+  font-size: var(--blockr-font-size-section);
+  font-weight: var(--blockr-font-weight-medium);
+  color: var(--blockr-color-text-secondary);
+}
+
+.blockr-label {
+  font-size: var(--blockr-font-size-sm);
+  font-weight: var(--blockr-font-weight-medium);
+  color: var(--blockr-color-text-secondary);
+}
+
+.blockr-helper {
+  font-size: var(--blockr-font-size-sm);
+  font-weight: var(--blockr-font-weight-normal);
+  color: var(--blockr-color-text-muted);
+}
+
+.blockr-meta {
+  font-size: var(--blockr-font-size-xs);
+  font-weight: var(--blockr-font-weight-normal);
+  color: var(--blockr-color-text-meta);
+}
+
+/* ============================================
    FAB Button
    ============================================ */
 .blockr-fab {

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -93,6 +93,23 @@
   color: var(--blockr-color-text-meta);
 }
 
+.blockr-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 12px;
+  margin: 8px 0 18px 0;
+  color: var(--blockr-color-error);
+  font-size: var(--blockr-font-size-base);
+}
+
+.blockr-error-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  margin-top: 3px;
+}
+
 /* ============================================
    FAB Button
    ============================================ */

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -198,3 +198,79 @@
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
   }
 }
+
+/* ============================================
+   Bootstrap Base Overrides
+   ============================================ */
+body {
+  font-size: var(--blockr-font-size-base);
+}
+
+label,
+.form-label,
+.shiny-input-container .control-label {
+  font-size: var(--blockr-font-size-xs);
+  color: var(--blockr-color-text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.form-control, .form-select {
+  font-size: var(--blockr-font-size-base);
+}
+
+/* Selectize - set base font-size, spacing adjusts via em units */
+.selectize-control {
+  font-size: var(--blockr-font-size-base);
+}
+
+.selectize-input {
+  font-size: var(--blockr-font-size-base);
+}
+
+.selectize-dropdown {
+  font-size: var(--blockr-font-size-base);
+}
+
+/* Buttons - scaled down to match reduced font sizes */
+.btn {
+  font-size: var(--blockr-font-size-base);
+}
+
+.btn-sm {
+  font-size: var(--blockr-font-size-xs);
+  padding: 0.25rem 0.5rem;
+}
+
+/* Secondary buttons - use text color grays */
+.btn-outline-secondary {
+  color: var(--blockr-color-text-secondary);
+  border-color: var(--blockr-color-border);
+}
+
+.btn-outline-secondary:hover {
+  color: var(--blockr-color-text-primary);
+  background-color: var(--blockr-color-bg-subtle);
+  border-color: var(--blockr-color-border-hover);
+}
+
+h4, .h4 {
+  font-size: var(--blockr-font-size-section);
+  font-weight: var(--blockr-font-weight-medium);
+  font-variant-caps: all-small-caps;
+  color: var(--blockr-color-text-secondary);
+  letter-spacing: 0.5px;
+}
+
+h5, .h5 {
+  font-size: var(--blockr-font-size-section);
+  font-weight: var(--blockr-font-weight-medium);
+}
+
+h6, .h6 {
+  font-size: var(--blockr-font-size-base);
+  font-weight: var(--blockr-font-weight-medium);
+}
+
+small, .small {
+  font-size: var(--blockr-font-size-sm);
+}

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -110,6 +110,19 @@
   margin-top: 3px;
 }
 
+/* Package badge - two-tone subtle style */
+.badge-two-tone {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.625rem;
+  border-radius: 0.25rem;
+  background-color: rgba(148, 163, 184, 0.1);
+  color: rgba(100, 116, 139, 0.9);
+  border: 1px solid rgba(100, 116, 139, 0.1);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 /* ============================================
    FAB Button
    ============================================ */

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -169,34 +169,64 @@
 }
 
 /* ============================================
-   FAB Button
+   Edge Tab (Settings Panel Trigger)
    ============================================ */
-.blockr-fab {
+.blockr-edge-tab {
   position: fixed;
-  bottom: 30px;
-  right: 30px;
-  width: 60px;
-  height: 60px;
-  background-color: #000;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  font-size: 24px;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 80px;
+  background-color: white;
+  border: 1px solid var(--blockr-grey-300);
+  border-right: none;
+  border-radius: 8px 0 0 8px;
   cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  opacity: 1;
-  transform: scale(1);
-  transition: all 0.3s ease-in-out;
+  transition: all 0.2s ease;
   z-index: 1000;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0;
+  overflow: hidden;
+  box-shadow: -2px 0 6px rgba(0, 0, 0, 0.06);
+}
 
-  :hover {
-    background-color: #000;
-    transform: scale(1.1);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
-  }
+/* Accent stripe on left edge */
+.blockr-edge-tab::before {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  background-color: var(--blockr-color-text-secondary);
+  border-radius: 2px;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+}
+
+.blockr-edge-tab:hover {
+  width: 28px;
+  background-color: white;
+}
+
+.blockr-edge-tab:hover::before {
+  opacity: 0.6;
+}
+
+.blockr-edge-tab svg,
+.blockr-edge-tab i {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  font-size: 14px;
+  color: var(--blockr-color-text-secondary);
+}
+
+.blockr-edge-tab:hover svg,
+.blockr-edge-tab:hover i {
+  opacity: 1;
 }
 
 /* ============================================

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -110,6 +110,38 @@
   margin-top: 3px;
 }
 
+/* Section toggle buttons (inputs/outputs) - matches dockview tabs */
+.blockr-section-toggle .btn.btn-light {
+  background-color: var(--blockr-grey-200) !important;
+  border: none !important;
+  border-radius: 8px;
+  color: var(--blockr-color-text-muted) !important;
+  font-size: var(--blockr-font-size-xs);
+  font-weight: var(--blockr-font-weight-normal);
+  padding: 0.25rem 0.5rem;
+  margin: 0 2px;
+}
+
+.blockr-section-toggle .btn.btn-light:hover {
+  background-color: var(--blockr-grey-300) !important;
+  color: var(--blockr-color-text-secondary) !important;
+}
+
+.blockr-section-toggle .btn-check:checked + .btn.btn-light:hover {
+  background-color: hsl(220, 3%, 87%) !important;
+}
+
+.blockr-section-toggle .btn.btn-light.active,
+.blockr-section-toggle .btn-check:checked + .btn.btn-light {
+  background-color: var(--blockr-grey-300) !important;
+  color: var(--blockr-color-text-secondary) !important;
+  box-shadow: none !important;
+}
+
+.blockr-section-toggle .btn-group {
+  gap: 6px;
+}
+
 /* Package badge - two-tone subtle style */
 .badge-two-tone {
   display: inline-block;

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -416,3 +416,10 @@ small, .small {
   padding: 0.2rem 0.5rem;
   font-size: var(--blockr-font-size-xs);
 }
+
+/* ============================================
+   G6 Graph Toolbar Override
+   ============================================ */
+.g6-toolbar {
+  box-shadow: none !important;
+}

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -329,3 +329,25 @@ small, .small {
   border-top-color: white !important;
   border-bottom-color: white !important;
 }
+
+/* ============================================
+   DataTables Styling
+   ============================================ */
+
+/* Grey stripes instead of blue - override Bootstrap variable */
+.table-striped {
+  --bs-table-striped-bg: var(--blockr-grey-200);
+}
+
+/* Info text - small and muted */
+.dataTables_wrapper .dataTables_info {
+  font-size: var(--blockr-font-size-sm) !important;
+  color: var(--blockr-color-text-muted) !important;
+  padding-top: 0.5rem;
+}
+
+/* Smaller paginator */
+.dataTables_wrapper .dataTables_paginate .page-link {
+  padding: 0.2rem 0.5rem;
+  font-size: var(--blockr-font-size-xs);
+}

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -1,3 +1,60 @@
+/* ============================================
+   CSS Design System - Variables
+   ============================================ */
+:root {
+  /* ===========================================
+     Grey Scale
+     ===========================================
+
+     We use HSL (Hue, Saturation, Lightness) for greys because:
+     - Easy to tweak: just change the lightness % value
+     - Consistent: all greys share the same hue/saturation
+
+     Subtle cool tint (blue hue 220, 3% saturation):
+     - 100: 99% lightness (lightest - page bg)
+     - 200: 97% lightness (blocks, cards, toolbar, input bg)
+     - 300: 91% lightness (borders)
+
+     To remove tint: change hue to 0, saturation to 0%
+     To warm tint: change hue to 30
+     =========================================== */
+  --blockr-grey-100: hsl(220, 3%, 99%);
+  --blockr-grey-200: hsl(220, 3%, 97%);
+  --blockr-grey-300: hsl(220, 3%, 91%);
+
+  /* Shadow - subtle, consistent across components */
+  --blockr-shadow: rgba(0, 0, 0, 0.08) 0px 2px 8px;
+
+  /* Font Sizes */
+  --blockr-font-size-base: 0.875rem;      /* 14px - base for body/inputs */
+  --blockr-font-size-sm: 0.8125rem;       /* 13px - helper text */
+  --blockr-font-size-xs: 0.75rem;         /* 12px - meta, toggles, subtitle */
+  --blockr-font-size-title: 1.25rem;      /* 20px - block title */
+  --blockr-font-size-section: 0.875rem;   /* 14px - section headers */
+
+  /* Font Weights */
+  --blockr-font-weight-normal: 400;
+  --blockr-font-weight-medium: 500;
+  --blockr-font-weight-semibold: 600;
+
+  /* Colors - Text (softened) */
+  --blockr-color-text-primary: #333;
+  --blockr-color-text-secondary: #666;
+  --blockr-color-text-muted: #999;
+  --blockr-color-text-subtle: #ccc;
+  --blockr-color-text-meta: #7a7d8f;
+
+  /* Colors - UI */
+  --blockr-color-border: var(--blockr-grey-300);
+  --blockr-color-border-hover: hsl(220, 3%, 85%);
+  --blockr-color-bg-subtle: var(--blockr-grey-200);
+  --blockr-color-bg-hover: var(--blockr-grey-300);
+  --blockr-color-error: #dc2626;
+}
+
+/* ============================================
+   FAB Button
+   ============================================ */
 .blockr-fab {
   position: fixed;
   bottom: 30px;

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -62,6 +62,41 @@
   margin: 0;
 }
 
+/* Inline editable title */
+.blockr-inline-edit {
+  position: relative;
+}
+
+.blockr-title-edit {
+  position: absolute;
+  top: -9px;
+  left: -8px;
+}
+
+.blockr-title-edit .form-group {
+  margin: 0;
+}
+
+.blockr-title-edit .form-control {
+  font-size: var(--blockr-font-size-title);
+  font-weight: var(--blockr-font-weight-semibold);
+  color: var(--blockr-color-text-primary);
+  padding: 4px 8px;
+  height: auto;
+  width: auto;
+  min-width: 150px;
+  border: 2px dashed #ddd;
+  border-radius: 4px;
+  background: white;
+  box-shadow: none;
+}
+
+.blockr-title-edit .form-control:focus {
+  border-color: #ccc;
+  box-shadow: none;
+  outline: none;
+}
+
 .blockr-subtitle {
   font-size: var(--blockr-font-size-sm);
   font-weight: var(--blockr-font-weight-normal);

--- a/inst/assets/css/blockr-fab.css
+++ b/inst/assets/css/blockr-fab.css
@@ -97,8 +97,9 @@
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 8px 12px;
-  margin: 8px 0 18px 0;
+  padding: 12px 16px;
+  margin: 0 -16px;
+  background-color: rgba(220, 38, 38, 0.08);
   color: var(--blockr-color-error);
   font-size: var(--blockr-font-size-base);
 }


### PR DESCRIPTION
Comprehensive set ot non-functional style tweaks that should make life with blockr more fun:

<img width="1449" height="740" alt="image" src="https://github.com/user-attachments/assets/13715231-314c-4137-bb4f-28232406ebfc" />

Each tweak has its own commit and a relatively detailed description.

The most consequential change are the bootstrap overviews. They make it easier for block authors to just use default shiny / bootstrap classes and get a look that work well in blockr. This includes a change of the default font size from 16 to 14, which leads to a more professional and modern appearance.

