### PR TITLE
decorate for OTEL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dock
 Title: A Docking Layout Manager for 'blockr'
-Version: 0.1.1
+Version: 0.1.1.9000
 Authors@R:
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Imports:
-    blockr.core (>= 0.1.2),
+    blockr.core (>= 0.1.2.9000),
     bsicons,
     shiny,
     shinyjs,
@@ -41,6 +41,8 @@ Suggests:
     shinytest2,
     knitr,
     rmarkdown
+Remotes:
+    BristolMyersSquibb/blockr.core
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# blockr.dock (development version)
+
+## Internal changes
+
+* Label observers for OTEL support.
+
 # blockr.dock 0.1.1
 
 * Added prepend block action.

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -17,7 +17,8 @@ add_block_action <- function(trigger, board, update, ...) {
               mode = "add"
             )
           )
-        }
+        },
+        label = "add_block"
       )
 
       observeEvent(
@@ -37,7 +38,8 @@ add_block_action <- function(trigger, board, update, ...) {
           )
 
           blk(new_blk)
-        }
+        },
+        label = "add_block_select"
       )
 
       observeEvent(
@@ -74,7 +76,8 @@ add_block_action <- function(trigger, board, update, ...) {
 
           update(list(blocks = list(add = bk)))
           removeModal()
-        }
+        },
+        label = "add_block_confirm"
       )
 
       NULL
@@ -100,7 +103,8 @@ append_block_action <- function(trigger, board, update, ...) {
               mode = "append"
             )
           )
-        }
+        },
+        label = "append_block"
       )
 
       observeEvent(
@@ -135,7 +139,8 @@ append_block_action <- function(trigger, board, update, ...) {
           )
 
           blk(new_blk)
-        }
+        },
+        label = "append_block_select"
       )
 
       observeEvent(
@@ -195,7 +200,8 @@ append_block_action <- function(trigger, board, update, ...) {
           )
 
           removeModal()
-        }
+        },
+        label = "append_block_confirm"
       )
 
       NULL
@@ -221,7 +227,8 @@ prepend_block_action <- function(trigger, board, update, ...) {
               mode = "prepend"
             )
           )
-        }
+        },
+        label = "prepend_block"
       )
 
       observeEvent(
@@ -241,7 +248,8 @@ prepend_block_action <- function(trigger, board, update, ...) {
           )
 
           blk(new_blk)
-        }
+        },
+        label = "prepend_block_select"
       )
 
       observeEvent(
@@ -311,7 +319,8 @@ prepend_block_action <- function(trigger, board, update, ...) {
           )
 
           removeModal()
-        }
+        },
+        label = "prepend_block_confirm"
       )
 
       NULL
@@ -325,7 +334,8 @@ remove_block_action <- function(trigger, board, update, ...) {
     function(input, output, session) {
       observeEvent(
         trigger(),
-        update(list(blocks = list(rm = trigger())))
+        update(list(blocks = list(rm = trigger()))),
+        label = "remove_block"
       )
       NULL
     },

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -18,7 +18,7 @@ add_block_action <- function(trigger, board, update, ...) {
             )
           )
         },
-        label = "add_block"
+        label = otel_lbl("add_block")
       )
 
       observeEvent(
@@ -39,7 +39,7 @@ add_block_action <- function(trigger, board, update, ...) {
 
           blk(new_blk)
         },
-        label = "add_block_select"
+        label = otel_lbl("add_block_select")
       )
 
       observeEvent(
@@ -77,7 +77,7 @@ add_block_action <- function(trigger, board, update, ...) {
           update(list(blocks = list(add = bk)))
           removeModal()
         },
-        label = "add_block_confirm"
+        label = otel_lbl("add_block_confirm")
       )
 
       NULL
@@ -104,7 +104,7 @@ append_block_action <- function(trigger, board, update, ...) {
             )
           )
         },
-        label = "append_block"
+        label = otel_lbl("append_block")
       )
 
       observeEvent(
@@ -140,7 +140,7 @@ append_block_action <- function(trigger, board, update, ...) {
 
           blk(new_blk)
         },
-        label = "append_block_select"
+        label = otel_lbl("append_block_select")
       )
 
       observeEvent(
@@ -201,7 +201,7 @@ append_block_action <- function(trigger, board, update, ...) {
 
           removeModal()
         },
-        label = "append_block_confirm"
+        label = otel_lbl("append_block_confirm")
       )
 
       NULL
