### PR TITLE
Route panel-ID stripping through as_obj_id() machinery

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -535,19 +535,19 @@ manage_dock <- function(
         }
 
         for (pid in input$add_dock_panel) {
-          if (grepl("^blk-", pid)) {
+          if (maybe_block_panel_id(pid)) {
             show_block_panel(
-              board_blocks(board$board)[sub("^blk-", "", pid)],
+              board_blocks(board$board)[as_obj_id(new_block_panel_id(pid))],
               add_panel = pos,
               proxy = dock
             )
 
             n_panels(n_panels() + 1L)
-          } else if (grepl("^ext-", pid)) {
+          } else if (maybe_ext_panel_id(pid)) {
             exts <- as.list(dock_extensions(board$board))
 
             show_ext_panel(
-              exts[[sub("^ext-", "", pid)]],
+              exts[[as_obj_id(new_ext_panel_id(pid))]],
               add_panel = pos,
               proxy = dock
             )
@@ -992,8 +992,8 @@ suggest_panels_to_add <- function(
   )
 
   options_data <- c(
-    build_block_options(board$board, blk_opts, prefix = "blk-"),
-    build_ext_options(board$board, ext_opts, prefix = "ext-")
+    build_block_options(board$board, blk_opts, value_fun = as_block_panel_id),
+    build_ext_options(board$board, ext_opts, value_fun = as_ext_panel_id)
   )
 
   if (length(options_data)) {
@@ -1080,12 +1080,15 @@ build_one_option <- function(value, label, id, package, icon, color) {
 #'
 #' @param board Board object.
 #' @param blk_ids Character vector of block IDs to include.
-#' @param prefix String prepended to each value (e.g. `"blk-"`).
+#' @param value_fun Coercion applied to each ID to form the option value;
+#'   defaults to `identity` (bare IDs, for a block-only selectize). The
+#'   panel picker passes `as_block_panel_id` so a single mixed selectize
+#'   can be disambiguated on read-back.
 #'
 #' @return A list of option lists suitable for `selectizeInput`.
 #'
 #' @noRd
-build_block_options <- function(board, blk_ids, prefix = "") {
+build_block_options <- function(board, blk_ids, value_fun = identity) {
   if (!length(blk_ids)) {
     return(list())
   }
@@ -1096,7 +1099,7 @@ build_block_options <- function(board, blk_ids, prefix = "") {
   lapply(seq_along(blk_ids), function(i) {
     id <- blk_ids[i]
     build_one_option(
-      value = paste0(prefix, id),
+      value = as.character(value_fun(id)),
       label = block_name(blks[[id]]),
       id = id,
       package = meta$package[i],
@@ -1110,12 +1113,15 @@ build_block_options <- function(board, blk_ids, prefix = "") {
 #'
 #' @param board Board object.
 #' @param ext_ids Character vector of extension IDs to include.
-#' @param prefix String prepended to each value (e.g. `"ext-"`).
+#' @param value_fun Coercion applied to each ID to form the option value;
+#'   defaults to `identity` (bare IDs, for an extension-only selectize). The
+#'   panel picker passes `as_ext_panel_id` so a single mixed selectize
+#'   can be disambiguated on read-back.
 #'
 #' @return A list of option lists suitable for `selectizeInput`.
 #'
 #' @noRd
-build_ext_options <- function(board, ext_ids, prefix = "") {
+build_ext_options <- function(board, ext_ids, value_fun = identity) {
   if (!length(ext_ids)) {
     return(list())
   }
@@ -1128,7 +1134,7 @@ build_ext_options <- function(board, ext_ids, prefix = "") {
     ext_pkg <- ctor_pkg(extension_ctor(ext))
 
     build_one_option(
-      value = paste0(prefix, ext_id),
+      value = as.character(value_fun(ext_id)),
       label = ext_name,
       id = ext_id,
       package = coal(ext_pkg, "local"),

--- a/R/dock-board.R
+++ b/R/dock-board.R
@@ -148,8 +148,8 @@ resolve_views <- function(specs, c_blks, c_exts) {
 panel_obj_ids <- function(ids) {
   is_blk <- maybe_block_panel_id(ids)
   is_ext <- maybe_ext_panel_id(ids)
-  ids[is_blk] <- sub("^block_panel-", "", ids[is_blk])
-  ids[is_ext] <- sub("^ext_panel-", "", ids[is_ext])
+  ids[is_blk] <- as_obj_id(new_block_panel_id(ids[is_blk]))
+  ids[is_ext] <- as_obj_id(new_ext_panel_id(ids[is_ext]))
   ids
 }
 

--- a/R/layout-class.R
+++ b/R/layout-class.R
@@ -578,8 +578,8 @@ dockview_payload <- function(layout, blocks = list(), extensions = list()) {
   blk_pids <- panel_ids[maybe_block_panel_id(panel_ids)]
   ext_pids <- panel_ids[maybe_ext_panel_id(panel_ids)]
 
-  blk_ids <- sub("^block_panel-", "", blk_pids)
-  ext_ids <- sub("^ext_panel-", "", ext_pids)
+  blk_ids <- as_obj_id(new_block_panel_id(blk_pids))
+  ext_ids <- as_obj_id(new_ext_panel_id(ext_pids))
 
   blk_panels <- lapply(split(blocks[blk_ids], seq_along(blk_ids)), block_panel)
   ext_panels <- lapply(ext_list[ext_ids], ext_panel)

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -113,7 +113,13 @@ test_that("board server", {
   do.call(
     ms$setInputs,
     set_names(
-      list(1L, c("blk-a", "ext-edit_board_extension")),
+      list(
+        1L,
+        c(
+          as_block_panel_id("a"),
+          as_ext_panel_id("edit_board_extension")
+        )
+      ),
       c(mod_input("confirm_add"), mod_input("add_dock_panel"))
     )
   )


### PR DESCRIPTION
## Summary

- `dockview_payload()` and `panel_obj_ids()` hand-stripped `block_panel-`/`ext_panel-` prefixes; both now route through `as_obj_id(new_*_panel_id())`. `panel_obj_ids()` keeps its lenient pass-through for non-panel IDs (kept local — it's the only caller, so no new vectorized `as_obj_id` variant was added).
- The "Add panel" picker ran a *separate, untyped* `blk-`/`ext-` scheme. Rather than build parallel typed classes, it now reuses the canonical panel-ID machinery: the builders take a `value_fun` (default `identity`) and the picker passes `as_block_panel_id`/`as_ext_panel_id`, while the consumer dispatches with `maybe_*_panel_id()` + `as_obj_id()`. The ad-hoc scheme is deleted.
- Net effect: the `block_panel-`/`ext_panel-` literals now live solely in the `utils-id.R` methods.
- Deferred per the issue: blockr.assistant's `strip_panel_prefix()` is the same anti-pattern across the package boundary. No new exported surface was needed here (`as_obj_id` is already exported), so that coordination can land separately.

Fixes #154