### PR TITLE
fix: guard rename observer against missing dock panels

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -473,7 +473,12 @@ manage_dock <- function(
 
           old_title <- get_dock_panel(blk_panel_id, dock)$title
 
-          if (new_name == old_title) {
+          # Skip when there's no panel for this block (e.g. card still in
+          # the offcanvas) or when the name didn't actually change. Without
+          # the length guard, comparing against a NULL/empty old_title
+          # produces logical(0) and crashes the `if`.
+          if (length(old_title) == 0L || length(new_name) == 0L ||
+              identical(new_name, old_title)) {
             next
           }
 


### PR DESCRIPTION
Fixes #116.

## Problem

Renaming a block crashes the per-view rename observer with `Error in if (new_name == old_title): argument is of length zero` whenever the renamed block is not present in *this* view's dock — most commonly because:

- the block is parked in the offcanvas (no panel anywhere), or
- the board has multiple views and the block lives in only some of them.

## Root cause

`R/board-server.R` (`manage_dock`, the `update()$blocks$mod` observer) calls

```r
old_title <- get_dock_panel(blk_panel_id, dock)$title
if (new_name == old_title) next
```

`get_dock_panel()` returns `NULL` when no panel matches the id, so `old_title` is `NULL` and `NULL == "..."` is `logical(0)`, which crashes the `if`.

## Fix

Short-circuit on length zero before the equality check, and use `identical()` for the comparison. No-op when the block has a panel and the title actually changed.

```r
if (length(old_title) == 0L || length(new_name) == 0L ||
    identical(new_name, old_title)) {
  next
}
```