@@ -228,7 +228,7 @@ prepend_block_action <- function(trigger, board, update, ...) {
             )
           )
         },
-        label = "prepend_block"
+        label = otel_lbl("prepend_block")
       )
 
       observeEvent(
@@ -249,7 +249,7 @@ prepend_block_action <- function(trigger, board, update, ...) {
 
           blk(new_blk)
         },
-        label = "prepend_block_select"
+        label = otel_lbl("prepend_block_select")
       )
 
       observeEvent(
@@ -320,7 +320,7 @@ prepend_block_action <- function(trigger, board, update, ...) {
 
           removeModal()
         },
-        label = "prepend_block_confirm"
+        label = otel_lbl("prepend_block_confirm")
       )
 
       NULL
@@ -335,7 +335,7 @@ remove_block_action <- function(trigger, board, update, ...) {
       observeEvent(
         trigger(),
         update(list(blocks = list(rm = trigger()))),
-        label = "remove_block"
+        label = otel_lbl("remove_block")
       )
       NULL
     },

--- a/R/action-class.R
+++ b/R/action-class.R
@@ -150,7 +150,10 @@ register_action <- function(id, action, ..., session = get_session()) {
 }
 
 new_trigger <- function(value = NULL) {
-  rv <- reactiveVal(list(value = value, counter = 0L))
+  rv <- reactiveVal(
+    list(value = value, counter = 0L),
+    label = "action_trigger"
+  )
 
   structure(
     function(new) {

--- a/R/action-class.R
+++ b/R/action-class.R
@@ -152,7 +152,7 @@ register_action <- function(id, action, ..., session = get_session()) {
 new_trigger <- function(value = NULL) {
   rv <- reactiveVal(
     list(value = value, counter = 0L),
-    label = "action_trigger"
+    label = otel_lbl("action_trigger")
   )
 
   structure(

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -5,7 +5,8 @@ add_link_action <- function(trigger, board, update, ...) {
 
       observeEvent(
         trigger(),
-        showModal(link_modal(session$ns, board$board, trigger()))
+        showModal(link_modal(session$ns, board$board, trigger())),
+        label = "add_link"
       )
 
       observeEvent(
@@ -29,7 +30,8 @@ add_link_action <- function(trigger, board, update, ...) {
             )
             return()
           }
-        }
+        },
+        label = "add_link_select"
       )
 
       observeEvent(
@@ -83,7 +85,8 @@ add_link_action <- function(trigger, board, update, ...) {
           )
 
           removeModal()
-        }
+        },
+        label = "add_link_confirm"
       )
 
       NULL
@@ -97,7 +100,8 @@ remove_link_action <- function(trigger, board, update, ...) {
     function(input, output, session) {
       observeEvent(
         trigger(),
-        update(list(links = list(rm = trigger())))
+        update(list(links = list(rm = trigger()))),
+        label = "remove_link"
       )
       NULL
     },

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -6,7 +6,7 @@ add_link_action <- function(trigger, board, update, ...) {
       observeEvent(
         trigger(),
         showModal(link_modal(session$ns, board$board, trigger())),
-        label = "add_link"
+        label = otel_lbl("add_link")
       )
 
       observeEvent(
@@ -31,7 +31,7 @@ add_link_action <- function(trigger, board, update, ...) {
             return()
           }
         },
-        label = "add_link_select"
+        label = otel_lbl("add_link_select")
       )
 
       observeEvent(
@@ -86,7 +86,7 @@ add_link_action <- function(trigger, board, update, ...) {
 
           removeModal()
         },
-        label = "add_link_confirm"
+        label = otel_lbl("add_link_confirm")
       )
 
       NULL
@@ -101,7 +101,7 @@ remove_link_action <- function(trigger, board, update, ...) {
       observeEvent(
         trigger(),
         update(list(links = list(rm = trigger()))),
-        label = "remove_link"
+        label = otel_lbl("remove_link")
       )
       NULL
     },

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -7,7 +7,8 @@ add_stack_action <- function(trigger, board, update, ...) {
         trigger(),
         showModal(
           stack_modal(ns = session$ns, board = board$board, mode = "create")
-        )
+        ),
+        label = "add_stack"
       )
 
       observeEvent(
@@ -75,7 +76,8 @@ add_stack_action <- function(trigger, board, update, ...) {
           update(list(stacks = list(add = new_stk)))
 
           removeModal()
-        }
+        },
+        label = "add_stack_confirm"
       )
 
       NULL
@@ -105,7 +107,8 @@ edit_stack_action <- function(trigger, board, update, ...) {
               stack_id = trigger()
             )
           )
