### PR TITLE
fix: action tests broken by reactiveVal scoping in testServer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,8 @@ Suggests:
     methods,
     withr,
     shinytest2
+Remotes:
+    BristolMyersSquibb/blockr.core
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/tests/testthat/test-action-block.R
+++ b/tests/testthat/test-action-block.R
@@ -1,13 +1,16 @@
 test_that("add block action", {
 
+  r_board <- reactiveValues(board = new_board())
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         add_block_action(
           trigger = reactive(TRUE),
-          board = reactiveValues(board = new_board()),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
@@ -18,34 +21,34 @@ test_that("add block action", {
       session$setInputs(add_block_selection = "dataset_block")
       expect_s3_class(blk(), "block")
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
         add_block_confirm = 1L,
         add_block_id = ""
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       tmp <- blk()
       blk(NULL)
 
       session$setInputs(
-        add_block_confirm = 1L,
+        add_block_confirm = 2L,
         add_block_id = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       blk(tmp)
 
       session$setInputs(
-        add_block_confirm = 1L,
+        add_block_confirm = 3L,
         add_block_id = "test",
         add_block_name = "Test block"
       )
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 1L)
       expect_named(upd, "blocks")
@@ -62,16 +65,19 @@ test_that("add block action", {
 
 test_that("append block action", {
 
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(a = new_dataset_block()))
+  )
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         append_block_action(
           trigger = reactive("a"),
-          board = reactiveValues(
-            board = new_board(blocks = c(a = new_dataset_block()))
-          ),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
@@ -85,44 +91,44 @@ test_that("append block action", {
       session$setInputs(append_block_selection = "head_block")
       expect_s3_class(blk(), "block")
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
         append_block_confirm = 1L,
         append_block_id = ""
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        append_block_confirm = 1L,
+        append_block_confirm = 2L,
         append_block_id = "test",
         append_link_id = ""
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       tmp <- blk()
       blk(NULL)
 
       session$setInputs(
-        append_block_confirm = 1L,
+        append_block_confirm = 3L,
         append_block_id = "test",
         append_link_id = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       blk(tmp)
 
       session$setInputs(
-        append_block_confirm = 1L,
+        append_block_confirm = 4L,
         append_block_id = "test",
         append_link_id = "test",
         append_block_name = "Test block"
       )
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 2L)
       expect_named(upd, c("blocks", "links"))
@@ -146,25 +152,28 @@ test_that("append block action", {
 
 test_that("remove block action", {
 
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(a = new_dataset_block()))
+  )
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         remove_block_action(
           trigger = reactive("a"),
-          board = reactiveValues(
-            board = new_board(blocks = c(a = new_dataset_block()))
-          ),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
     {
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$flushReact()
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 1L)
       expect_named(upd, "blocks")

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -24,56 +24,59 @@ test_that("add link action", {
     }
   )
 
+  r_board <- reactiveValues(
+    board = new_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_head_block()
+      )
+    )
+  )
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         add_link_action(
           trigger = reactive("a"),
-          board = reactiveValues(
-            board = new_board(
-              c(
-                a = new_dataset_block("iris"),
-                b = new_head_block()
-              )
-            )
-          ),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
     {
       session$flushReact()
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(create_link = "a")
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(create_link = "b")
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
         add_link_confirm = 1L,
         add_link_id = ""
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        add_link_confirm = 1L,
+        add_link_confirm = 2L,
         add_link_id = "test",
         add_link_input = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        add_link_confirm = 1L,
+        add_link_confirm = 3L,
         add_link_id = "test",
         add_link_input = "data"
       )
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 1L)
       expect_named(upd, "links")
@@ -90,29 +93,32 @@ test_that("add link action", {
 
 test_that("remove link action", {
 
+  r_board <- reactiveValues(
+    board = new_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_head_block()
+      ),
+      links = links(id = "ab", from = "a", to = "b")
+    )
+  )
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         remove_link_action(
           trigger = reactive("ab"),
-          board = reactiveValues(
-            board = new_board(
-              c(
-                a = new_dataset_block("iris"),
-                b = new_head_block()
-              ),
-              links = links(id = "ab", from = "a", to = "b")
-            )
-          ),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
     {
       session$flushReact()
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 1L)
       expect_named(upd, "links")

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -1,66 +1,69 @@
 test_that("add stack action", {
 
+  r_board <- reactiveValues(
+    board = new_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_head_block()
+      )
+    )
+  )
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         add_stack_action(
           trigger = reactive(TRUE),
-          board = reactiveValues(
-            board = new_board(
-              c(
-                a = new_dataset_block("iris"),
-                b = new_head_block()
-              )
-            )
-          ),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
     {
       session$flushReact()
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
         stack_confirm = 1L,
         stack_id = ""
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        stack_confirm = 1L,
+        stack_confirm = 2L,
         stack_id = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        stack_confirm = 1L,
+        stack_confirm = 3L,
         stack_id = "test",
         stack_block_selection = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        stack_confirm = 1L,
+        stack_confirm = 4L,
         stack_id = "test",
         stack_block_selection = "",
         stack_color = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        stack_confirm = 1L,
+        stack_confirm = 5L,
         stack_id = "test",
         stack_block_selection = "",
         stack_color = "#FFFFFF"
       )
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 1L)
       expect_named(upd, "stacks")
@@ -77,61 +80,64 @@ test_that("add stack action", {
 
 test_that("edit stack action", {
 
+  r_board <- reactiveValues(
+    board = new_dock_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_head_block()
+      ),
+      stacks = stacks(a = "a")
+    )
+  )
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         edit_stack_action(
           trigger = reactive("a"),
-          board = reactiveValues(
-            board = new_dock_board(
-              c(
-                a = new_dataset_block("iris"),
-                b = new_head_block()
-              ),
-              stacks = stacks(a = "a")
-            )
-          ),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
     {
       session$flushReact()
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
         edit_stack_confirm = 1L,
         edit_stack_blocks = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        edit_stack_confirm = 1L,
+        edit_stack_confirm = 2L,
         edit_stack_blocks = "",
         edit_stack_color = "test"
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        edit_stack_confirm = 1L,
+        edit_stack_confirm = 3L,
         edit_stack_blocks = "",
         edit_stack_color = "#FFFFFF",
         edit_stack_name = ""
       )
 
-      expect_length(update(), 0L)
+      expect_length(r_update(), 0L)
 
       session$setInputs(
-        edit_stack_confirm = 1L,
+        edit_stack_confirm = 4L,
         edit_stack_blocks = "",
         edit_stack_color = "#FFFFFF",
         edit_stack_name = "Test stack"
       )
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 1L)
       expect_named(upd, "stacks")
@@ -148,29 +154,32 @@ test_that("edit stack action", {
 
 test_that("remove stack action", {
 
+  r_board <- reactiveValues(
+    board = new_dock_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_head_block()
+      ),
+      stacks = stacks(a = "a")
+    )
+  )
+  r_update <- reactiveVal(list())
+
   testServer(
     function(id, ...) {
       moduleServer(
         id,
         remove_stack_action(
           trigger = reactive("a"),
-          board = reactiveValues(
-            board = new_dock_board(
-              c(
-                a = new_dataset_block("iris"),
-                b = new_head_block()
-              ),
-              stacks = stacks(a = "a")
-            )
-          ),
-          update = reactiveVal(list())
+          board = r_board,
+          update = r_update
         )
       )
     },
     {
       session$flushReact()
 
-      upd <- update()
+      upd <- r_update()
 
       expect_length(upd, 1L)
       expect_named(upd, "stacks")


### PR DESCRIPTION
@nbenn for the CRAN issue. To merge before #103 

- reactiveVal/reactiveValues created inside the testServer app function live in a different reactive domain than the module's closure. The action handler sets the reactiveVal but the test expression reads a different copy. Fix: create them outside testServer.

```deps
BristolMyersSquibb/blockr.dag#111
```