### PR TITLE
Fix #119: AI assistant reachable when dock is locked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# blockr.dock (development version)
+
+* Fix #119: when the dock is locked, the AI assistant sparkle button stays in the block header alongside the Controls panel — the inputs/outputs section toggles remain hidden as before.
+
 # blockr.dock 0.1.1
 
 * Added prepend block action.

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -140,7 +140,7 @@ block_card_title <- function(block, id, info) {
 block_card_toggles <- function(blk, ns, ctrl_meta = NULL) {
 
   if (is_dock_locked()) {
-    return(NULL)
+    return(locked_ctrl_button(blk, ns, ctrl_meta))
   }
 
   vals <- c("inputs", "outputs")
@@ -188,6 +188,27 @@ block_card_toggles <- function(blk, ns, ctrl_meta = NULL) {
       ns("collapse_blk_sections"),
       jsonlite::toJSON(tooltip_titles)
     )))
+  )
+}
+
+locked_ctrl_button <- function(blk, ns, ctrl_meta) {
+
+  if (is.null(ctrl_meta)) {
+    return(NULL)
+  }
+
+  visible <- coal(attr(blk, "visible"), c("inputs", "outputs"))
+
+  if (!"inputs" %in% visible) {
+    return(NULL)
+  }
+
+  tags$button(
+    id = ns("toggle_ctrl_locked"),
+    type = "button",
+    class = "action-button btn btn-light blockr-header-icon",
+    title = coal(ctrl_meta$tooltip, ctrl_meta$label, "AI Assistant"),
+    ctrl_button_label(ctrl_meta)
   )
 }
 
@@ -519,6 +540,21 @@ edit_block_server <- function(callbacks = list()) {
             input$collapse_blk_sections,
             session
           )
+        )
+
+        ctrl_locked_open <- reactiveVal(FALSE)
+
+        observeEvent(
+          input$toggle_ctrl_locked,
+          {
+            ctrl_locked_open(!ctrl_locked_open())
+            if (ctrl_locked_open()) {
+              accordion_panel_open("blk_accordion", "ctrl", session = session)
+            } else {
+              accordion_panel_close("blk_accordion", "ctrl", session = session)
+            }
+          },
+          ignoreInit = TRUE
         )
 
         conds <- reactive(

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -50,6 +50,63 @@ test_that("edit block server", {
   )
 })
 
+test_that("block_card_toggles renders standalone sparkle when locked and Controls visible", {
+
+  withr::local_options(blockr.dock_is_locked = TRUE)
+
+  ctrl_meta <- list(
+    label   = "",
+    icon    = htmltools::HTML("<svg/>"),
+    class   = "blockr-sparkle-btn",
+    tooltip = "AI Assistant"
+  )
+
+  ui <- block_card_toggles(
+    new_dataset_block(),
+    shiny::NS("test"),
+    ctrl_meta
+  )
+
+  rendered <- as.character(htmltools::renderTags(ui)$html)
+
+  expect_match(rendered, 'id="test-toggle_ctrl_locked"', fixed = TRUE)
+  expect_match(rendered, "blockr-header-icon", fixed = TRUE)
+  expect_match(rendered, "blockr-sparkle-btn", fixed = TRUE)
+  expect_no_match(rendered, "collapse_blk_sections")
+})
+
+test_that("block_card_toggles hides sparkle when locked and Controls hidden", {
+
+  withr::local_options(blockr.dock_is_locked = TRUE)
+
+  ctrl_meta <- list(
+    label   = "",
+    icon    = htmltools::HTML("<svg/>"),
+    class   = "blockr-sparkle-btn",
+    tooltip = "AI Assistant"
+  )
+
+  blk <- new_dataset_block()
+  attr(blk, "visible") <- c("outputs")
+
+  ui <- block_card_toggles(blk, shiny::NS("test"), ctrl_meta)
+
+  expect_null(ui)
+})
+
+test_that("block_card_toggles returns NULL when locked without ctrl_meta", {
+
+  withr::local_options(blockr.dock_is_locked = TRUE)
+
+  ui <- block_card_toggles(
+    new_dataset_block(),
+    shiny::NS("test"),
+    ctrl_meta = NULL
+  )
+
+  expect_null(ui)
+})
+
 test_that("condition ui test", {
 
   insert_count <- 0L


### PR DESCRIPTION
## Summary
When the dock is locked, a standalone sparkle button is now rendered in the block header whenever the Controls panel is visible. The AI assistant is conceptually part of Controls (it drives the same inputs via natural language), so its availability tracks Controls visibility rather than lock state. Inputs/outputs section toggles remain hidden under locking — locking still freezes which panels the reader can show/hide.

Closes #119.

## Test plan
- [x] `devtools::test()` — 27 passing in test-plugin-block (3 new); 380 passing overall
- [x] Manual repro with `options(blockr.dock_is_locked = TRUE)` — sparkle visible in header, click toggles only the AI panel without affecting inputs/outputs
- [x] Sanity-checked unlocked mode — toggle row unchanged, sparkle still in the checkboxGroupButtons