### PR TITLE
Extract grid_map_leaves primitive for layout tree transforms

### DIFF
--- a/R/layout-class.R
+++ b/R/layout-class.R
@@ -438,10 +438,8 @@ draw_panel_tree <- function(x) {
 }
 
 grid_panel_ids <- function(grid) {
-
-  views <- unlist(lst_xtr(grid_leaves(grid), "views"), use.names = FALSE)
-
-  if (is.null(views)) character() else views
+  views <- unlst(lst_xtr(grid_leaves(grid), "views"), recursive = TRUE)
+  coal(views, character())
 }
 
 #' @rdname layout-json

--- a/R/layout-class.R
+++ b/R/layout-class.R
@@ -438,8 +438,7 @@ draw_panel_tree <- function(x) {
 }
 
 grid_panel_ids <- function(grid) {
-  views <- unlst(lst_xtr(grid_leaves(grid), "views"), recursive = TRUE)
-  coal(views, character())
+  chr_ply(unlst(lst_xtr(grid_leaves(grid), "views")), identity)
 }
 
 #' @rdname layout-json

--- a/R/layout-class.R
+++ b/R/layout-class.R
@@ -439,23 +439,9 @@ draw_panel_tree <- function(x) {
 
 grid_panel_ids <- function(grid) {
 
-  if (is.null(grid) || !length(grid[["root"]])) {
-    return(character())
-  }
+  views <- unlist(lst_xtr(grid_leaves(grid), "views"), use.names = FALSE)
 
-  walk <- function(node) {
-    if (is.null(node) || !length(node)) {
-      return(NULL)
-    }
-    if (identical(node[["type"]], "leaf")) {
-      return(unlist(node[["data"]][["views"]]))
-    }
-    unlist(lapply(node[["data"]], walk))
-  }
-
-  res <- walk(grid[["root"]])
-
-  if (is.null(res)) character() else res
+  if (is.null(views)) character() else views
 }
 
 #' @rdname layout-json
@@ -514,24 +500,20 @@ resolve_dock_layout <- function(blocks = list(), extensions = list(),
 
 rewrite_grid_leaves <- function(grid, id_map) {
 
-  walk <- function(node) {
-    if (is.null(node) || !length(node)) {
-      return(node)
-    }
-    if (identical(node[["type"]], "leaf")) {
-      views <- chr_ply(node[["data"]][["views"]], identity)
-      mapped <- chr_mply(coal, as.list(id_map)[views], views)
-      active_view <- node[["data"]][["activeView"]]
-      node[["data"]][["views"]] <- as.list(mapped)
-      node[["data"]][["activeView"]] <- coal(id_map[[active_view]], active_view)
-      return(node)
-    }
-    node[["data"]] <- lapply(node[["data"]], walk)
-    node
+  rename_leaf <- function(leaf) {
+
+    views <- chr_ply(leaf[["data"]][["views"]], identity)
+    active <- leaf[["data"]][["activeView"]]
+
+    leaf[["data"]][["views"]] <- as.list(
+      chr_mply(coal, as.list(id_map)[views], views)
+    )
+    leaf[["data"]][["activeView"]] <- coal(id_map[[active]], active)
+
+    leaf
   }
 
-  grid[["root"]] <- walk(grid[["root"]])
-  grid
+  grid_map_leaves(grid, rename_leaf)
 }
 
 create_layout_panel <- function(x) {

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -169,6 +169,9 @@ blockr_deser.dock_extensions <- function(x, data, ...) {
 # atomic-vector coercion `jsonlite::fromJSON(simplifyVector = TRUE)`
 # applies to all-scalar arrays.
 
+# A whole-tree fold rather than a leaf map: branches become wire
+# `children`/`sizes` and leaves collapse to strings or `panels`, so the
+# leaf-only grid_map_leaves() can't express it — it keeps its own walk.
 grid_to_spec <- function(grid) {
 
   walk <- function(node) {
@@ -356,6 +359,37 @@ grid_leaves <- function(grid) {
 
   walk(grid[["root"]])
   leaves
+}
+
+# Map counterpart to grid_leaves(): rebuild the grid, applying `fn` to
+# each leaf node. `fn` returns a replacement leaf (to transform it) or
+# NULL (to prune it); a branch whose children all prune away collapses to
+# NULL too, so empty leaves and branches never survive. Returns the grid
+# with its root rebuilt (a NULL root when everything prunes).
+grid_map_leaves <- function(grid, fn) {
+
+  walk <- function(node) {
+
+    if (is.null(node) || !length(node)) {
+      return(NULL)
+    }
+
+    if (identical(node[["type"]], "leaf")) {
+      return(fn(node))
+    }
+
+    children <- Filter(Negate(is.null), lapply(node[["data"]], walk))
+
+    if (!length(children)) {
+      return(NULL)
+    }
+
+    node[["data"]] <- children
+    node
+  }
+
+  grid[["root"]] <- walk(grid[["root"]])
+  grid
 }
 
 # Serialize side: translate the focused group id to its open panel.

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -241,7 +241,7 @@ drop_panels_from_layout <- function(layout, panel_ids) {
 
   drop_from_leaf <- function(leaf) {
 
-    views <- unlist(leaf[["data"]][["views"]], use.names = FALSE)
+    views <- unlst(leaf[["data"]][["views"]])
     kept <- setdiff(views, panel_ids)
 
     if (!length(kept)) {

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -239,46 +239,29 @@ drop_panels_from_layout <- function(layout, panel_ids) {
     return(layout)
   }
 
-  walk <- function(node) {
+  drop_from_leaf <- function(leaf) {
 
-    if (is.null(node) || !length(node)) {
+    views <- unlist(leaf[["data"]][["views"]], use.names = FALSE)
+    kept <- setdiff(views, panel_ids)
+
+    if (!length(kept)) {
       return(NULL)
     }
 
-    if (identical(node[["type"]], "leaf")) {
+    leaf[["data"]][["views"]] <- as.list(kept)
 
-      views <- unlist(node[["data"]][["views"]], use.names = FALSE)
-      kept <- setdiff(views, panel_ids)
-
-      if (length(kept) == 0L) {
-        return(NULL)
-      }
-
-      node[["data"]][["views"]] <- as.list(kept)
-
-      av <- node[["data"]][["activeView"]]
-      if (is.null(av) || !av %in% kept) {
-        node[["data"]][["activeView"]] <- kept[[1L]]
-      }
-
-      return(node)
+    av <- leaf[["data"]][["activeView"]]
+    if (is.null(av) || !av %in% kept) {
+      leaf[["data"]][["activeView"]] <- kept[[1L]]
     }
 
-    children <- lapply(node[["data"]], walk)
-    children <- Filter(Negate(is.null), children)
-
-    if (length(children) == 0L) {
-      return(NULL)
-    }
-
-    node[["data"]] <- children
-    node
+    leaf
   }
 
   was_active <- is_active_view(layout)
 
   result <- layout
-  result[["grid"]][["root"]] <- walk(layout[["grid"]][["root"]])
+  result[["grid"]] <- grid_map_leaves(result[["grid"]], drop_from_leaf)
 
   if (!length(grid_panel_ids(result[["grid"]]))) {
     result[["activeGroup"]] <- NULL

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -137,6 +137,97 @@ test_that("spec_to_grid leaves branch children unnamed for char-vector input", {
   expect_identical(from_vector, from_list)
 })
 
+test_that("grid_map_leaves transforms leaves and keeps the tree shape", {
+
+  grid <- spec_to_grid(
+    list(
+      orientation = "horizontal",
+      children = list("a", list(children = list("b", "c")))
+    )
+  )
+
+  upcase_leaf <- function(leaf) {
+
+    views <- toupper(unlist(leaf[["data"]][["views"]]))
+    leaf[["data"]][["views"]] <- as.list(views)
+    leaf[["data"]][["activeView"]] <- toupper(leaf[["data"]][["activeView"]])
+
+    leaf
+  }
+
+  out <- grid_map_leaves(grid, upcase_leaf)
+
+  expect_identical(grid_panel_ids(out), c("A", "B", "C"))
+  expect_identical(out[["orientation"]], "HORIZONTAL")
+
+  inner <- out[["root"]][["data"]][[2L]]
+  expect_identical(inner[["type"]], "branch")
+  expect_length(inner[["data"]], 2L)
+})
+
+test_that("grid_map_leaves prunes a leaf on NULL and keeps its siblings", {
+
+  grid <- spec_to_grid(
+    list(
+      orientation = "horizontal",
+      children = list("a", list(children = list("b", "c")))
+    )
+  )
+
+  drop_b <- function(leaf) {
+    if (identical(unlist(leaf[["data"]][["views"]]), "b")) NULL else leaf
+  }
+
+  out <- grid_map_leaves(grid, drop_b)
+
+  expect_identical(grid_panel_ids(out), c("a", "c"))
+
+  inner <- out[["root"]][["data"]][[2L]]
+  expect_identical(inner[["type"]], "branch")
+  expect_length(inner[["data"]], 1L)
+})
+
+test_that("grid_map_leaves collapses a branch whose leaves all prune", {
+
+  grid <- spec_to_grid(
+    list(
+      orientation = "horizontal",
+      children = list("a", list(children = list("b", "c")))
+    )
+  )
+
+  drop_bc <- function(leaf) {
+    keep <- !any(unlist(leaf[["data"]][["views"]]) %in% c("b", "c"))
+    if (keep) leaf else NULL
+  }
+
+  out <- grid_map_leaves(grid, drop_bc)
+
+  expect_identical(grid_panel_ids(out), "a")
+  expect_length(out[["root"]][["data"]], 1L)
+  expect_identical(
+    out[["root"]][["data"]][[1L]][["data"]][["views"]][[1L]],
+    "a"
+  )
+})
+
+test_that("grid_map_leaves collapses to a NULL root when every leaf prunes", {
+
+  grid <- spec_to_grid(
+    list(
+      orientation = "horizontal",
+      children = list("a", list(children = list("b", "c")))
+    )
+  )
+
+  prune_all <- function(leaf) NULL
+
+  out <- grid_map_leaves(grid, prune_all)
+
+  expect_null(out[["root"]])
+  expect_identical(grid_panel_ids(out), character())
+})
+
 test_that("constructor and JSON paths yield identical specs", {
 
   ctor <- dock_layout("a", "b")

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -228,6 +228,15 @@ test_that("grid_map_leaves collapses to a NULL root when every leaf prunes", {
   expect_identical(grid_panel_ids(out), character())
 })
 
+test_that("grid_map_leaves is a no-op on an already-empty grid", {
+
+  grid <- list(root = NULL, orientation = "HORIZONTAL")
+  out <- grid_map_leaves(grid, identity)
+
+  expect_null(out[["root"]])
+  expect_identical(out[["orientation"]], "HORIZONTAL")
+})
+
 test_that("constructor and JSON paths yield identical specs", {
 
   ctor <- dock_layout("a", "b")

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -367,6 +367,17 @@ test_that("drop_panels_from_layout preserves remaining structure", {
   expect_length(layout_panel_ids(res_full), 0L)
 })
 
+test_that("drop_panels_from_layout resets the active tab when it is dropped", {
+
+  ly <- dock_layout(panels("a", "b", active = "b"))
+
+  res <- drop_panels_from_layout(ly, "b")
+  leaf <- res[["grid"]][["root"]][["data"]][[1L]][["data"]]
+
+  expect_identical(unlist(leaf[["views"]]), "a")
+  expect_identical(leaf[["activeView"]], "a")
+})
+
 test_that("empty views payload causes apply to be a no-op", {
 
   brd <- new_dock_board(


### PR DESCRIPTION
## Summary

- Add `grid_map_leaves(grid, fn)` — the map-side counterpart to the existing `grid_leaves()` fold. It rebuilds the grid, applies `fn` to each leaf, prunes leaves whose `fn` returns `NULL`, and collapses branches that empty out.
- Route `rewrite_grid_leaves()` and `drop_panels_from_layout()` through it, removing their two open-coded branch recursions; fold `grid_panel_ids()` onto `grid_leaves()` to mirror the fold side.
- **Left `grid_to_spec()` standalone** (the issue's "if it fits" walker): it folds the whole tree into a *different shape* — branches become wire `children`/`sizes`, leaves collapse to strings/`panels` — and carries a stricter node contract, so the leaf-only primitive can't express it. Unifying it would take a second general `grid_map(leaf_fn, branch_fn)` whose only non-trivial caller would be `grid_to_spec` itself. Happy to add that if you'd rather see all three consolidated.

Fixes #156