### PR TITLE
Sync the view_nav switcher on lifecycle view removal

### DIFF
--- a/R/layouts-class.R
+++ b/R/layouts-class.R
@@ -19,8 +19,9 @@
 #'
 #' @return `is_dock_layouts()` returns a boolean.
 #'   `validate_dock_layouts()` returns its input and throws on error.
-#'   `active_view()` returns a string and `active_view<-()` returns
-#'   the modified `dock_layouts` (or `dock_board`) object invisibly.
+#'   `active_view()` returns the active view's name, or `NULL` when no
+#'   view is active, and `active_view<-()` returns the modified
+#'   `dock_layouts` (or `dock_board`) object invisibly.
 #'
 #' @examples
 #' brd <- new_dock_board(
@@ -138,7 +139,13 @@ active_view <- function(x) {
 
 #' @export
 active_view.dock_layouts <- function(x) {
+
   idx <- which(lgl_ply(x, is_active_view))[1L]
+
+  if (is.na(idx)) {
+    return(NULL)
+  }
+
   names(x)[idx]
 }
 
@@ -218,6 +225,10 @@ as_dock_layouts.dock_layout <- function(x, ...) {
 
 is_active_view <- function(x) {
   is_dock_layout(x) && isTRUE(attr(x, "active"))
+}
+
+any_active_view <- function(x) {
+  any(lgl_ply(x, is_active_view))
 }
 
 set_active_view <- function(x, active = TRUE) {

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -323,7 +323,7 @@ apply_views_rm <- function(rm_names, board, dock_mgr = NULL, session = NULL) {
     class = "dock_layouts"
   )
 
-  if (length(layouts) && is.null(active_view(layouts))) {
+  if (length(layouts) && !any_active_view(layouts)) {
     layouts[[1L]] <- set_active_view(layouts[[1L]])
   }
 
@@ -361,7 +361,7 @@ apply_views_rm <- function(rm_names, board, dock_mgr = NULL, session = NULL) {
     state[[v]] <- NULL
   }
 
-  if (length(state) && is.null(active_view(state))) {
+  if (length(state) && !any_active_view(state)) {
     active_view(state) <- names(state)[[1L]]
   }
 
@@ -372,6 +372,14 @@ apply_views_rm <- function(rm_names, board, dock_mgr = NULL, session = NULL) {
     new_active <- active_view(state)
     update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[new_active]])
     dock_mgr$current_active(new_active)
+  }
+
+  for (v in rm_names) {
+    session$sendInputMessage("view_nav", list(remove = v))
+  }
+
+  if (length(state)) {
+    session$sendInputMessage("view_nav", list(value = active_view(state)))
   }
 
   board

--- a/man/view.Rd
+++ b/man/view.Rd
@@ -37,8 +37,9 @@ as_dock_layouts(x, ...)
 \value{
 \code{is_dock_layouts()} returns a boolean.
 \code{validate_dock_layouts()} returns its input and throws on error.
-\code{active_view()} returns a string and \verb{active_view<-()} returns
-the modified \code{dock_layouts} (or \code{dock_board}) object invisibly.
+\code{active_view()} returns the active view's name, or \code{NULL} when no
+view is active, and \verb{active_view<-()} returns the modified
+\code{dock_layouts} (or \code{dock_board}) object invisibly.
 }
 \description{
 A \code{dock_board} always holds a \code{dock_layouts} object (multi-view tabs).

--- a/tests/testthat/test-layouts-class.R
+++ b/tests/testthat/test-layouts-class.R
@@ -91,6 +91,20 @@ test_that("active_view get/set on a dock_board", {
   )
 })
 
+test_that("active_view returns NULL when no view is active", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(First = list("a"), Second = list("b"))
+  )
+
+  views <- board_layouts(brd)
+  views[["First"]] <- NULL
+
+  expect_false(any_active_view(views))
+  expect_null(active_view(views))
+})
+
 test_that("rejects invalid layout shapes at the new_dock_board boundary", {
 
   expect_error(

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -431,3 +431,57 @@ test_that("blocks$rm augment carries through to apply for view cleanup", {
     0L
   )
 })
+
+test_that("apply_views_rm syncs the view_nav switcher on lifecycle removal", {
+
+  run_rm <- function(rm_names, active) {
+
+    brd <- new_dock_board(
+      blocks = c(a = new_dataset_block(), b = new_head_block()),
+      layouts = list(A = list("a"), B = list("b"), C = list("a"))
+    )
+
+    sent <- list()
+    session <- list(
+      ns = identity,
+      sendInputMessage = function(input_id, message) {
+        sent[[length(sent) + 1L]] <<- message
+        invisible()
+      }
+    )
+
+    dock_mgr <- new_dock_manager()
+    dock_mgr$current_active <- reactiveVal(active)
+
+    state <- dock_layouts(
+      A = new_dock_layout(),
+      B = new_dock_layout(),
+      C = new_dock_layout()
+    )
+    active_view(state) <- active
+    dock_mgr$vs <- reactiveValues(state = state)
+
+    isolate(apply_views_rm(rm_names, brd, dock_mgr, session))
+
+    sent
+  }
+
+  non_active <- run_rm("B", active = "A")
+  expect_true(any(lgl_ply(non_active, function(m) identical(m$remove, "B"))))
+  expect_true(any(lgl_ply(non_active, function(m) identical(m$value, "A"))))
+
+  was_active <- run_rm("A", active = "A")
+  expect_true(any(lgl_ply(was_active, function(m) identical(m$remove, "A"))))
+  expect_true(any(lgl_ply(was_active, function(m) identical(m$value, "B"))))
+})
+
+test_that("apply_views_rm skips nav sync on the headless path", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(A = list("a"), B = list("b"))
+  )
+
+  expect_silent(out <- apply_views_rm("B", brd))
+  expect_named(board_layouts(out), "A")
+})


### PR DESCRIPTION
## Summary

- `apply_views_rm()` tore down a removed view's dock and dropped it from state but never sent the `view_nav` binding a `remove`, so an orphaned tab lingered and crashed `switch_view_observer` on click (`View <name> does not exist.`). It now mirrors `apply_views_add()` and the manual remove path: one `list(remove = v)` per removed view plus a `list(value = …)` to resync the active tab, behind the existing headless early return. (`view-binding.js` already handles both `remove` and `value`, so no client change.)
- Fixed the active-view reseat in the same function: `active_view()` reports "no active view" as `NA`, not `NULL`, so the `is.null` guards never fired — removing the active view left it unreseated, which the active-dock update and the new value sync would then propagate. Both guards now check `is.na`.
- Added regression tests for the `view_nav` `remove`/`value` messages on non-active and active removal, plus the silent headless path.

Fixes #159