### PR TITLE
fix: clearer message when no panels can be added (#99)

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -903,8 +903,18 @@ suggest_panels_to_add <- function(
     )
   } else if (!isFALSE(suggest_new)) {
     suggest_new(TRUE)
+  } else if (
+    length(board_block_ids(board$board)) == 0L &&
+      length(dock_ext_ids(board$board)) == 0L
+  ) {
+    notify("The board has no blocks yet. Add a new block to get started.")
   } else {
-    notify("No further panels can be added. Remove some panels first.")
+    notify(
+      paste(
+        "All blocks and extensions are already in this view.",
+        "Add a new block to the board first."
+      )
+    )
   }
 }
 


### PR DESCRIPTION
When the user clicks the "+" button on a tab/group, `suggest_panels_to_add()` shows a modal listing blocks/extensions present in the board but not yet in this view. If that pool is empty, it falls through to a notification that previously said:

  "No further panels can be added. Remove some panels first."

This is misleading: removing a panel just makes that same panel re-addable, it does not enable adding *new* blocks.

Split the empty-pool fallback into two cases with distinct messages:

* Board has no blocks/extensions at all (e.g. fresh app): "The board has no blocks yet. Add a new block to get started."

* Board has blocks/extensions but all are already shown in this view: "All blocks and extensions are already in this view. Add a new block to the board first."

Closes #99.