### PR TITLE
docs: surface views API in pkgdown reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,6 +13,12 @@ reference:
   desc: Tools for defining panel arrangements.
   contents:
     - new_dock_layout
+- title: Dock views
+  desc: Multi-view (tabbed) boards. Each view is its own panel arrangement.
+  contents:
+    - new_dock_layouts
+    - dock_view
+    - active_view
 - title: Board extensions
   desc: Board extensions allow for adding components that interact with and modify board state.
   contents:
@@ -23,7 +29,7 @@ reference:
   contents:
     - new_action
 - title: Utilities
-  desc: Various utility functions that are exported for use in dependen packages.
+  desc: Various utility functions that are exported for use in dependent packages.
   contents:
     - show_panel
     - blks_metadata


### PR DESCRIPTION
Fixes pkgdown failure.

Add a "Dock views" section to the reference index pulling in the multi-view API from man/view.Rd (new_dock_layouts, dock_view, active_view and friends), which was previously uncategorised and caused `pkgdown::check_pkgdown()` to error.

Also fix a typo in the Utilities section description ("dependen" -> "dependent").