### PR TITLE
 as_ext_panel_id.character warn issue

### DIFF
--- a/R/utils-id.R
+++ b/R/utils-id.R
@@ -275,7 +275,7 @@ as_ext_panel_id.character <- function(x) {
 
   warn <- maybe_ext_panel_id(x)
 
-  if (warn) {
+  if (any(warn)) {
     blockr_warn(
       "Potentially converting ID{?s} {x[warn]} again.",
       class = "maybe_multiple_ext_id_conversion"


### PR DESCRIPTION
@nbenn Aligned with `as_block_handle_id.character()`, and `as_ext_handle_id.character`.

Fix #58