### PR TITLE
Handle delta-shape blocks$mod in dock observers and edit plugin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dock
 Title: A Docking Layout Manager for 'blockr'
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -467,13 +467,17 @@ manage_dock <- function(
         blks <- update()$blocks$mod
 
         for (blk_id in names(blks)) {
-          blk <- blks[[blk_id]]
-          new_name <- block_name(blk)
+
+          if (!"block_name" %in% names(blks[[blk_id]])) {
+            next
+          }
+
+          new_name <- block_name(board_blocks(board$board)[[blk_id]])
           blk_panel_id <- as_block_panel_id(blk_id)
 
           old_title <- get_dock_panel(blk_panel_id, dock)$title
 
-          if (new_name == old_title) {
+          if (identical(new_name, old_title)) {
             next
           }
 

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -470,19 +470,19 @@ edit_block_server <- function(callbacks = list()) {
               block_id %in% board_block_ids(board$board)
             )
 
-            blk <- board_blocks(board$board)[[block_id]]
-            cur <- block_name(blk)
+            cur <- block_name(board_blocks(board$board)[[block_id]])
 
             if (identical(cur, input$block_name_in)) {
               return()
             }
 
-            block_name(blk) <- input$block_name_in
-
             update(
               list(
                 blocks = list(
-                  mod = as_blocks(set_names(list(blk), block_id))
+                  mod = set_names(
+                    list(list(block_name = input$block_name_in)),
+                    block_id
+                  )
                 )
               )
             )
@@ -496,13 +496,14 @@ edit_block_server <- function(callbacks = list()) {
 
             continue <- "blocks" %in% names(upd) &&
               "mod" %in% names(upd$blocks) &&
-              block_id %in% names(upd$blocks$mod)
+              block_id %in% names(upd$blocks$mod) &&
+              "block_name" %in% names(upd$blocks$mod[[block_id]])
 
             if (!continue) {
               return()
             }
 
-            new <- block_name(upd$blocks$mod[[block_id]])
+            new <- block_name(board_blocks(board$board)[[block_id]])
 
             if (identical(new, input$block_name_in)) {
               return()

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -179,18 +179,37 @@ test_that("board server", {
 
   ms3$flushReact()
 
-  with_mock_context(ms3, {
-    upd(
-      list(
-        blocks = list(
-          mod = blocks(a = new_dataset_block(block_name = "Test block"))
-        )
-      )
-    )
-  })
+  panel_lookups <- 0L
 
   with_mocked_bindings(
-    ms3$flushReact(),
-    get_dock_panel = function(...) list(title = "Old title")
+    {
+      with_mock_context(ms3, {
+        upd(
+          list(
+            blocks = list(
+              mod = list(a = list(block_name = "Test block"))
+            )
+          )
+        )
+      })
+      ms3$flushReact()
+
+      with_mock_context(ms3, {
+        upd(
+          list(
+            blocks = list(
+              mod = list(a = list(dataset = "iris"))
+            )
+          )
+        )
+      })
+      ms3$flushReact()
+    },
+    get_dock_panel = function(...) {
+      panel_lookups <<- panel_lookups + 1L
+      list(title = "Old title")
+    }
   )
+
+  expect_identical(panel_lookups, 1L)
 })

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -20,11 +20,11 @@ test_that("edit block server", {
 
       expect_length(upd$blocks$mod, 1L)
       expect_named(upd$blocks$mod, "a")
-      expect_s3_class(upd$blocks$mod, "blocks")
+      expect_type(upd$blocks$mod, "list")
 
       expect_identical(
-        block_name(upd$blocks$mod[[1L]]),
-        "Test block name"
+        upd$blocks$mod$a,
+        list(block_name = "Test block name")
       )
     },
     args = list(


### PR DESCRIPTION
## Summary

- The dock panel-title observer in `R/board-server.R` and the
  `block_name_in` observer pair in `R/plugin-block.R` both treated
  `update()$blocks$mod` entries as full blocks. Post-blockr.core#176 they
  are deltas (named lists of fields), so the observers errored at
  `is_block(x) is not TRUE` — this blocked blockr.assistant#11's
  `modify_block` end-to-end on a `dock_board`.
- Read `block_name` from the applied state (`board_blocks(board$board)`)
  rather than the delta payload, and short-circuit mods whose delta
  does not touch `block_name`.
- The edit plugin now emits the delta shape directly
  (`list(<id> = list(block_name = ...))`) instead of wrapping a mutated
  block in `as_blocks()`, matching the ctrl plugin in blockr.core PR #176.

Fixes #131