-        }
+        },
+        label = "edit_stack"
       )
 
       observeEvent(
@@ -170,7 +173,8 @@ edit_stack_action <- function(trigger, board, update, ...) {
           update(list(stacks = list(mod = stack)))
 
           removeModal()
-        }
+        },
+        label = "edit_stack_confirm"
       )
 
       NULL
@@ -184,7 +188,8 @@ remove_stack_action <- function(trigger, board, update, ...) {
     function(input, output, session) {
       observeEvent(
         trigger(),
-        update(list(stacks = list(rm = trigger())))
+        update(list(stacks = list(rm = trigger()))),
+        label = "remove_stack"
       )
       NULL
     },

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -8,7 +8,7 @@ add_stack_action <- function(trigger, board, update, ...) {
         showModal(
           stack_modal(ns = session$ns, board = board$board, mode = "create")
         ),
-        label = "add_stack"
+        label = otel_lbl("add_stack")
       )
 
       observeEvent(
@@ -77,7 +77,7 @@ add_stack_action <- function(trigger, board, update, ...) {
 
           removeModal()
         },
-        label = "add_stack_confirm"
+        label = otel_lbl("add_stack_confirm")
       )
 
       NULL
@@ -108,7 +108,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
             )
           )
         },
-        label = "edit_stack"
+        label = otel_lbl("edit_stack")
       )
 
       observeEvent(
@@ -174,7 +174,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
 
           removeModal()
         },
-        label = "edit_stack_confirm"
+        label = otel_lbl("edit_stack_confirm")
       )
 
       NULL
@@ -189,7 +189,7 @@ remove_stack_action <- function(trigger, board, update, ...) {
       observeEvent(
         trigger(),
         update(list(stacks = list(rm = trigger()))),
-        label = "remove_stack"
+        label = otel_lbl("remove_stack")
       )
       NULL
     },

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -117,7 +117,7 @@ new_dock_manager <- function() {
 init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
   ns <- session$ns
   active_v <- active_view(views)
-  current_active <- reactiveVal(active_v)
+  current_active <- reactiveVal(active_v, label = "current_active_view")
 
   for (view_name in names(views)) {
     v_ly <- views[[view_name]]
@@ -151,7 +151,10 @@ init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
       update,
       triggers,
       layout = v_ly,
-      is_active = reactive(identical(current_active(), local_name))
+      is_active = reactive(
+        identical(current_active(), local_name),
+        label = "dock_is_active"
+      )
     )
     dock_res$dock_id <- v_did
     dock_mgr$docks[[view_name]] <- dock_res
@@ -210,7 +213,8 @@ switch_view_observer <- function(vs, session, dock_mgr) {
         dock_mgr$current_active(new_v)
       }
     },
-    ignoreInit = TRUE
+    ignoreInit = TRUE,
+    label = "switch_view"
   )
 }
 
@@ -227,15 +231,18 @@ switch_view_observer <- function(vs, session, dock_mgr) {
 #'
 #' @noRd
 live_view_data <- function(vs, dock_mgr) {
-  reactive({
-    state <- vs$state
-    v_list <- lapply(names(state), function(view_name) {
-      as_dock_layout(dock_mgr$docks[[view_name]]$layout())
-    })
-    res <- dock_layouts(set_names(v_list, names(state)))
-    active_view(res) <- active_view(state)
-    res
-  })
+  reactive(
+    {
+      state <- vs$state
+      v_list <- lapply(names(state), function(view_name) {
+        as_dock_layout(dock_mgr$docks[[view_name]]$layout())
+      })
+      res <- dock_layouts(set_names(v_list, names(state)))
+      active_view(res) <- active_view(state)
+      res
+    },
+    label = "live_view_data"
+  )
 }
 
 #' Hide all block and extension UI for a view.
@@ -309,7 +316,7 @@ manage_dock <- function(
   update,
   actions,
   layout = NULL,
-  is_active = reactive(TRUE)
+  is_active = reactive(TRUE, label = "dock_is_active_default")
 ) {
   # Resolve layout: use provided layout or fall back to board's dock_layout
   init_layout <- layout %||% isolate(dock_layout(board$board))
@@ -328,7 +335,8 @@ manage_dock <- function(
           # nolint next: object_usage_linter.
           ag <- input[[dock_input("active-group")]]
           log_debug("active group is now {ag}")
-        }
+        },
+        label = "dock_active_group_log"
       )
     }
 
