### PR TITLE
ci: pass secrets explicitly instead of inherit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ jobs:
     with:
       revdep-packages: |
         BristolMyersSquibb/blockr.dag
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
     permissions:
       contents: write

--- a/.github/workflows/deps-rerun.yaml
+++ b/.github/workflows/deps-rerun.yaml
@@ -8,4 +8,5 @@ name: deps-rerun
 jobs:
   rerun:
     uses: cynkra/blockr.ci/.github/workflows/deps-rerun.yaml@main
-    secrets: inherit
+    secrets:
+      BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}


### PR DESCRIPTION
## Summary

- Switches `secrets: inherit` to explicit `secrets:` blocks in `ci.yaml` (`CODECOV_TOKEN`, `BLOCKR_PAT`) and `deps-rerun.yaml` (`BLOCKR_PAT`), picking up the fix landed in cynkra/blockr.ci#11.

## Why

`secrets: inherit` silently drops cross-org-inherited values when calling `cynkra/blockr.ci`'s reusable workflows. `CODECOV_TOKEN` arrives blank in the coverage step, causing tokenless Codecov uploads which are rate-limited (intermittent 429s). `BLOCKR_PAT` arrives blank too but the failure is invisible — the YAML falls back to `github.token`, which is always set.

The reusable workflow now declares its secrets explicitly (cynkra/blockr.ci#11), so consumers can pass them by name. BristolMyersSquibb/blockr.assistant#16 did this for `blockr.assistant` and confirmed coverage uploads work end-to-end.