### PR TITLE
Phase 2: adopt blockr.ui sidebar primitive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Imports:
     blockr.core (>= 0.1.2),
+    blockr.ui,
     bsicons,
     shiny,
     shinyjs,
@@ -32,6 +33,8 @@ Imports:
     cli,
     shinyWidgets,
     jsonlite
+Remotes:
+    BristolMyersSquibb/blockr.ui@phase1-sidebar-primitive
 Suggests:
     testthat (>= 3.0.0),
     DT,
@@ -46,7 +49,7 @@ Collate:
     'action-class.R'
     'action-block.R'
     'action-link.R'
-    'action-modal.R'
+    'action-sidebar.R'
     'action-stack.R'
     'action-ui.R'
     'action-utils.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     shinyWidgets,
     jsonlite
 Remotes:
-    BristolMyersSquibb/blockr.ui@phase1-sidebar-primitive
+    BristolMyersSquibb/blockr.ui
 Suggests:
     testthat (>= 3.0.0),
     DT,

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -1,4 +1,5 @@
-add_block_action <- function(trigger, board, update, ...) {
+add_block_action <- function(trigger, board, update, ...,
+                             sidebar_id = "main_sidebar") {
   new_action(
     function(input, output, session) {
       ns <- session$ns
@@ -7,11 +8,13 @@ add_block_action <- function(trigger, board, update, ...) {
       observeEvent(
         trigger(),
         {
-          log_debug("showing add block action modal")
+          log_debug("showing add block action sidebar")
           blk(NULL)
 
-          showModal(
-            block_modal(
+          blockr.ui::show_sidebar(
+            sidebar_id,
+            title = "Add new block",
+            ui = block_sidebar_body(
               ns = ns,
               board = board$board,
               mode = "add"
@@ -73,7 +76,11 @@ add_block_action <- function(trigger, board, update, ...) {
           bk <- as_blocks(set_names(list(bk), id))
 
           update(list(blocks = list(add = bk)))
-          removeModal()
+          blockr.ui::keep_or_hide_sidebar(
+            sidebar_id,
+            title = "Add new block",
+            ui = block_sidebar_body(ns, board$board, mode = "add")
+          )
         }
       )
 
@@ -83,7 +90,8 @@ add_block_action <- function(trigger, board, update, ...) {
   )
 }
 
-append_block_action <- function(trigger, board, update, ...) {
+append_block_action <- function(trigger, board, update, ...,
+                                sidebar_id = "main_sidebar") {
   new_action(
     function(input, output, session) {
       ns <- session$ns
@@ -93,8 +101,10 @@ append_block_action <- function(trigger, board, update, ...) {
         trigger(),
         {
           blk(NULL)
-          showModal(
-            block_modal(
+          blockr.ui::show_sidebar(
+            sidebar_id,
+            title = "Append new block",
+            ui = block_sidebar_body(
               ns = ns,
               board = board$board,
               mode = "append"
@@ -194,7 +204,11 @@ append_block_action <- function(trigger, board, update, ...) {
             )
           )
 
-          removeModal()
+          blockr.ui::keep_or_hide_sidebar(
+            sidebar_id,
+            title = "Append new block",
+            ui = block_sidebar_body(ns, board$board, mode = "append")
+          )
         }
       )
 
@@ -204,7 +218,8 @@ append_block_action <- function(trigger, board, update, ...) {
   )
 }
 
-prepend_block_action <- function(trigger, board, update, ...) {
+prepend_block_action <- function(trigger, board, update, ...,
+                                 sidebar_id = "main_sidebar") {
   new_action(
     function(input, output, session) {
       ns <- session$ns
@@ -214,8 +229,10 @@ prepend_block_action <- function(trigger, board, update, ...) {
         trigger(),
         {
           blk(NULL)
-          showModal(
-            block_modal(
+          blockr.ui::show_sidebar(
+            sidebar_id,
+            title = "Prepend new block",
+            ui = block_sidebar_body(
               ns = ns,
               board = board$board,
               mode = "prepend"
@@ -310,7 +327,11 @@ prepend_block_action <- function(trigger, board, update, ...) {
             )
           )
 
-          removeModal()
+          blockr.ui::keep_or_hide_sidebar(
+            sidebar_id,
+            title = "Prepend new block",
+            ui = block_sidebar_body(ns, board$board, mode = "prepend")
+          )
         }
       )
 

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -1,5 +1,4 @@
-add_block_action <- function(trigger, board, update, ...,
-                             sidebar_id = "main_sidebar") {
+add_block_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
       ns <- session$ns
@@ -12,7 +11,7 @@ add_block_action <- function(trigger, board, update, ...,
           blk(NULL)
 
           blockr.ui::show_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Add new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -77,7 +76,7 @@ add_block_action <- function(trigger, board, update, ...,
 
           update(list(blocks = list(add = bk)))
           blockr.ui::keep_or_hide_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Add new block",
             ui = block_sidebar_body(ns, board$board, mode = "add")
           )
@@ -90,8 +89,7 @@ add_block_action <- function(trigger, board, update, ...,
   )
 }
 
-append_block_action <- function(trigger, board, update, ...,
-                                sidebar_id = "main_sidebar") {
+append_block_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
       ns <- session$ns
@@ -102,7 +100,7 @@ append_block_action <- function(trigger, board, update, ...,
         {
           blk(NULL)
           blockr.ui::show_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Append new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -205,7 +203,7 @@ append_block_action <- function(trigger, board, update, ...,
           )
 
           blockr.ui::keep_or_hide_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Append new block",
             ui = block_sidebar_body(ns, board$board, mode = "append")
           )
@@ -218,8 +216,7 @@ append_block_action <- function(trigger, board, update, ...,
   )
 }
 
-prepend_block_action <- function(trigger, board, update, ...,
-                                 sidebar_id = "main_sidebar") {
+prepend_block_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
       ns <- session$ns
@@ -230,7 +227,7 @@ prepend_block_action <- function(trigger, board, update, ...,
         {
           blk(NULL)
           blockr.ui::show_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Prepend new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -328,7 +325,7 @@ prepend_block_action <- function(trigger, board, update, ...,
           )
 
           blockr.ui::keep_or_hide_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Prepend new block",
             ui = block_sidebar_body(ns, board$board, mode = "prepend")
           )

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -3,6 +3,7 @@ add_block_action <- function(trigger, board, update, ...) {
     function(input, output, session) {
       ns <- session$ns
       blk <- reactiveVal()
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
 
       observeEvent(
         trigger(),
@@ -11,7 +12,7 @@ add_block_action <- function(trigger, board, update, ...) {
           blk(NULL)
 
           blockr.ui::show_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Add new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -76,7 +77,7 @@ add_block_action <- function(trigger, board, update, ...) {
 
           update(list(blocks = list(add = bk)))
           blockr.ui::keep_or_hide_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Add new block",
             ui = block_sidebar_body(ns, board$board, mode = "add")
           )
@@ -94,13 +95,14 @@ append_block_action <- function(trigger, board, update, ...) {
     function(input, output, session) {
       ns <- session$ns
       blk <- reactiveVal()
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
 
       observeEvent(
         trigger(),
         {
           blk(NULL)
           blockr.ui::show_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Append new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -203,7 +205,7 @@ append_block_action <- function(trigger, board, update, ...) {
           )
 
           blockr.ui::keep_or_hide_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Append new block",
             ui = block_sidebar_body(ns, board$board, mode = "append")
           )
@@ -221,13 +223,14 @@ prepend_block_action <- function(trigger, board, update, ...) {
     function(input, output, session) {
       ns <- session$ns
       blk <- reactiveVal()
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
 
       observeEvent(
         trigger(),
         {
           blk(NULL)
           blockr.ui::show_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Prepend new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -325,7 +328,7 @@ prepend_block_action <- function(trigger, board, update, ...) {
           )
 
           blockr.ui::keep_or_hide_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Prepend new block",
             ui = block_sidebar_body(ns, board$board, mode = "prepend")
           )

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -11,7 +11,7 @@ add_block_action <- function(trigger, board, update, ...) {
           blk(NULL)
 
           blockr.ui::show_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Add new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -76,7 +76,7 @@ add_block_action <- function(trigger, board, update, ...) {
 
           update(list(blocks = list(add = bk)))
           blockr.ui::keep_or_hide_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Add new block",
             ui = block_sidebar_body(ns, board$board, mode = "add")
           )
@@ -100,7 +100,7 @@ append_block_action <- function(trigger, board, update, ...) {
         {
           blk(NULL)
           blockr.ui::show_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Append new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -203,7 +203,7 @@ append_block_action <- function(trigger, board, update, ...) {
           )
 
           blockr.ui::keep_or_hide_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Append new block",
             ui = block_sidebar_body(ns, board$board, mode = "append")
           )
@@ -227,7 +227,7 @@ prepend_block_action <- function(trigger, board, update, ...) {
         {
           blk(NULL)
           blockr.ui::show_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Prepend new block",
             ui = block_sidebar_body(
               ns = ns,
@@ -325,7 +325,7 @@ prepend_block_action <- function(trigger, board, update, ...) {
           )
 
           blockr.ui::keep_or_hide_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Prepend new block",
             ui = block_sidebar_body(ns, board$board, mode = "prepend")
           )

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -7,7 +7,13 @@ add_link_action <- function(trigger, board, update, ...) {
         trigger(),
         {
           body <- link_sidebar_body(session$ns, board$board, trigger())
-          if (is.null(body)) return()
+          if (is.null(body)) {
+            notify(
+              "No inputs are currently available.",
+              type = "warning"
+            )
+            return()
+          }
 
           blockr.ui::show_sidebar(
             "main_sidebar",
@@ -91,10 +97,30 @@ add_link_action <- function(trigger, board, update, ...) {
             list(links = list(add = new_lnk))
           )
 
-          blockr.ui::keep_or_hide_sidebar(
-            "main_sidebar",
-            title = "Create new link",
-            ui = link_sidebar_body(session$ns, board$board, trigger())
+          # Pinned sidebar: rebuild the form for another link, or close
+          # silently if the link we just added consumed the last input.
+          # `update()` only sets a reactiveVal; the board state is mutated
+          # on the next reactive flush, so defer the availability check
+          # until after the flush — otherwise `board$board` is still the
+          # pre-link snapshot. `onFlushed` runs outside a reactive context,
+          # so `isolate()` is needed to read `board$board`.
+          src_id <- trigger()
+          session$onFlushed(
+            function() {
+              isolate({
+                body <- link_sidebar_body(session$ns, board$board, src_id)
+                if (is.null(body)) {
+                  blockr.ui::hide_sidebar("main_sidebar")
+                } else {
+                  blockr.ui::keep_or_hide_sidebar(
+                    "main_sidebar",
+                    title = "Create new link",
+                    ui = body
+                  )
+                }
+              })
+            },
+            once = TRUE
           )
         }
       )

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -3,6 +3,8 @@ add_link_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
 
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
+
       observeEvent(
         trigger(),
         {
@@ -16,7 +18,7 @@ add_link_action <- function(trigger, board, update, ...) {
           }
 
           blockr.ui::show_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Create new link",
             ui = body
           )
@@ -101,7 +103,7 @@ add_link_action <- function(trigger, board, update, ...) {
           # silently if the link we just added consumed the last input.
           # `update()` only sets a reactiveVal; the board state is mutated
           # on the next reactive flush, so defer the availability check
-          # until after the flush — otherwise `board$board` is still the
+          # until after the flush; otherwise `board$board` is still the
           # pre-link snapshot. `onFlushed` runs outside a reactive context,
           # so `isolate()` is needed to read `board$board`.
           src_id <- trigger()
@@ -110,10 +112,10 @@ add_link_action <- function(trigger, board, update, ...) {
               isolate({
                 body <- link_sidebar_body(session$ns, board$board, src_id)
                 if (is.null(body)) {
-                  blockr.ui::hide_sidebar("actions_sidebar")
+                  blockr.ui::hide_sidebar(sidebar_id)
                 } else {
                   blockr.ui::keep_or_hide_sidebar(
-                    "actions_sidebar",
+                    sidebar_id,
                     title = "Create new link",
                     ui = body
                   )

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -16,7 +16,7 @@ add_link_action <- function(trigger, board, update, ...) {
           }
 
           blockr.ui::show_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Create new link",
             ui = body
           )
@@ -110,10 +110,10 @@ add_link_action <- function(trigger, board, update, ...) {
               isolate({
                 body <- link_sidebar_body(session$ns, board$board, src_id)
                 if (is.null(body)) {
-                  blockr.ui::hide_sidebar("main_sidebar")
+                  blockr.ui::hide_sidebar("actions_sidebar")
                 } else {
                   blockr.ui::keep_or_hide_sidebar(
-                    "main_sidebar",
+                    "actions_sidebar",
                     title = "Create new link",
                     ui = body
                   )

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -1,11 +1,21 @@
-add_link_action <- function(trigger, board, update, ...) {
+add_link_action <- function(trigger, board, update, ...,
+                            sidebar_id = "main_sidebar") {
 
   new_action(
     function(input, output, session) {
 
       observeEvent(
         trigger(),
-        showModal(link_modal(session$ns, board$board, trigger()))
+        {
+          body <- link_sidebar_body(session$ns, board$board, trigger())
+          if (is.null(body)) return()
+
+          blockr.ui::show_sidebar(
+            sidebar_id,
+            title = "Create new link",
+            ui = body
+          )
+        }
       )
 
       observeEvent(
@@ -82,7 +92,11 @@ add_link_action <- function(trigger, board, update, ...) {
             list(links = list(add = new_lnk))
           )
 
-          removeModal()
+          blockr.ui::keep_or_hide_sidebar(
+            sidebar_id,
+            title = "Create new link",
+            ui = link_sidebar_body(session$ns, board$board, trigger())
+          )
         }
       )
 

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -1,5 +1,4 @@
-add_link_action <- function(trigger, board, update, ...,
-                            sidebar_id = "main_sidebar") {
+add_link_action <- function(trigger, board, update, ...) {
 
   new_action(
     function(input, output, session) {
@@ -11,7 +10,7 @@ add_link_action <- function(trigger, board, update, ...,
           if (is.null(body)) return()
 
           blockr.ui::show_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Create new link",
             ui = body
           )
@@ -93,7 +92,7 @@ add_link_action <- function(trigger, board, update, ...,
           )
 
           blockr.ui::keep_or_hide_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Create new link",
             ui = link_sidebar_body(session$ns, board$board, trigger())
           )

--- a/R/action-sidebar.R
+++ b/R/action-sidebar.R
@@ -1,15 +1,8 @@
-block_modal <- function(ns, board, mode = c("append", "add", "prepend")) {
+block_sidebar_body <- function(ns, board, mode = c("append", "add", "prepend")) {
 
   mode <- match.arg(mode)
   board_block_ids <- board_block_ids(board)
   board_link_ids <- board_link_ids(board)
-
-  title <- switch(
-    mode,
-    append = "Append new block",
-    prepend = "Prepend new block",
-    add = "Add new block"
-  )
 
   button_label <- switch(
     mode,
@@ -68,29 +61,22 @@ block_modal <- function(ns, board, mode = c("append", "add", "prepend")) {
     tagList(advanced_fields)
   )
 
-  modalDialog(
-    title = title,
-    size = "l",
-    easyClose = TRUE,
-    footer = NULL,
-    tagList(
-      css_modal_advanced(ns("block-advanced-options")),
-      visible_fields,
-      toggle_button(
-        ns("block-advanced-options"),
-        ns("block-advanced-toggle")
-      ),
-      advanced_section,
-      confirm_button(
-        inputId = ns(confirm_id),
-        label = button_label
-      ),
-      auto_focus_script(ns(selection_id))
+  tagList(
+    css_modal_advanced(ns("block-advanced-options")),
+    visible_fields,
+    toggle_button(
+      ns("block-advanced-options"),
+      ns("block-advanced-toggle")
+    ),
+    advanced_section,
+    confirm_button(
+      inputId = ns(confirm_id),
+      label = button_label
     )
   )
 }
 
-link_modal <- function(ns, board, block_id) {
+link_sidebar_body <- function(ns, board, block_id) {
   board_blocks <- board_blocks(board)
 
   stopifnot(is_string(block_id), block_id %in% names(board_blocks))
@@ -111,7 +97,7 @@ link_modal <- function(ns, board, block_id) {
       "No inputs are currently available.",
       type = "warning"
     )
-    return()
+    return(NULL)
   }
 
   visible_fields <- list(
@@ -145,26 +131,19 @@ link_modal <- function(ns, board, block_id) {
     tagList(advanced_fields)
   )
 
-  modalDialog(
-    title = "Create new link",
-    size = "m",
-    easyClose = TRUE,
-    footer = NULL,
-    tagList(
-      css_modal_advanced(ns("link-advanced-options")),
-      visible_fields,
-      toggle,
-      advanced_section,
-      confirm_button(
-        inputId = ns("add_link_confirm"),
-        label = "Add Link"
-      ),
-      auto_focus_script(ns(selection_id))
+  tagList(
+    css_modal_advanced(ns("link-advanced-options")),
+    visible_fields,
+    toggle,
+    advanced_section,
+    confirm_button(
+      inputId = ns("add_link_confirm"),
+      label = "Add Link"
     )
   )
 }
 
-stack_modal <- function(
+stack_sidebar_body <- function(
   ns,
   board,
   mode = c("create", "edit"),
@@ -189,7 +168,6 @@ stack_modal <- function(
   board_blocks <- board_blocks[avail]
 
   # Mode-specific values
-  title <- if (mode == "create") "Create new stack" else "Edit stack"
   button_label <- if (mode == "create") "Create Stack" else "Update Stack"
 
   selection_id <- if (mode == "create") {
@@ -277,21 +255,14 @@ stack_modal <- function(
     )
   }
 
-  modalDialog(
-    title = title,
-    size = "l",
-    easyClose = TRUE,
-    footer = NULL,
-    tagList(
-      css_modal_advanced(ns("stack-advanced-options")),
-      visible_fields,
-      toggle,
-      advanced_section,
-      confirm_button(
-        inputId = ns(confirm_id),
-        label = button_label
-      ),
-      auto_focus_script(ns(selection_id))
+  tagList(
+    css_modal_advanced(ns("stack-advanced-options")),
+    visible_fields,
+    toggle,
+    advanced_section,
+    confirm_button(
+      inputId = ns(confirm_id),
+      label = button_label
     )
   )
 }

--- a/R/action-sidebar.R
+++ b/R/action-sidebar.R
@@ -96,10 +96,9 @@ link_sidebar_body <- function(ns, board, block_id) {
   )
 
   if (sum(lengths(avail)) == 0L) {
-    notify(
-      "No inputs are currently available.",
-      type = "warning"
-    )
+    # Pure UI builder: signal "nothing to render" with NULL and let the
+    # caller decide whether to warn (initial open) or close silently
+    # (post-confirm chain path).
     return(NULL)
   }
 

--- a/R/action-sidebar.R
+++ b/R/action-sidebar.R
@@ -1,5 +1,8 @@
-block_sidebar_body <- function(ns, board, mode = c("append", "add", "prepend")) {
-
+block_sidebar_body <- function(
+  ns,
+  board,
+  mode = c("append", "add", "prepend")
+) {
   mode <- match.arg(mode)
   board_block_ids <- board_block_ids(board)
   board_link_ids <- board_link_ids(board)

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -1,13 +1,22 @@
-add_stack_action <- function(trigger, board, update, ...) {
+add_stack_action <- function(trigger, board, update, ...,
+                             sidebar_id = "main_sidebar") {
 
   new_action(
     function(input, output, session) {
 
       observeEvent(
         trigger(),
-        showModal(
-          stack_modal(ns = session$ns, board = board$board, mode = "create")
-        )
+        {
+          blockr.ui::show_sidebar(
+            sidebar_id,
+            title = "Create new stack",
+            ui = stack_sidebar_body(
+              ns = session$ns,
+              board = board$board,
+              mode = "create"
+            )
+          )
+        }
       )
 
       observeEvent(
@@ -74,7 +83,11 @@ add_stack_action <- function(trigger, board, update, ...) {
 
           update(list(stacks = list(add = new_stk)))
 
-          removeModal()
+          blockr.ui::keep_or_hide_sidebar(
+            sidebar_id,
+            title = "Create new stack",
+            ui = stack_sidebar_body(session$ns, board$board, mode = "create")
+          )
         }
       )
 
@@ -84,7 +97,8 @@ add_stack_action <- function(trigger, board, update, ...) {
   )
 }
 
-edit_stack_action <- function(trigger, board, update, ...) {
+edit_stack_action <- function(trigger, board, update, ...,
+                              sidebar_id = "main_sidebar") {
 
   new_action(
     function(input, output, session) {
@@ -96,8 +110,10 @@ edit_stack_action <- function(trigger, board, update, ...) {
         {
           stack <- board_stacks(board$board)[[trigger()]]
 
-          showModal(
-            stack_modal(
+          blockr.ui::show_sidebar(
+            sidebar_id,
+            title = "Edit stack",
+            ui = stack_sidebar_body(
               ns = ns,
               board = board$board,
               mode = "edit",
@@ -169,7 +185,19 @@ edit_stack_action <- function(trigger, board, update, ...) {
 
           update(list(stacks = list(mod = stack)))
 
-          removeModal()
+          # Re-pull the stack so the form reflects the just-saved state.
+          fresh_stack <- board_stacks(board$board)[[trigger()]]
+          blockr.ui::keep_or_hide_sidebar(
+            sidebar_id,
+            title = "Edit stack",
+            ui = stack_sidebar_body(
+              ns,
+              board$board,
+              mode = "edit",
+              stack = fresh_stack,
+              stack_id = trigger()
+            )
+          )
         }
       )
 

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -7,7 +7,7 @@ add_stack_action <- function(trigger, board, update, ...) {
         trigger(),
         {
           blockr.ui::show_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Create new stack",
             ui = stack_sidebar_body(
               ns = session$ns,
@@ -83,7 +83,7 @@ add_stack_action <- function(trigger, board, update, ...) {
           update(list(stacks = list(add = new_stk)))
 
           blockr.ui::keep_or_hide_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Create new stack",
             ui = stack_sidebar_body(session$ns, board$board, mode = "create")
           )
@@ -109,7 +109,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
           stack <- board_stacks(board$board)[[trigger()]]
 
           blockr.ui::show_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Edit stack",
             ui = stack_sidebar_body(
               ns = ns,
@@ -186,7 +186,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
           # Re-pull the stack so the form reflects the just-saved state.
           fresh_stack <- board_stacks(board$board)[[trigger()]]
           blockr.ui::keep_or_hide_sidebar(
-            "main_sidebar",
+            "actions_sidebar",
             title = "Edit stack",
             ui = stack_sidebar_body(
               ns,

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -3,11 +3,13 @@ add_stack_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
 
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
+
       observeEvent(
         trigger(),
         {
           blockr.ui::show_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Create new stack",
             ui = stack_sidebar_body(
               ns = session$ns,
@@ -83,7 +85,7 @@ add_stack_action <- function(trigger, board, update, ...) {
           update(list(stacks = list(add = new_stk)))
 
           blockr.ui::keep_or_hide_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Create new stack",
             ui = stack_sidebar_body(session$ns, board$board, mode = "create")
           )
@@ -102,6 +104,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
     function(input, output, session) {
 
       ns <- session$ns
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
 
       observeEvent(
         trigger(),
@@ -109,7 +112,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
           stack <- board_stacks(board$board)[[trigger()]]
 
           blockr.ui::show_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Edit stack",
             ui = stack_sidebar_body(
               ns = ns,
@@ -186,7 +189,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
           # Re-pull the stack so the form reflects the just-saved state.
           fresh_stack <- board_stacks(board$board)[[trigger()]]
           blockr.ui::keep_or_hide_sidebar(
-            "actions_sidebar",
+            sidebar_id,
             title = "Edit stack",
             ui = stack_sidebar_body(
               ns,

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -1,5 +1,4 @@
-add_stack_action <- function(trigger, board, update, ...,
-                             sidebar_id = "main_sidebar") {
+add_stack_action <- function(trigger, board, update, ...) {
 
   new_action(
     function(input, output, session) {
@@ -8,7 +7,7 @@ add_stack_action <- function(trigger, board, update, ...,
         trigger(),
         {
           blockr.ui::show_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Create new stack",
             ui = stack_sidebar_body(
               ns = session$ns,
@@ -84,7 +83,7 @@ add_stack_action <- function(trigger, board, update, ...,
           update(list(stacks = list(add = new_stk)))
 
           blockr.ui::keep_or_hide_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Create new stack",
             ui = stack_sidebar_body(session$ns, board$board, mode = "create")
           )
@@ -97,8 +96,7 @@ add_stack_action <- function(trigger, board, update, ...,
   )
 }
 
-edit_stack_action <- function(trigger, board, update, ...,
-                              sidebar_id = "main_sidebar") {
+edit_stack_action <- function(trigger, board, update, ...) {
 
   new_action(
     function(input, output, session) {
@@ -111,7 +109,7 @@ edit_stack_action <- function(trigger, board, update, ...,
           stack <- board_stacks(board$board)[[trigger()]]
 
           blockr.ui::show_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Edit stack",
             ui = stack_sidebar_body(
               ns = ns,
@@ -188,7 +186,7 @@ edit_stack_action <- function(trigger, board, update, ...,
           # Re-pull the stack so the form reflects the just-saved state.
           fresh_stack <- board_stacks(board$board)[[trigger()]]
           blockr.ui::keep_or_hide_sidebar(
-            sidebar_id,
+            "main_sidebar",
             title = "Edit stack",
             ui = stack_sidebar_body(
               ns,

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -15,15 +15,6 @@
 #'
 #' @noRd
 board_server_callback <- function(board, update, ..., session = get_session()) {
-  dot_args <- list(...)
-
-  # `app_options` is the user-supplied `options` from `serve()`, re-passed
-  # by `blockr_app_server.dock_board()` so it survives blockr.core's
-  # callback dispatch (which consumes the official `options` arg for its
-  # own userData wiring and does not forward it). May be `NULL` if the
-  # caller did not customise — `settings_body()` falls back to recompute.
-  app_options <- dot_args[["app_options"]]
-
   initial_board <- isolate(board$board)
 
   exts <- as.list(dock_extensions(initial_board))
@@ -53,7 +44,6 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   add_view_observer(vs, session, dock_mgr, board, update, triggers)
   remove_view_observer(vs, session, dock_mgr)
   rename_view_observer(vs, session, dock_mgr)
-  settings_observer(session, board, options = app_options)
 
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
@@ -178,39 +168,6 @@ init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
   )
   active_view(bare) <- active_v
   reactiveValues(state = bare)
-}
-
-#' Observe navbar settings-gear clicks.
-#'
-#' Replaces the previous Bootstrap settings offcanvas: when the gear
-#' fires, render the same options accordion (`settings_body()`) into
-#' the shared sidebar via `blockr.ui::show_sidebar()`.
-#'
-#' @param session Shiny session (the board's session).
-#' @param board Reactive board state.
-#' @param options Optional `board_options`. When supplied (typically the
-#'   user-customised value threaded down from `serve(board, options = ...)`),
-#'   it overrides `settings_body()`'s default recompute so the sidebar
-#'   renders the caller's intended options set. `NULL` falls through to
-#'   the default `blockr.core::blockr_app_options(x)`.
-#' @noRd
-settings_observer <- function(session, board, options = NULL) {
-  input <- session$input
-  # `session$ns(NULL)` returns the bare module id (documented Shiny API:
-  # `?NS`, `id = NULL` → namespace itself). Used here because
-  # `settings_body()` namespaces its own children with `NS(id, ...)`.
-  id <- session$ns(NULL)
-
-  observeEvent(
-    input$settings_btn,
-    {
-      blockr.ui::show_sidebar(
-        "settings_sidebar",
-        title = "Board options",
-        ui = settings_body(id, board$board, options = options)
-      )
-    }
-  )
 }
 
 #' Observe view tab switches.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -15,6 +15,15 @@
 #'
 #' @noRd
 board_server_callback <- function(board, update, ..., session = get_session()) {
+  dot_args <- list(...)
+
+  # `app_options` is the user-supplied `options` from `serve()`, re-passed
+  # by `blockr_app_server.dock_board()` so it survives blockr.core's
+  # callback dispatch (which consumes the official `options` arg for its
+  # own userData wiring and does not forward it). May be `NULL` if the
+  # caller did not customise — `settings_body()` falls back to recompute.
+  app_options <- dot_args[["app_options"]]
+
   initial_board <- isolate(board$board)
 
   exts <- as.list(dock_extensions(initial_board))
@@ -44,7 +53,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   add_view_observer(vs, session, dock_mgr, board, update, triggers)
   remove_view_observer(vs, session, dock_mgr)
   rename_view_observer(vs, session, dock_mgr)
-  settings_observer(session, board)
+  settings_observer(session, board, options = app_options)
 
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
@@ -179,8 +188,13 @@ init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
 #'
 #' @param session Shiny session (the board's session).
 #' @param board Reactive board state.
+#' @param options Optional `board_options`. When supplied (typically the
+#'   user-customised value threaded down from `serve(board, options = ...)`),
+#'   it overrides `settings_body()`'s default recompute so the sidebar
+#'   renders the caller's intended options set. `NULL` falls through to
+#'   the default `blockr.core::blockr_app_options(x)`.
 #' @noRd
-settings_observer <- function(session, board) {
+settings_observer <- function(session, board, options = NULL) {
   input <- session$input
   # `session$ns(NULL)` returns the bare module id (documented Shiny API:
   # `?NS`, `id = NULL` → namespace itself). Used here because
@@ -193,7 +207,7 @@ settings_observer <- function(session, board) {
       blockr.ui::show_sidebar(
         "main_sidebar",
         title = "Board options",
-        ui = settings_body(id, board$board)
+        ui = settings_body(id, board$board, options = options)
       )
     }
   )

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -182,9 +182,10 @@ init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
 #' @noRd
 settings_observer <- function(session, board) {
   input <- session$input
-  # Strip the trailing "-" so settings_body() can use NS(id, ...) on the
-  # un-namespaced board module id, exactly as `options_ui()` did before.
-  id <- sub("-$", "", session$ns(""))
+  # `session$ns(NULL)` returns the bare module id (documented Shiny API:
+  # `?NS`, `id = NULL` → namespace itself). Used here because
+  # `settings_body()` namespaces its own children with `NS(id, ...)`.
+  id <- session$ns(NULL)
 
   observeEvent(
     input$settings_btn,

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -44,6 +44,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   add_view_observer(vs, session, dock_mgr, board, update, triggers)
   remove_view_observer(vs, session, dock_mgr)
   rename_view_observer(vs, session, dock_mgr)
+  settings_observer(session, board)
 
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
@@ -168,6 +169,33 @@ init_view_docks <- function(views, board, update, triggers, session, dock_mgr) {
   )
   active_view(bare) <- active_v
   reactiveValues(state = bare)
+}
+
+#' Observe navbar settings-gear clicks.
+#'
+#' Replaces the previous Bootstrap settings offcanvas: when the gear
+#' fires, render the same options accordion (`settings_body()`) into
+#' the shared sidebar via `blockr.ui::show_sidebar()`.
+#'
+#' @param session Shiny session (the board's session).
+#' @param board Reactive board state.
+#' @noRd
+settings_observer <- function(session, board) {
+  input <- session$input
+  # Strip the trailing "-" so settings_body() can use NS(id, ...) on the
+  # un-namespaced board module id, exactly as `options_ui()` did before.
+  id <- sub("-$", "", session$ns(""))
+
+  observeEvent(
+    input$settings_btn,
+    {
+      blockr.ui::show_sidebar(
+        "main_sidebar",
+        title = "Board options",
+        ui = settings_body(id, board$board)
+      )
+    }
+  )
 }
 
 #' Observe view tab switches.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -205,7 +205,7 @@ settings_observer <- function(session, board, options = NULL) {
     input$settings_btn,
     {
       blockr.ui::show_sidebar(
-        "main_sidebar",
+        "settings_sidebar",
         title = "Board options",
         ui = settings_body(id, board$board, options = options)
       )

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -3,7 +3,6 @@ board_ui.dock_board <- function(
   id,
   x,
   plugins = board_plugins(x),
-  options = board_options(x),
   ...
 ) {
   stopifnot(is_string(id))
@@ -101,11 +100,16 @@ settings_body <- function(
   id,
   x,
   plugins = board_plugins(x),
-  options = blockr.core::blockr_app_options(x)
+  options = NULL
 ) {
   opt_ui_or_null <- function(plg, plgs, x) {
     if (plg %in% names(plgs)) board_ui(id, plgs[[plg]], x)
   }
+
+  # Caller-supplied `options` (threaded from `serve()` through
+  # `blockr_app_server.dock_board()` / `settings_observer()`) wins; fall
+  # back to the recomputed default only when the caller has nothing to say.
+  options <- options %||% blockr.core::blockr_app_options(x)
 
   stopifnot(is_board_options(options))
 

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -2,13 +2,8 @@
 board_ui.dock_board <- function(id, x, plugins = board_plugins(x),
                                 options = board_options(x), ...) {
 
-  opt_ui_or_null <- function(plg, plgs, x) {
-    if (plg %in% names(plgs)) board_ui(id, plgs[[plg]], x)
-  }
-
   stopifnot(is_string(id))
 
-  offcanvas_id <- NS(id, "options_offcanvas")
   views <- board_views(x)
 
   # View nav in the navbar -- always present, since boards always carry a
@@ -34,25 +29,18 @@ board_ui.dock_board <- function(id, x, plugins = board_plugins(x),
       class = "blockr-navbar",
       div(
         class = "blockr-navbar-left",
-        opt_ui_or_null("preserve_board", plugins, x)
+        if ("preserve_board" %in% names(plugins)) {
+          board_ui(id, plugins[["preserve_board"]], x)
+        }
       ),
       div(
         class = "blockr-navbar-right",
         v_nav,
-        tags$button(
-          class = "blockr-navbar-icon-btn",
-          `data-bs-toggle` = "offcanvas",
-          `data-bs-target` = paste0("#", offcanvas_id),
-          bsicons::bs_icon("gear")
+        actionButton(
+          inputId = NS(id, "settings_btn"),
+          label = bsicons::bs_icon("gear"),
+          class = "blockr-navbar-icon-btn"
         )
-      )
-    ),
-    options_ui(
-      id,
-      options,
-      div(
-        id = "generate_code",
-        opt_ui_or_null("generate_code", plugins, x)
       )
     ),
     dock_outputs,
@@ -66,7 +54,11 @@ board_ui.dock_board <- function(id, x, plugins = board_plugins(x),
         id = id,
         board = x
       )
-    )
+    ),
+    # Sidebar mount: fixed top-level DOM id so any deeply-nested action
+    # handler can target it via `blockr.ui::show_sidebar("main_sidebar", ...)`
+    # through `rootScope` walking. Single sidebar per app at v0.
+    blockr.ui::sidebar_ui("main_sidebar")
   )
 }
 
@@ -82,17 +74,39 @@ dock_outputs_ui <- function(id, views) {
   )
 }
 
-options_ui <- function(id, x, ...) {
+#' Build the body of the board-options sidebar.
+#'
+#' Returns a tagList containing the same options accordion that the
+#' Bootstrap offcanvas used to render. Called at server time from
+#' `board_server_callback()` when the user clicks the navbar gear, and
+#' passed to `blockr.ui::show_sidebar()`.
+#'
+#' Uses `blockr.core::blockr_app_options(x)` (rather than `board_options(x)`)
+#' so the accordion includes options contributed by blocks on the board and
+#' by registered block constructors — same set `serve()` passes to the
+#' top-level `board_ui()` call.
+#'
+#' @param id Board module id.
+#' @param x Current board (`board$board`).
+#' @param plugins Board plugins.
+#' @param options Augmented board options (board + block contributions).
+#' @noRd
+settings_body <- function(id, x, plugins = board_plugins(x),
+                          options = blockr.core::blockr_app_options(x)) {
 
-  stopifnot(is_board_options(x))
+  opt_ui_or_null <- function(plg, plgs, x) {
+    if (plg %in% names(plgs)) board_ui(id, plgs[[plg]], x)
+  }
 
-  opts <- split(x, chr_ply(x, attr, "category"))
+  stopifnot(is_board_options(options))
 
-  off_canvas(
-    id = NS(id, "options_offcanvas"),
-    position = "end",
-    title = "Board options",
-    ...,
+  opts <- split(options, chr_ply(options, attr, "category"))
+
+  tagList(
+    div(
+      id = "generate_code",
+      opt_ui_or_null("generate_code", plugins, x)
+    ),
     hr(),
     do.call(
       accordion,

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -60,10 +60,23 @@ board_ui.dock_board <- function(
         board = x
       )
     ),
-    # Sidebar mount: fixed top-level DOM id so any deeply-nested action
-    # handler can target it via `blockr.ui::show_sidebar("main_sidebar", ...)`
-    # through `rootScope` walking. Single sidebar per app at v0.
-    blockr.ui::sidebar_ui("main_sidebar", mode = "push")
+    # Sidebar mounts. Fixed top-level DOM ids so any deeply-nested
+    # consumer can target them via `blockr.ui::show_sidebar(<id>, ...)`
+    # through `rootScope` walking. Contract: one sidebar = one concern.
+    # We mount two on the right (matching their navbar triggers) but with
+    # different modes so they coexist cleanly when both are open:
+    #   * "actions_sidebar"  — the six action handlers (add/append/prepend
+    #     block, add link, add/edit stack). `push` mode: shifts page
+    #     content aside while open.
+    #   * "settings_sidebar" — the navbar gear's board-options panel.
+    #     `overlay` mode: layers above the page (and above the action
+    #     panel when both are pinned) without reflowing content.
+    # Reusing one DOM slot across both concerns would let a foreign caller
+    # silently swap a pinned panel's body — the JS replaces content in
+    # place and never inspects the pin class. Splitting by concern keeps
+    # pin semantics intuitive without multi-pin machinery on the JS side.
+    blockr.ui::sidebar_ui("actions_sidebar", mode = "push", side = "right"),
+    blockr.ui::sidebar_ui("settings_sidebar", mode = "overlay", side = "right")
   )
 }
 

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -1,7 +1,11 @@
 #' @export
-board_ui.dock_board <- function(id, x, plugins = board_plugins(x),
-                                options = board_options(x), ...) {
-
+board_ui.dock_board <- function(
+  id,
+  x,
+  plugins = board_plugins(x),
+  options = board_options(x),
+  ...
+) {
   stopifnot(is_string(id))
 
   views <- board_views(x)
@@ -21,7 +25,9 @@ board_ui.dock_board <- function(id, x, plugins = board_plugins(x),
       id = NS(id, "blocks_offcanvas"),
       title = "Offcanvas blocks",
       block_ui(
-        id, x, plugins[["edit_block"]],
+        id,
+        x,
+        plugins[["edit_block"]],
         ctrl_ui = if ("ctrl_block" %in% names(plugins)) plugins[["ctrl_block"]]
       )
     ),
@@ -58,7 +64,7 @@ board_ui.dock_board <- function(id, x, plugins = board_plugins(x),
     # Sidebar mount: fixed top-level DOM id so any deeply-nested action
     # handler can target it via `blockr.ui::show_sidebar("main_sidebar", ...)`
     # through `rootScope` walking. Single sidebar per app at v0.
-    blockr.ui::sidebar_ui("main_sidebar")
+    blockr.ui::sidebar_ui("main_sidebar", mode = "push")
   )
 }
 
@@ -91,9 +97,12 @@ dock_outputs_ui <- function(id, views) {
 #' @param plugins Board plugins.
 #' @param options Augmented board options (board + block contributions).
 #' @noRd
-settings_body <- function(id, x, plugins = board_plugins(x),
-                          options = blockr.core::blockr_app_options(x)) {
-
+settings_body <- function(
+  id,
+  x,
+  plugins = board_plugins(x),
+  options = blockr.core::blockr_app_options(x)
+) {
   opt_ui_or_null <- function(plg, plgs, x) {
     if (plg %in% names(plgs)) board_ui(id, plgs[[plg]], x)
   }

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -3,6 +3,7 @@ board_ui.dock_board <- function(
   id,
   x,
   plugins = board_plugins(x),
+  options = blockr.core::blockr_app_options(x),
   ...
 ) {
   stopifnot(is_string(id))
@@ -41,10 +42,17 @@ board_ui.dock_board <- function(
       div(
         class = "blockr-navbar-right",
         v_nav,
-        actionButton(
-          inputId = NS(id, "settings_btn"),
-          label = bsicons::bs_icon("gear"),
-          class = "blockr-navbar-icon-btn"
+        # Pure-JS open trigger via `data-blockr-sidebar-target`. The
+        # settings sidebar's body is pre-rendered into its mount below, so
+        # no server observer is needed: clicking the gear toggles the
+        # panel client-side. `tags$button` (not `actionButton`) because
+        # there is no `input$<id>` to wire.
+        tags$button(
+          type = "button",
+          class = "btn action-button blockr-navbar-icon-btn",
+          `data-blockr-sidebar-target` = NS(id, "settings_sidebar"),
+          `aria-label` = "Board options",
+          bsicons::bs_icon("gear")
         )
       )
     ),
@@ -60,23 +68,39 @@ board_ui.dock_board <- function(
         board = x
       )
     ),
-    # Sidebar mounts. Fixed top-level DOM ids so any deeply-nested
-    # consumer can target them via `blockr.ui::show_sidebar(<id>, ...)`
-    # through `rootScope` walking. Contract: one sidebar = one concern.
-    # We mount two on the right (matching their navbar triggers) but with
-    # different modes so they coexist cleanly when both are open:
-    #   * "actions_sidebar"  — the six action handlers (add/append/prepend
+    # Sidebar mounts. Ids are namespaced with `NS(id, ...)` so two
+    # `board_ui.dock_board()` instances on the same page don't collide on
+    # DOM ids. Action handlers reach the matching mount by reading
+    # `board$board_id` (set by blockr.core in the board's reactiveValues)
+    # and composing `NS(board$board_id, "actions_sidebar")` at server time.
+    # Contract: one sidebar = one concern. We mount two on the right
+    # (matching their navbar triggers) but with different modes so they
+    # coexist cleanly when both are open:
+    #   * "actions_sidebar":  the six action handlers (add/append/prepend
     #     block, add link, add/edit stack). `push` mode: shifts page
-    #     content aside while open.
-    #   * "settings_sidebar" — the navbar gear's board-options panel.
+    #     content aside while open. Body is populated server-side via
+    #     `show_sidebar()` because each action ships a freshly-built form.
+    #   * "settings_sidebar": the navbar gear's board-options panel.
     #     `overlay` mode: layers above the page (and above the action
-    #     panel when both are pinned) without reflowing content.
+    #     panel when both are pinned) without reflowing content. Body is
+    #     pre-rendered here at UI-build time and the gear button opens it
+    #     via `data-blockr-sidebar-target` (pure JS, no server roundtrip).
     # Reusing one DOM slot across both concerns would let a foreign caller
-    # silently swap a pinned panel's body — the JS replaces content in
+    # silently swap a pinned panel's body, since the JS replaces content in
     # place and never inspects the pin class. Splitting by concern keeps
     # pin semantics intuitive without multi-pin machinery on the JS side.
-    blockr.ui::sidebar_ui("actions_sidebar", mode = "push", side = "right"),
-    blockr.ui::sidebar_ui("settings_sidebar", mode = "overlay", side = "right")
+    blockr.ui::sidebar_ui(
+      NS(id, "actions_sidebar"),
+      mode = "push",
+      side = "right"
+    ),
+    blockr.ui::sidebar_ui(
+      NS(id, "settings_sidebar"),
+      ui = settings_body(id, x, options = options),
+      title = "Board options",
+      mode = "overlay",
+      side = "right"
+    )
   )
 }
 
@@ -104,7 +128,7 @@ dock_outputs_ui <- function(id, views) {
 #' `board_server_callback()` → `settings_observer()`) wins. When the
 #' caller passed nothing, falls back to `blockr.core::blockr_app_options(x)`
 #' so the accordion still includes options contributed by blocks on the
-#' board and by registered block constructors — the same set `serve()`
+#' board and by registered block constructors, the same set `serve()`
 #' would have computed on the default path.
 #'
 #' @param id Board module id.

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -86,15 +86,20 @@ dock_outputs_ui <- function(id, views) {
 #' `board_server_callback()` when the user clicks the navbar gear, and
 #' passed to `blockr.ui::show_sidebar()`.
 #'
-#' Uses `blockr.core::blockr_app_options(x)` (rather than `board_options(x)`)
-#' so the accordion includes options contributed by blocks on the board and
-#' by registered block constructors — same set `serve()` passes to the
-#' top-level `board_ui()` call.
+#' Caller-supplied `options` (threaded down from `serve(board, options =
+#' custom_options(...))` via `blockr_app_server.dock_board()` →
+#' `board_server_callback()` → `settings_observer()`) wins. When the
+#' caller passed nothing, falls back to `blockr.core::blockr_app_options(x)`
+#' so the accordion still includes options contributed by blocks on the
+#' board and by registered block constructors — the same set `serve()`
+#' would have computed on the default path.
 #'
 #' @param id Board module id.
 #' @param x Current board (`board$board`).
 #' @param plugins Board plugins.
 #' @param options Augmented board options (board + block contributions).
+#'   `NULL` means "no caller override"; the default is recomputed via
+#'   `blockr.core::blockr_app_options(x)`.
 #' @noRd
 settings_body <- function(
   id,

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -13,6 +13,11 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
 
   args <- list(...)
 
+  # `options` is part of blockr.core's `blockr_app_ui` contract but the dock
+  # UI no longer renders the options accordion at UI-build time — the
+  # settings sidebar is rendered lazily server-side, see
+  # `blockr_app_server.dock_board()` and `settings_observer()`.
+
   do.call(
     page_fillable,
     c(
@@ -33,7 +38,7 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
           pulse_height = "5px"
         ),
         shinyjs::useShinyjs(),
-        board_ui(id, x, plugins, options)
+        board_ui(id, x, plugins)
       ),
       unname(args)
     )
@@ -42,6 +47,13 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
 
 #' @export
 blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
+  # `options` is consumed by `blockr.core::board_server()` for its own
+  # `board_options_to_userdata` wiring and is NOT forwarded into the
+  # `callbacks = ` list. To keep `serve(board, options = custom_options(...))`
+  # working in the settings sidebar (#TBD), re-pass the user-supplied
+  # options as a renamed extra dot (`app_options = options`) so it lands
+  # in `board_server_callback`'s `...` and can be threaded into
+  # `settings_observer()` / `settings_body()`.
   board_server(id, x, plugins, options, callbacks = board_server_callback,
-               callback_location = "start", ...)
+               callback_location = "start", app_options = options, ...)
 }

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -13,10 +13,9 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
 
   args <- list(...)
 
-  # `options` is part of blockr.core's `blockr_app_ui` contract but the dock
-  # UI no longer renders the options accordion at UI-build time — the
-  # settings sidebar is rendered lazily server-side, see
-  # `blockr_app_server.dock_board()` and `settings_observer()`.
+  # `options` is forwarded to `board_ui()` so the settings sidebar's
+  # pre-rendered body reflects `serve(board, options = custom_options(...))`
+  # overrides at page-build time.
 
   do.call(
     page_fillable,
@@ -38,7 +37,7 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
           pulse_height = "5px"
         ),
         shinyjs::useShinyjs(),
-        board_ui(id, x, plugins)
+        board_ui(id, x, plugins, options = options)
       ),
       unname(args)
     )
@@ -47,13 +46,6 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
 
 #' @export
 blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
-  # `options` is consumed by `blockr.core::board_server()` for its own
-  # `board_options_to_userdata` wiring and is NOT forwarded into the
-  # `callbacks = ` list. To keep `serve(board, options = custom_options(...))`
-  # working in the settings sidebar (#TBD), re-pass the user-supplied
-  # options as a renamed extra dot (`app_options = options`) so it lands
-  # in `board_server_callback`'s `...` and can be threaded into
-  # `settings_observer()` / `settings_body()`.
   board_server(id, x, plugins, options, callbacks = board_server_callback,
-               callback_location = "start", app_options = options, ...)
+               callback_location = "start", ...)
 }

--- a/tests/testthat/test-action-block.R
+++ b/tests/testthat/test-action-block.R
@@ -150,6 +150,56 @@ test_that("append block action", {
   )
 })
 
+test_that("add block action chains via keep_or_hide_sidebar on confirm", {
+  # Successful confirm should fire `keep_or_hide_sidebar()` (the chain
+  # branch) — the pinned-vs-unpinned decision lives inside blockr.ui, so
+  # we just assert the call shape from the action handler.
+
+  keep_calls <- list()
+
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(id, ...) {
+      keep_calls[[length(keep_calls) + 1L]] <<- list(id = id, args = list(...))
+      invisible(NULL)
+    },
+    hide_sidebar = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  r_board <- reactiveValues(board = new_board(), board_id = "my_board")
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_block_action(
+          trigger = reactive(TRUE),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      session$setInputs(add_block_selection = "dataset_block")
+
+      session$setInputs(
+        add_block_confirm = 1L,
+        add_block_id = "x",
+        add_block_name = "X block"
+      )
+
+      expect_length(r_update(), 1L)
+      expect_length(keep_calls, 1L)
+      # `sidebar_id` is composed from `board$board_id` inside the action.
+      expect_identical(keep_calls[[1L]]$id, "my_board-actions_sidebar")
+      expect_identical(keep_calls[[1L]]$args$title, "Add new block")
+    }
+  )
+})
+
 test_that("remove block action", {
 
   r_board <- reactiveValues(

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -91,6 +91,193 @@ test_that("add link action", {
   )
 })
 
+test_that("add link action warns and skips sidebar when no inputs available", {
+  # Board with a single block: any target with free inputs would have to
+  # be a *different* block, so `link_sidebar_body()` finds none and
+  # returns NULL. The action handler should `notify()` and NOT open the
+  # sidebar.
+
+  notify_calls <- list()
+  show_calls <- list()
+
+  local_mocked_bindings(
+    notify = function(message, ...) {
+      notify_calls[[length(notify_calls) + 1L]] <<- message
+      invisible(NULL)
+    },
+    .package = "blockr.dock"
+  )
+  local_mocked_bindings(
+    show_sidebar = function(id, ...) {
+      show_calls[[length(show_calls) + 1L]] <<- list(id = id, args = list(...))
+      invisible(NULL)
+    },
+    .package = "blockr.ui"
+  )
+
+  r_board <- reactiveValues(
+    board = new_board(c(a = new_dataset_block("iris"))),
+    board_id = "my_board"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_link_action(
+          trigger = reactive("a"),
+          board = r_board,
+          update = reactiveVal(list())
+        )
+      )
+    },
+    {
+      session$flushReact()
+      expect_length(show_calls, 0L)
+      expect_length(notify_calls, 1L)
+      expect_match(notify_calls[[1L]], "No inputs are currently available")
+    }
+  )
+})
+
+test_that("add link action chains via keep_or_hide when inputs remain", {
+  # Two unconnected blocks + a third with a free input: confirming a link
+  # from `a` to `b` leaves `c` available, so the post-confirm rebuild
+  # should call `keep_or_hide_sidebar()` (chain branch) and NOT
+  # `hide_sidebar()`.
+
+  keep_calls <- list()
+  hide_calls <- list()
+
+  local_mocked_bindings(
+    keep_or_hide_sidebar = function(id, ...) {
+      keep_calls[[length(keep_calls) + 1L]] <<- list(id = id, args = list(...))
+      invisible(NULL)
+    },
+    hide_sidebar = function(id, ...) {
+      hide_calls[[length(hide_calls) + 1L]] <<- list(id = id)
+      invisible(NULL)
+    },
+    show_sidebar = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  r_board <- reactiveValues(
+    board = new_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_head_block(),
+        c = new_head_block()
+      )
+    ),
+    board_id = "my_board"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_link_action(
+          trigger = reactive("a"),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      session$setInputs(create_link = "b")
+      session$setInputs(
+        add_link_confirm = 1L,
+        add_link_id = "ab",
+        add_link_input = "data"
+      )
+      # Drive the reactive flush so the deferred `session$onFlushed()`
+      # callback installed by the confirm handler fires.
+      session$flushReact()
+
+      expect_length(r_update(), 1L)
+      expect_length(keep_calls, 1L)
+      expect_identical(keep_calls[[1L]]$id, "my_board-actions_sidebar")
+      expect_length(hide_calls, 0L)
+    }
+  )
+})
+
+test_that("add link action hides sidebar when no inputs remain post-confirm", {
+  # Only one target block with a single available input: after the link
+  # consumes it, the post-flush check finds nothing left, so the action
+  # should `hide_sidebar()` rather than `keep_or_hide_sidebar()`.
+
+  keep_calls <- list()
+  hide_calls <- list()
+
+  local_mocked_bindings(
+    keep_or_hide_sidebar = function(id, ...) {
+      keep_calls[[length(keep_calls) + 1L]] <<- list(id = id)
+      invisible(NULL)
+    },
+    hide_sidebar = function(id, ...) {
+      hide_calls[[length(hide_calls) + 1L]] <<- list(id = id)
+      invisible(NULL)
+    },
+    show_sidebar = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), b = new_head_block())
+    ),
+    board_id = "my_board"
+  )
+  r_update <- reactiveVal(list())
+
+  # Wire `update()` to reflect into r_board so the post-flush
+  # `link_sidebar_body()` actually sees the just-added link.
+  testServer(
+    function(id, ...) {
+      observeEvent(
+        r_update(),
+        {
+          upd <- r_update()
+          if (length(upd$links$add)) {
+            board_links(r_board$board) <- c(
+              board_links(r_board$board),
+              upd$links$add
+            )
+          }
+        }
+      )
+      moduleServer(
+        id,
+        add_link_action(
+          trigger = reactive("a"),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      session$setInputs(create_link = "b")
+      session$setInputs(
+        add_link_confirm = 1L,
+        add_link_id = "ab",
+        add_link_input = "data"
+      )
+      session$flushReact()
+
+      expect_length(hide_calls, 1L)
+      expect_identical(hide_calls[[1L]]$id, "my_board-actions_sidebar")
+      expect_length(keep_calls, 0L)
+    }
+  )
+})
+
 test_that("remove link action", {
 
   r_board <- reactiveValues(

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -1,3 +1,56 @@
+test_that("add stack action chains via keep_or_hide_sidebar on confirm", {
+  keep_calls <- list()
+
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(id, ...) {
+      keep_calls[[length(keep_calls) + 1L]] <<- list(id = id, args = list(...))
+      invisible(NULL)
+    },
+    hide_sidebar = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  r_board <- reactiveValues(
+    board = new_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_head_block()
+      )
+    ),
+    board_id = "my_board"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_stack_action(
+          trigger = reactive(TRUE),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      session$setInputs(
+        stack_confirm = 1L,
+        stack_id = "s1",
+        stack_name = "Stack 1",
+        stack_block_selection = c("a", "b"),
+        stack_color = "#ff0000"
+      )
+
+      expect_length(r_update(), 1L)
+      expect_length(keep_calls, 1L)
+      expect_identical(keep_calls[[1L]]$id, "my_board-actions_sidebar")
+      expect_identical(keep_calls[[1L]]$args$title, "Create new stack")
+    }
+  )
+})
+
 test_that("add stack action", {
 
   r_board <- reactiveValues(

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -6,5 +6,5 @@ test_that("dummy board ui test", {
   )
 
   expect_s3_class(ui, "shiny.tag.list")
-  expect_length(ui, 7L)
+  expect_length(ui, 8L)
 })

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -8,3 +8,87 @@ test_that("dummy board ui test", {
   expect_s3_class(ui, "shiny.tag.list")
   expect_length(ui, 8L)
 })
+
+# Settings sidebar is mounted with pre-rendered content + a JS-trigger gear
+# button (PR #2 amendment: static-content sidebar). The chain that used to
+# live server-side (settings_observer → show_sidebar → settings_body) is
+# replaced by markup, so the assertions move to the rendered tag tree.
+
+test_that("settings sidebar mount is pre-rendered with the options accordion", {
+  ui <- board_ui(
+    "test",
+    new_dock_board(blocks = c(a = new_dataset_block()))
+  )
+  html <- as.character(ui)
+
+  # The settings sidebar exists with the namespaced DOM id and overlay
+  # mode. The id is `NS("test", "settings_sidebar")` so two boards on
+  # the same page don't collide.
+  expect_match(html, 'id="test-settings_sidebar"', fixed = TRUE)
+  expect_match(html, 'data-mode="overlay"', fixed = TRUE)
+
+  # Its body slot carries the rendered options accordion. We probe by
+  # looking for the inputId of the default `board_name` option, which is
+  # always present (contributed by blockr.core for any board).
+  expect_match(html, 'id="test-board_name"', fixed = TRUE)
+
+  # And the panel's title slot is populated at UI-build time.
+  expect_match(
+    html,
+    '<h2 class="blockr-sidebar-title">Board options</h2>',
+    fixed = TRUE
+  )
+})
+
+test_that("gear button targets the settings sidebar via data-attribute", {
+  ui <- board_ui(
+    "test",
+    new_dock_board(blocks = c(a = new_dataset_block()))
+  )
+  html <- as.character(ui)
+
+  # The gear opens the settings sidebar purely client-side; no Shiny input
+  # is wired, so no `id="test-settings_btn"` should appear.
+  expect_match(
+    html,
+    'data-blockr-sidebar-target="test-settings_sidebar"',
+    fixed = TRUE
+  )
+  expect_false(grepl('id="test-settings_btn"', html, fixed = TRUE))
+})
+
+test_that("caller-supplied `options` flows into the rendered settings body", {
+  # Simulate `serve(board, options = custom_options(...))`: replace the
+  # default `board_options` with a single synthetic option carrying a
+  # unique id we can grep for.
+  marker_id <- "marker_opt_for_test"
+  custom <- blockr.core::as_board_options(
+    list(
+      blockr.core::new_board_option(
+        id = marker_id,
+        default = "hi",
+        ui = function(id) {
+          shiny::textInput(NS(id, marker_id), label = "Marker")
+        },
+        category = "custom",
+        # `ctor` defaults to `sys.parent()`, which tries to resolve the
+        # package of the calling closure. In a test scope that closure has
+        # no namespace, so pass an explicit `pkg::fn` identifier instead.
+        ctor = "blockr.core::new_board_option"
+      )
+    )
+  )
+
+  ui <- board_ui(
+    "test",
+    new_dock_board(blocks = c(a = new_dataset_block())),
+    options = custom
+  )
+  html <- as.character(ui)
+
+  # The custom option appears.
+  expect_match(html, sprintf('id="test-%s"', marker_id), fixed = TRUE)
+  # The default options that would have been recomputed are NOT
+  # present — the override fully replaces the set.
+  expect_false(grepl('id="test-board_name"', html, fixed = TRUE))
+})


### PR DESCRIPTION
## Summary

Adopts the sidebar primitive from \`blockr.ui\` (PR \`BristolMyersSquibb/blockr.ui#2\`) for board-mutation flows and the navbar settings gear.

- Six action handlers (\`add_block\`, \`append_block\`, \`prepend_block\`, \`add_link\`, \`add_stack\`, \`edit_stack\`) drop \`showModal\`/\`removeModal\` and now use \`blockr.ui::show_sidebar()\` + \`blockr.ui::keep_or_hide_sidebar()\`. On confirm, a pinned panel re-renders a fresh form for chaining; an unpinned panel closes — same code path for all six.
- Modal builders (\`block_modal\`, \`link_modal\`, \`stack_modal\`) become \`*_sidebar_body()\` (return plain \`tagList()\`); file renamed \`R/action-modal.R\` → \`R/action-sidebar.R\`.
- The navbar gear becomes a regular \`actionButton(NS(id, "settings_btn"))\`; the Bootstrap \`options_offcanvas\` markup is removed.
- A new \`settings_observer()\` opens the sidebar with \`settings_body(id, board$board)\` on click. \`settings_body()\` uses \`blockr.core::blockr_app_options(x)\` (not bare \`board_options(x)\`) so the accordion includes block-contributed sections — same set \`serve()\` passes to \`board_ui()\`.
- \`board_ui.dock_board()\` mounts \`blockr.ui::sidebar_ui("main_sidebar")\` at top level (unwrapped by \`NS()\`); deep action handlers reach it via \`rootScope\` walking inside \`show_sidebar()\` — no session-proxy plumbing.

## Test plan

- [x] \`devtools::test()\` — 372 / 372 pass
- [x] \`devtools::check()\` — 0 errors / 0 warnings / 1 NOTE (timestamp only)
- [x] Headless chromote run against \`inst/examples/single-page\`:
  - pin / unpin / Esc / outside-click / X-button all behave per the sidebar spec
  - settings sidebar matches \`main\`'s offcanvas: two accordion sections (\`Board options\`, \`Table options\`) with \`board_name\` + \`n_rows\` + \`page_size\` + \`filter_rows\`
  - confirm while pinned re-renders a fresh form
- [ ] Manual smoke test of the \`dock\` + \`dag\` example (right-click append node, "+" toolbar button, settings gear)

## Sequencing

\`Remotes: BristolMyersSquibb/blockr.ui@phase1-sidebar-primitive\` is pinned to that PR's branch until it merges. Once \`blockr.ui#2\` lands, this PR's \`Remotes:\` line drops the \`@phase1-sidebar-primitive\` suffix.

## Out of scope

The block-browser UX (collapsible cards by category) is a separate follow-up; this PR ships the existing modal bodies into the sidebar unchanged so the diff stays mechanical.