@@ -350,16 +358,19 @@ manage_dock <- function(
           }
         }
       },
-      once = TRUE
+      once = TRUE,
+      label = "dock_initialize"
     )
 
     n_panels <- reactiveVal(
-      length(determine_active_views(init_layout))
+      length(determine_active_views(init_layout)),
+      label = "dock_n_panels"
     )
 
     observeEvent(
       req(input[[dock_input("n-panels")]]),
-      n_panels(input[[dock_input("n-panels")]])
+      n_panels(input[[dock_input("n-panels")]]),
+      label = "dock_n_panels_sync"
     )
 
     observeEvent(
@@ -381,12 +392,14 @@ manage_dock <- function(
             class = "dock_panel_invalid"
           )
         }
-      }
+      },
+      label = "dock_panel_remove"
     )
 
     observeEvent(
       input[[dock_input("panel-to-add")]],
-      suggest_panels_to_add(dock, board, session = session)
+      suggest_panels_to_add(dock, board, session = session),
+      label = "dock_panel_add_suggest"
     )
 
     # Empty-dock prompt — rendered for all empty docks, visibility
@@ -397,7 +410,8 @@ manage_dock <- function(
 
     observeEvent(
       input$empty_dock_add,
-      suggest_panels_to_add(dock, board, panels = list(), session = session)
+      suggest_panels_to_add(dock, board, panels = list(), session = session),
+      label = "dock_empty_add"
     )
 
     observeEvent(
@@ -442,11 +456,12 @@ manage_dock <- function(
         }
 
         removeModal()
-      }
+      },
+      label = "dock_panel_add_confirm"
     )
 
-    prev_active_group <- reactiveVal()
-    active_group_trail <- reactiveVal()
+    prev_active_group <- reactiveVal(label = "dock_prev_active_group")
+    active_group_trail <- reactiveVal(label = "dock_active_group_trail")
 
     observeEvent(
       input[[dock_input("active-group")]],
@@ -458,7 +473,8 @@ manage_dock <- function(
           prev_active_group(pre_ag)
         }
         active_group_trail(cur_ag)
-      }
+      },
+      label = "dock_active_group_track"
     )
 
     observeEvent(
@@ -485,11 +501,12 @@ manage_dock <- function(
             new_name
           )
         }
-      }
+      },
+      label = "dock_panel_title_sync"
     )
 
     list(
-      layout = reactive(dockViewR::get_dock(dock)),
+      layout = reactive(dockViewR::get_dock(dock), label = "dock_layout"),
       proxy = dock,
       prev_active_group = prev_active_group,
       n_panels = n_panels,
@@ -585,7 +602,7 @@ add_view_observer <- function(vs, session, dock_mgr, board, update, triggers) {
         )
       )
     )
-  })
+  }, label = "view_add")
 
   # Name validation feedback
   output$view_name_validation <- renderUI({
@@ -659,7 +676,7 @@ add_view_observer <- function(vs, session, dock_mgr, board, update, triggers) {
         id = ns(paste0("view_wrap_", v_id))
       )
     )
-  })
+  }, label = "view_add_confirm")
 }
 
 #' Observe view removal requests.
@@ -714,7 +731,7 @@ remove_view_observer <- function(vs, session, dock_mgr) {
         )
       )
     )
-  })
+  }, label = "view_remove")
 
   # Perform removal after confirmation
   observeEvent(input$confirm_view_remove, {
@@ -776,7 +793,7 @@ remove_view_observer <- function(vs, session, dock_mgr) {
         value = active_name
       )
     )
-  })
+  }, label = "view_remove_confirm")
 }
 
 #' Observe view rename requests.
@@ -819,7 +836,7 @@ rename_view_observer <- function(vs, session, dock_mgr) {
       dock_mgr$docks[[rename$to]] <- dock_mgr$docks[[rename$from]]
       rm(list = rename$from, envir = dock_mgr$docks)
     }
