### PR TITLE
Fall back to a fixed palette when colorspace is unavailable

### DIFF
--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -10,13 +10,15 @@ filter_empty <- function(x) Filter(Negate(is_empty), x)
 
 last <- function(x) x[[length(x)]]
 
+fallback_palette <- c(
+  "#66C2A5", "#FC8D62", "#8DA0CB", "#E78AC3",
+  "#A6D854", "#FFD92F", "#E5C494", "#B3B3B3"
+)
+
 next_color <- function(colors = character(), lum_var = TRUE) {
 
   if (!pkg_avail("colorspace")) {
-    blockr_abort(
-      "Package 'colorspace' is required.",
-      class = "colorspace_not_available"
-    )
+    return(fallback_palette[(length(colors) %% length(fallback_palette)) + 1L])
   }
 
   if (length(colors)) {

--- a/tests/testthat/test-utils-misc.R
+++ b/tests/testthat/test-utils-misc.R
@@ -20,3 +20,19 @@ test_that("suggest_new_colors", {
     suggest_new_colors(rev(cur))
   )
 })
+
+test_that("suggest_new_colors falls back when colorspace is unavailable", {
+
+  with_mocked_bindings(
+    {
+      cols <- suggest_new_colors(n = length(fallback_palette) + 2L)
+
+      expect_identical(cols[seq_along(fallback_palette)], fallback_palette)
+      expect_identical(
+        cols[length(fallback_palette) + seq_len(2L)],
+        fallback_palette[seq_len(2L)]
+      )
+    },
+    pkg_avail = function(...) FALSE
+  )
+})


### PR DESCRIPTION
Clicking *add stack* without the suggested `colorspace` package installed crashed the app, since `next_color()` aborted with `colorspace_not_available`.

`next_color()` now returns a color from a small built-in palette (cycled by `length(colors)`) when `colorspace` is missing, so stack creation works regardless of whether the suggested package is installed and the colors stay visually distinguishable.

Closes #96