-  })
+  }, label = "view_rename")
 }
 
 #' Show a modal for adding panels to the dock.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -117,7 +117,7 @@ new_dock_manager <- function() {
 init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
   ns <- session$ns
   active_v <- active_view(views)
-  current_active <- reactiveVal(active_v, label = "current_active_view")
+  current_active <- reactiveVal(active_v, label = otel_lbl("current_active_view"))
 
   for (view_name in names(views)) {
     v_ly <- views[[view_name]]
@@ -153,7 +153,7 @@ init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
       layout = v_ly,
       is_active = reactive(
         identical(current_active(), local_name),
-        label = "dock_is_active"
+        label = otel_lbl("dock_is_active")
       )
     )
     dock_res$dock_id <- v_did
@@ -214,7 +214,7 @@ switch_view_observer <- function(vs, session, dock_mgr) {
       }
     },
     ignoreInit = TRUE,
-    label = "switch_view"
+    label = otel_lbl("switch_view")
   )
 }
 
@@ -241,7 +241,7 @@ live_view_data <- function(vs, dock_mgr) {
       active_view(res) <- active_view(state)
       res
     },
-    label = "live_view_data"
+    label = otel_lbl("live_view_data")
   )
 }
 
@@ -316,7 +316,7 @@ manage_dock <- function(
   update,
   actions,
   layout = NULL,
-  is_active = reactive(TRUE, label = "dock_is_active_default")
+  is_active = reactive(TRUE, label = otel_lbl("dock_is_active_default"))
 ) {
   # Resolve layout: use provided layout or fall back to board's dock_layout
   init_layout <- layout %||% isolate(dock_layout(board$board))
@@ -336,7 +336,7 @@ manage_dock <- function(
           ag <- input[[dock_input("active-group")]]
           log_debug("active group is now {ag}")
         },
-        label = "dock_active_group_log"
+        label = otel_lbl("dock_active_group_log")
       )
     }
 
@@ -359,18 +359,18 @@ manage_dock <- function(
         }
       },
       once = TRUE,
-      label = "dock_initialize"
+      label = otel_lbl("dock_initialize")
     )
 
     n_panels <- reactiveVal(
       length(determine_active_views(init_layout)),
-      label = "dock_n_panels"
+      label = otel_lbl("dock_n_panels")
     )
 
     observeEvent(
       req(input[[dock_input("n-panels")]]),
       n_panels(input[[dock_input("n-panels")]]),
-      label = "dock_n_panels_sync"
+      label = otel_lbl("dock_n_panels_sync")
     )
 
     observeEvent(
@@ -393,13 +393,13 @@ manage_dock <- function(
           )
         }
       },
-      label = "dock_panel_remove"
+      label = otel_lbl("dock_panel_remove")
     )
 
     observeEvent(
       input[[dock_input("panel-to-add")]],
       suggest_panels_to_add(dock, board, session = session),
-      label = "dock_panel_add_suggest"
+      label = otel_lbl("dock_panel_add_suggest")
     )
 
     # Empty-dock prompt — rendered for all empty docks, visibility
@@ -411,7 +411,7 @@ manage_dock <- function(
     observeEvent(
       input$empty_dock_add,
       suggest_panels_to_add(dock, board, panels = list(), session = session),
-      label = "dock_empty_add"
+      label = otel_lbl("dock_empty_add")
     )
 
     observeEvent(
@@ -457,11 +457,11 @@ manage_dock <- function(
 
         removeModal()
       },
-      label = "dock_panel_add_confirm"
+      label = otel_lbl("dock_panel_add_confirm")
     )
 
-    prev_active_group <- reactiveVal(label = "dock_prev_active_group")
-    active_group_trail <- reactiveVal(label = "dock_active_group_trail")
+    prev_active_group <- reactiveVal(label = otel_lbl("dock_prev_active_group"))
+    active_group_trail <- reactiveVal(label = otel_lbl("dock_active_group_trail"))
 
     observeEvent(
       input[[dock_input("active-group")]],
@@ -474,7 +474,7 @@ manage_dock <- function(
         }
         active_group_trail(cur_ag)
       },
-      label = "dock_active_group_track"
+      label = otel_lbl("dock_active_group_track")
     )
 
     observeEvent(
@@ -502,11 +502,11 @@ manage_dock <- function(
           )
         }
       },
-      label = "dock_panel_title_sync"
+      label = otel_lbl("dock_panel_title_sync")
     )
 
     list(
-      layout = reactive(dockViewR::get_dock(dock), label = "dock_layout"),
+      layout = reactive(dockViewR::get_dock(dock), label = otel_lbl("dock_layout")),
       proxy = dock,
       prev_active_group = prev_active_group,
       n_panels = n_panels,
@@ -602,7 +602,7 @@ add_view_observer <- function(vs, session, dock_mgr, board, update, triggers) {
         )
       )
     )
-  }, label = "view_add")
+  }, label = otel_lbl("view_add"))
 
   # Name validation feedback
   output$view_name_validation <- renderUI({
@@ -676,7 +676,7 @@ add_view_observer <- function(vs, session, dock_mgr, board, update, triggers) {
         id = ns(paste0("view_wrap_", v_id))
       )
     )
-  }, label = "view_add_confirm")
+  }, label = otel_lbl("view_add_confirm"))
 }
 
 #' Observe view removal requests.
@@ -731,7 +731,7 @@ remove_view_observer <- function(vs, session, dock_mgr) {
         )
       )
     )
-  }, label = "view_remove")
+  }, label = otel_lbl("view_remove"))
 
   # Perform removal after confirmation
   observeEvent(input$confirm_view_remove, {
@@ -793,7 +793,7 @@ remove_view_observer <- function(vs, session, dock_mgr) {
         value = active_name
       )
     )
-  }, label = "view_remove_confirm")
+  }, label = otel_lbl("view_remove_confirm"))
 }
 
 #' Observe view rename requests.
@@ -836,7 +836,7 @@ rename_view_observer <- function(vs, session, dock_mgr) {
       dock_mgr$docks[[rename$to]] <- dock_mgr$docks[[rename$from]]
       rm(list = rename$from, envir = dock_mgr$docks)
     }
-  }, label = "view_rename")
+  }, label = otel_lbl("view_rename"))
 }
 
 #' Show a modal for adding panels to the dock.

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -131,7 +131,8 @@ blk_ext_srv <- function(id, board, update, ...) {
         board_links(board$board),
         {
           upd$curr <- board_links(board$board)
-        }
+        },
+        label = "edit_ext_links_sync"
       )
 
       output$links_dt <- DT::renderDataTable(
@@ -179,7 +180,8 @@ add_block_observer <- function(input, board, update, session) {
       update(
         list(blocks = list(add = add))
       )
-    }
+    },
+    label = "edit_ext_add_block"
   )
 }
 
@@ -216,7 +218,8 @@ remove_block_observer <- function(input, board, update, session) {
       update(
         list(blocks = list(rm = sel))
       )
-    }
+    },
+    label = "edit_ext_remove_block"
   )
 }
 
@@ -227,7 +230,8 @@ update_block_select_observer <- function(board, session) {
       session,
       "block_select",
       choices = board_block_ids(board$board)
-    )
+    ),
+    label = "edit_ext_update_block_select"
   )
 }
 
@@ -484,7 +488,8 @@ create_dt_link_obs <- function(ids, upd, ...) {
 
         upd$edit <- list(row = row, col = col, val = new)
       },
-      ignoreInit = TRUE
+      ignoreInit = TRUE,
+      label = "edit_ext_link_cell"
     )
 
     res <- list(obs1)
@@ -517,7 +522,8 @@ create_dt_link_obs <- function(ids, upd, ...) {
             choices = from_choices(blks, new),
             selected = from_selected(upd)
           )
-        }
+        },
+        label = "edit_ext_link_block_sync"
       )
 
       res <- c(res, list(obs2))
@@ -571,7 +577,8 @@ create_link_obs_observer <- function(input, rv, upd, session, proxy) {
       upd <- create_dt_link_obs(setdiff(ids, names(upd$obs)), upd, input,
                                 rv, session)
       upd <- destroy_dt_link_obs(setdiff(names(upd$obs), ids), upd)
-    }
+    },
+    label = "edit_ext_create_link_obs"
   )
 }
 
@@ -599,7 +606,8 @@ edit_link_observer <- function(upd, rv) {
       } else {
         upd$add <- c(upd$add, new)
       }
-    }
+    },
+    label = "edit_ext_edit_link"
   )
 }
 
@@ -649,7 +657,8 @@ add_link_observer <- function(input, rv, upd, sess) {
           session = sess
         )
       }
-    }
+    },
+    label = "edit_ext_add_link"
   )
 }
 
@@ -675,7 +684,8 @@ rm_link_observer <- function(input, rv, upd, sess) {
 
         notify("No row selected", type = "warning", session = sess)
       }
-    }
+    },
+    label = "edit_ext_rm_link"
   )
 }
 
@@ -727,6 +737,7 @@ modify_link_observer <- function(input, rv, upd, session, proxy, res) {
         dt_board_link(upd$curr, session$ns, rv$board),
         rownames = FALSE
       )
-    }
+    },
+    label = "edit_ext_modify_links"
   )
 }

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -132,7 +132,7 @@ blk_ext_srv <- function(id, board, update, ...) {
         {
           upd$curr <- board_links(board$board)
         },
-        label = "edit_ext_links_sync"
+        label = otel_lbl("edit_ext_links_sync")
       )
 
       output$links_dt <- DT::renderDataTable(
@@ -181,7 +181,7 @@ add_block_observer <- function(input, board, update, session) {
         list(blocks = list(add = add))
       )
     },
-    label = "edit_ext_add_block"
+    label = otel_lbl("edit_ext_add_block")
   )
 }
 
@@ -219,7 +219,7 @@ remove_block_observer <- function(input, board, update, session) {
         list(blocks = list(rm = sel))
       )
     },
-    label = "edit_ext_remove_block"
+    label = otel_lbl("edit_ext_remove_block")
   )
 }
 
@@ -231,7 +231,7 @@ update_block_select_observer <- function(board, session) {
       "block_select",
       choices = board_block_ids(board$board)
     ),
-    label = "edit_ext_update_block_select"
+    label = otel_lbl("edit_ext_update_block_select")
   )
 }
 
@@ -489,7 +489,7 @@ create_dt_link_obs <- function(ids, upd, ...) {
         upd$edit <- list(row = row, col = col, val = new)
       },
       ignoreInit = TRUE,
-      label = "edit_ext_link_cell"
+      label = otel_lbl("edit_ext_link_cell")
     )
 
     res <- list(obs1)
@@ -523,7 +523,7 @@ create_dt_link_obs <- function(ids, upd, ...) {
             selected = from_selected(upd)
           )
         },
-        label = "edit_ext_link_block_sync"
+        label = otel_lbl("edit_ext_link_block_sync")
       )
 
       res <- c(res, list(obs2))
@@ -578,7 +578,7 @@ create_link_obs_observer <- function(input, rv, upd, session, proxy) {
                                 rv, session)
       upd <- destroy_dt_link_obs(setdiff(names(upd$obs), ids), upd)
     },
-    label = "edit_ext_create_link_obs"
+    label = otel_lbl("edit_ext_create_link_obs")
   )
 }
 
@@ -607,7 +607,7 @@ edit_link_observer <- function(upd, rv) {
         upd$add <- c(upd$add, new)
       }
     },
-    label = "edit_ext_edit_link"
+    label = otel_lbl("edit_ext_edit_link")
   )
 }
 
@@ -658,7 +658,7 @@ add_link_observer <- function(input, rv, upd, sess) {
         )
       }
     },
-    label = "edit_ext_add_link"
+    label = otel_lbl("edit_ext_add_link")
   )
 }
 
@@ -685,7 +685,7 @@ rm_link_observer <- function(input, rv, upd, sess) {
         notify("No row selected", type = "warning", session = sess)
       }
     },
-    label = "edit_ext_rm_link"
+    label = otel_lbl("edit_ext_rm_link")
   )
 }
 
@@ -738,6 +738,6 @@ modify_link_observer <- function(input, rv, upd, session, proxy, res) {
         rownames = FALSE
       )
     },
-    label = "edit_ext_modify_links"
+    label = otel_lbl("edit_ext_modify_links")
   )
 }

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -474,7 +474,8 @@ edit_block_server <- function(callbacks = list()) {
                 )
               )
             )
-          }
+          },
+          label = "block_rename"
         )
 
         observeEvent(
@@ -502,7 +503,8 @@ edit_block_server <- function(callbacks = list()) {
               "Block name",
               new
             )
-          }
+          },
+          label = "block_name_sync"
         )
 
         output$block_name_out <- renderUI(
@@ -518,7 +520,8 @@ edit_block_server <- function(callbacks = list()) {
             "blk_accordion",
             input$collapse_blk_sections,
             session
-          )
+          ),
+          label = "block_section_collapse"
         )
 
         conds <- reactive(
@@ -529,19 +532,22 @@ edit_block_server <- function(callbacks = list()) {
               function(cnd, cnds) coal(unlst(lst_xtr(cnds, cnd)), list()),
               reactiveValuesToList(board$blocks[[block_id]]$server$cond)
             )
-          }
+          },
+          label = "block_conds"
         )
 
         update_blk_cond_observer(conds, session)
 
         observeEvent(
           input$append_block,
-          actions[["append_block_action"]](block_id)
+          actions[["append_block_action"]](block_id),
+          label = "block_card_append"
         )
 
         observeEvent(
           input$delete_block,
-          actions[["remove_block_action"]](block_id)
+          actions[["remove_block_action"]](block_id),
+          label = "block_card_delete"
         )
 
         if (length(callbacks)) {
@@ -567,7 +573,10 @@ edit_block_server <- function(callbacks = list()) {
         }
 
         list(
-          visible = reactive(input$collapse_blk_sections)
+          visible = reactive(
+            input$collapse_blk_sections,
+            label = "block_visible"
+          )
         )
       }
     )
@@ -653,7 +662,8 @@ update_blk_cond_observer <- function(conds, session = get_session()) {
           ui = msgs
         )
       }
-    }
+    },
+    label = "block_cond_render"
   )
 }
 

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -475,7 +475,7 @@ edit_block_server <- function(callbacks = list()) {
               )
             )
           },
-          label = "block_rename"
+          label = otel_lbl("block_rename")
         )
 
         observeEvent(
@@ -504,7 +504,7 @@ edit_block_server <- function(callbacks = list()) {
               new
             )
           },
-          label = "block_name_sync"
+          label = otel_lbl("block_name_sync")
         )
 
         output$block_name_out <- renderUI(
@@ -521,7 +521,7 @@ edit_block_server <- function(callbacks = list()) {
             input$collapse_blk_sections,
             session
           ),
-          label = "block_section_collapse"
+          label = otel_lbl("block_section_collapse")
         )
 
         conds <- reactive(
@@ -533,7 +533,7 @@ edit_block_server <- function(callbacks = list()) {
               reactiveValuesToList(board$blocks[[block_id]]$server$cond)
             )
           },
-          label = "block_conds"
+          label = otel_lbl("block_conds")
         )
 
         update_blk_cond_observer(conds, session)
@@ -541,13 +541,13 @@ edit_block_server <- function(callbacks = list()) {
         observeEvent(
           input$append_block,
           actions[["append_block_action"]](block_id),
-          label = "block_card_append"
+          label = otel_lbl("block_card_append")
         )
 
         observeEvent(
           input$delete_block,
           actions[["remove_block_action"]](block_id),
-          label = "block_card_delete"
+          label = otel_lbl("block_card_delete")
         )
 
         if (length(callbacks)) {
@@ -575,7 +575,7 @@ edit_block_server <- function(callbacks = list()) {
         list(
           visible = reactive(
             input$collapse_blk_sections,
-            label = "block_visible"
+            label = otel_lbl("block_visible")
           )
         )
       }
@@ -663,7 +663,7 @@ update_blk_cond_observer <- function(conds, session = get_session()) {
         )
       }
     },
-    label = "block_cond_render"
+    label = otel_lbl("block_cond_render")
   )
 }
 


### PR DESCRIPTION
@nbenn As promised, a PR to decorate observers for OTEL.

We could go a bit further by prefixing the label with the package name because at the moment, there might be difficulties to retrieve what belongs to blockr.dag, core or dock, except for some very obvious traces. What do you think?

<img width="959" height="626" alt="Screenshot 2026-03-19 at 12 32 44" src="https://github.com/user-attachments/assets/d6b3c14d-bac3-4653-9488-041a2a1b5ec8" />

<img width="1395" height="790" alt="Screenshot 2026-03-17 at 11 25 47" src="https://github.com/user-attachments/assets/5336e1eb-8451-466a-a138-00639fad422f" />
