### PR TITLE
Reconcile views from the board; pure apply, no threaded handle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # blockr.dock (development version)
 
+* The dock manager is no longer threaded across the package boundary.
+  `apply_board_update.dock_board()` is now a pure reducer over
+  `board_layouts()`; the live view surgery (instantiate / tear down /
+  restore / rename / switch) runs in a single closure-resident reconcile
+  pass driven by the committed board, replacing the duplicated
+  delta-driven and UI-driven view CRUD. `new_dock_manager()` is now
+  per-session closure state instead of a handle returned from the board
+  callback and recovered through `dot_args`. Also makes
+  `augment_board_update.dock_board()` idempotent — a view id is minted
+  once rather than re-minted on every augment pass — fixing a view-add
+  loop (#164).
+
 * Views now carry a stable, immutable **id** decoupled from their
   editable display **name**, mirroring the id / name split used for
   blocks. `dock_layouts` (and the runtime `dock_mgr$docks` registry) are

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,17 @@
 # blockr.dock (development version)
 
-* The dock manager is no longer threaded across the package boundary.
-  `apply_board_update.dock_board()` is now a pure reducer over
-  `board_layouts()`; the live view surgery (instantiate / tear down /
-  restore / rename / switch) runs in a single closure-resident reconcile
-  pass driven by the committed board, replacing the duplicated
-  delta-driven and UI-driven view CRUD. `new_dock_manager()` is now
-  per-session closure state instead of a handle returned from the board
-  callback and recovered through `dot_args`. Also makes
-  `augment_board_update.dock_board()` idempotent — a view id is minted
-  once rather than re-minted on every augment pass — fixing a view-add
-  loop (#164).
+* The dock "manager" object is gone. `apply_board_update.dock_board()` is
+  now a pure reducer over `board_layouts()`; all live view surgery
+  (instantiate / tear down / restore / rename / switch) runs in a single
+  closure-resident reconcile pass driven by the committed board, replacing
+  the duplicated delta-driven and UI-driven view CRUD. View init is just the
+  empty-registry case of that pass (create every view, show the active one),
+  so there is no separate init path. The per-session dock state is ordinary
+  closure-private state passed explicitly, not a handle threaded back from
+  the board callback through `dot_args`. Also makes
+  `augment_board_update.dock_board()` idempotent — a view id is minted once
+  rather than re-minted on every augment pass — fixing a view-add loop
+  (#164).
 
 * Views now carry a stable, immutable **id** decoupled from their
   editable display **name**, mirroring the id / name split used for

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -50,10 +50,22 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   )
   dock_mgr$vs <- vs
 
-  switch_view_observer(vs, session, dock_mgr)
+  switch_view_observer(session, dock_mgr)
   add_view_observer(vs, session, dock_mgr, board, update)
   remove_view_observer(vs, session, dock_mgr)
   rename_view_observer(vs, session, dock_mgr)
+
+  # Make the live dock session match the committed board: a single
+  # closure-resident reconcile pass replaces the per-delta surgery that used
+  # to live in apply_board_update.dock_board, so that hook stays a pure
+  # reducer and dock state never crosses the package boundary. High priority
+  # so the DOM is current before other board observers react.
+  observeEvent(
+    board$board,
+    reconcile_views(board$board, dock_mgr, session),
+    ignoreInit = TRUE,
+    priority = 100
+  )
 
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
@@ -91,10 +103,15 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
     list(...)
   )
 
-  # Externally controllable extension state is written from the apply path
-  # (apply_board_update.dock_board), which reaches these live reactiveVals
-  # through dock_mgr.
   dock_mgr$ext_res <- ext_res
+
+  # Externally controllable extension state is applied here, in the closure
+  # that owns ext_res, rather than from the (now pure) apply hook. The update
+  # payload carries the mod directly; the reactiveVal writes are idempotent.
+  observeEvent(
+    update()$extensions$mod,
+    apply_extensions_mod(update()$extensions$mod, dock_mgr$ext_res)
+  )
 
   register_actions(actions, triggers, board, update, ext_res)
 
@@ -102,8 +119,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
     list(
       dock = dock,
       actions = triggers,
-      view_data = view_data,
-      dock_mgr = dock_mgr
+      view_data = view_data
     ),
     ext_res
   )
@@ -195,43 +211,23 @@ bare_view <- function(x) {
 
 #' Observe view tab switches.
 #'
-#' When the user selects a different tab via `input$view_nav` (carrying the
-#' target view id), hides block/ext UI for the old view, shows it for the
-#' new one, updates `vs$state`, and swaps `dock_mgr$active_dock` to point at
-#' the new view's dock.
+#' A tab click (`input$view_nav` carries the target view id) requests an
+#' active-view change through the update lifecycle; the reconcile pass does
+#' the DOM switch. Guarded so a no-op (e.g. the nav echoing a programmatic
+#' `value` set back) does not re-enter the lifecycle.
 #'
-#' @param vs Reactive view state (from `init_view_docks()`).
 #' @param session Shiny session.
 #' @param dock_mgr Dock manager.
 #'
 #' @noRd
-switch_view_observer <- function(vs, session, dock_mgr) {
-  input <- session$input
-
+switch_view_observer <- function(session, dock_mgr) {
   observeEvent(
-    input$view_nav,
+    session$input$view_nav,
     {
-      new_id <- input$view_nav
-      state <- vs$state
-      old_id <- active_view(state)
+      target <- session$input$view_nav
 
-      session$sendCustomMessage(
-        "switch-view",
-        list(
-          id = session$ns(
-            as_view_handle_id(dock_mgr$docks[[new_id]]$dock_id)
-          )
-        )
-      )
-
-      if (!identical(old_id, new_id)) {
-        hide_view_ui(old_id, dock_mgr$docks)
-        show_view_ui(new_id, dock_mgr$docks)
-
-        active_view(state) <- new_id
-        vs$state <- state
-        update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[new_id]])
-        dock_mgr$current_active(new_id)
+      if (!identical(target, isolate(dock_mgr$current_active()))) {
+        dock_mgr$update(list(views = list(active = target)))
       }
     },
     ignoreInit = TRUE
@@ -351,7 +347,7 @@ diff_dock_layouts <- function(current, new_layouts) {
 #'
 #' @noRd
 hide_view_ui <- function(view_id, docks) {
-  if (!exists(view_id, envir = docks, inherits = FALSE)) {
+  if (is.null(view_id) || !exists(view_id, envir = docks, inherits = FALSE)) {
     return()
   }
   proxy <- docks[[view_id]]$proxy
@@ -374,7 +370,7 @@ hide_view_ui <- function(view_id, docks) {
 #'
 #' @noRd
 show_view_ui <- function(view_id, docks) {
-  if (!exists(view_id, envir = docks, inherits = FALSE)) {
+  if (is.null(view_id) || !exists(view_id, envir = docks, inherits = FALSE)) {
     return()
   }
   proxy <- docks[[view_id]]$proxy
@@ -456,6 +452,90 @@ teardown_view <- function(v_id, session, docks) {
     session = session
   )
   rm(list = v_id, envir = docks)
+
+  invisible()
+}
+
+# Make the live dock session match the committed board's view set:
+# instantiate added views, tear down removed ones, restore views whose
+# layout changed, relabel renamed ones, and switch to the active view.
+# Driven by board$board so apply_board_update.dock_board stays a pure
+# reducer and dock state never crosses the package boundary. Idempotent — a
+# board already matching the live state produces no surgery — so it composes
+# with the live-sync (DOM -> board) path without ping-ponging.
+reconcile_views <- function(board, dock_mgr, session) {
+
+  layouts <- board_layouts(board)
+  want <- names(layouts)
+  state <- isolate(dock_mgr$vs$state)
+  have <- names(state)
+
+  for (v in setdiff(want, have)) {
+
+    instantiate_view(
+      v,
+      layouts[[v]],
+      dock_mgr$board_rv,
+      dock_mgr$update,
+      dock_mgr$triggers,
+      session,
+      dock_mgr$docks,
+      current_active = dock_mgr$current_active,
+      blocks = board_blocks(board),
+      extensions = dock_extensions(board)
+    )
+
+    session$sendInputMessage(
+      "view_nav",
+      list(add = list(id = v, name = view_name(layouts[[v]])))
+    )
+
+    state[[v]] <- bare_view(layouts[[v]])
+  }
+
+  for (v in setdiff(have, want)) {
+
+    teardown_view(v, session, dock_mgr$docks)
+    session$sendInputMessage("view_nav", list(remove = v))
+    state[[v]] <- NULL
+  }
+
+  for (v in intersect(want, have)) {
+
+    new_nm <- view_name(layouts[[v]])
+
+    if (!identical(new_nm, view_name(state[[v]]))) {
+      view_name(state[[v]]) <- new_nm
+      session$sendInputMessage(
+        "view_nav",
+        list(rename = list(id = v, to = new_nm))
+      )
+    }
+
+    live <- tryCatch(
+      isolate(dock_mgr$docks[[v]]$layout()),
+      error = function(e) NULL
+    )
+
+    if (!is.null(live) && !layouts_match(live, layouts[[v]])) {
+      apply_layout_diff(
+        view = v,
+        target = layouts[[v]],
+        proxy = dock_mgr$docks[[v]]$proxy,
+        blocks = board_blocks(board),
+        extensions = dock_extensions(board)
+      )
+    }
+  }
+
+  dock_mgr$vs$state <- state
+
+  active <- active_view(layouts)
+
+  if (!is.null(active) &&
+        !identical(active, isolate(dock_mgr$current_active()))) {
+    switch_active_view(active, dock_mgr, session)
+  }
 
   invisible()
 }
@@ -903,11 +983,11 @@ remove_view_observer <- function(vs, session, dock_mgr) {
 
 #' Observe view rename requests.
 #'
-#' Rename is a pure name-attribute write: `input$view_nav_rename` carries
-#' the stable view id and the new name. The view's id — and hence its dock
-#' module, DOM element and `dock_mgr$docks` key — is untouched; only the
-#' display name changes, in `vs$state` and (via a `rename` delta) on the
-#' board. No structure is re-keyed.
+#' Rename is a pure name-attribute write: `input$view_nav_rename` carries the
+#' stable view id and the new name. It travels through the update lifecycle as
+#' a `rename` delta; the reconcile pass writes the new name into `vs$state`
+#' and the nav. The id — and hence the dock module, DOM element and registry
+#' key — is untouched.
 #'
 #' @param vs Reactive view state.
 #' @param session Shiny session.
@@ -921,18 +1001,13 @@ rename_view_observer <- function(vs, session, dock_mgr) {
     req(views_can_crud(vs$state))
 
     rename <- input$view_nav_rename
-    id <- rename$id
-    state <- vs$state
 
-    if (!id %in% names(state)) {
+    if (!rename$id %in% names(vs$state)) {
       return()
     }
 
-    view_name(state[[id]]) <- rename$to
-    vs$state <- state
-
     dock_mgr$update(
-      list(views = list(rename = set_names(list(rename$to), id)))
+      list(views = list(rename = set_names(list(rename$to), rename$id)))
     )
   })
 }

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -42,19 +42,15 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   remove_view_observer(client_views, session, update)
   rename_view_observer(client_views, session, update)
 
-  # Reconcile the live dock session against the committed board: create /
-  # destroy / restore / rename / switch views, so apply_board_update.dock_board
-  # stays a pure reducer and nothing is threaded across the boundary. Runs on
-  # the initial board too (no ignoreInit): view init is just the empty-`docks`
-  # case of reconcile — create every view, show the active one. High priority
-  # so the DOM is current before other board observers react.
+  # Reconcile the live dock session against the committed board (create /
+  # destroy / restore / rename / switch views), keeping apply_board_update a
+  # pure reducer. No ignoreInit: initial render is the empty-`docks` case.
   observeEvent(
     board$board,
     reconcile_views(
       board$board, update, docks, active_dock, client_active, client_views,
       session
-    ),
-    priority = 100
+    )
   )
 
   # Extensions receive active_dock — a reactiveValues that always mirrors
@@ -160,15 +156,19 @@ switch_view_observer <- function(session, update, client_active) {
   )
 }
 
-# Returns NULL while any view's dockview `_state` input is still pending —
-# observers downstream can `req()` past the initial flush. The active view
-# comes from `client_active` (the single client-shown-active record), not
-# from `client_views`.
+# Returns NULL while any view is still pending — its dock not yet created by
+# reconcile, or its dockview layout not yet reported — so downstream observers
+# `req()` past the initial flush instead of racing reconcile. The active view
+# comes from `client_active`, not `client_views`.
 live_view_data <- function(client_views, docks, client_active) {
   reactive({
     state <- client_views()
     v_list <- lapply(names(state), function(v_id) {
-      ly <- docks[[v_id]]$layout()
+      dk <- docks[[v_id]]
+      if (is.null(dk)) {
+        return(NULL)
+      }
+      ly <- dk$layout()
       if (is.null(ly)) {
         return(NULL)
       }

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -154,47 +154,23 @@ new_dock_manager <- function() {
 #' @noRd
 init_view_docks <- function(views, board, update, triggers, session, dock_mgr,
                             blocks, extensions) {
-  ns <- session$ns
   active_v <- active_view(views)
   current_active <- reactiveVal(active_v)
 
   for (v_id in names(views)) {
-    v_ly <- views[[v_id]]
-    dock_output_id <- ns(NS(v_id, dock_id()))
-
-    insertUI(
-      selector = paste0("#", ns("view_container")),
-      where = "beforeEnd",
-      ui = div(
-        id = ns(as_view_handle_id(v_id)),
-        class = paste(
-          "blockr-view-dock",
-          if (identical(v_id, active_v)) "blockr-view-dock-active"
-        ),
-        dockViewR::dock_view_output(
-          dock_output_id,
-          width = "100%",
-          height = "100%"
-        ),
-        uiOutput(NS(ns(v_id), "empty_prompt"))
-      ),
-      immediate = TRUE,
-      session = session
-    )
-
-    local_id <- v_id
-    dock_res <- manage_dock(
+    instantiate_view(
       v_id,
+      views[[v_id]],
       board,
       update,
       triggers,
-      layout = v_ly,
-      is_active = reactive(identical(current_active(), local_id)),
+      session,
+      dock_mgr$docks,
+      current_active = current_active,
       blocks = blocks,
-      extensions = extensions
+      extensions = extensions,
+      active = identical(v_id, active_v)
     )
-    dock_res$dock_id <- v_id
-    dock_mgr$docks[[v_id]] <- dock_res
   }
 
   update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[active_v]])
@@ -409,6 +385,79 @@ show_view_ui <- function(view_id, docks) {
   for (eid in as_obj_id(ext_panel_ids(proxy))) {
     show_ext_ui(eid, proxy$session, board_ns = bns)
   }
+}
+
+# Insert a view's dock container into the DOM and start its manage_dock
+# module, keyed by the stable view id (which is the module id and the DOM
+# stem). Shared by the initial render and post-init view additions. When
+# `current_active` is supplied, the dock's empty-prompt tracks whether this
+# view is the active one; otherwise it is treated as always active.
+instantiate_view <- function(v_id, layout, board, update, triggers, session,
+                             docks, current_active = NULL, blocks = NULL,
+                             extensions = NULL, active = FALSE) {
+
+  ns <- session$ns
+
+  is_active <- if (is.null(current_active)) {
+    reactive(TRUE)
+  } else {
+    reactive(identical(current_active(), v_id))
+  }
+
+  insertUI(
+    selector = paste0("#", ns("view_container")),
+    where = "beforeEnd",
+    ui = div(
+      id = ns(as_view_handle_id(v_id)),
+      class = paste(
+        "blockr-view-dock",
+        if (isTRUE(active)) "blockr-view-dock-active"
+      ),
+      dockViewR::dock_view_output(
+        ns(NS(v_id, dock_id())),
+        width = "100%",
+        height = "100%"
+      ),
+      uiOutput(NS(ns(v_id), "empty_prompt"))
+    ),
+    immediate = TRUE,
+    session = session
+  )
+
+  dock_res <- manage_dock(
+    v_id, board, update, triggers,
+    layout = layout,
+    is_active = is_active,
+    blocks = blocks,
+    extensions = extensions
+  )
+  dock_res$dock_id <- v_id
+  docks[[v_id]] <- dock_res
+
+  invisible(dock_res)
+}
+
+# Tear down a view's dock module and remove its DOM container. Parks the
+# view's block / ext UIs in the offcanvas first, so a block that survives in
+# another view keeps its single-instance board-level UI.
+teardown_view <- function(v_id, session, docks) {
+
+  if (!exists(v_id, envir = docks, inherits = FALSE)) {
+    return(invisible())
+  }
+
+  rm_dock <- docks[[v_id]]
+
+  hide_view_ui(v_id, docks)
+  destroy_module(rm_dock$dock_id, session = session)
+  removeUI(
+    selector = paste0("#", session$ns(as_view_handle_id(rm_dock$dock_id))),
+    immediate = TRUE,
+    session = session
+  )
+  rm(list = v_id, envir = docks)
+
+  invisible()
 }
 
 #' Run a single dockViewR instance as a Shiny module.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -318,20 +318,14 @@ show_view_ui <- function(view_id, docks) {
 
 # Insert a view's dock container into the DOM and start its manage_dock
 # module, keyed by the stable view id (which is the module id and the DOM
-# stem). Shared by the initial render and post-init view additions. When
-# `current_active` is supplied, the dock's empty-prompt tracks whether this
-# view is the active one; otherwise it is treated as always active.
+# stem). Shared by the initial render and post-init view additions. `active`
+# stamps the active CSS class at insert so the initially-shown view is visible
+# without waiting on a switch round-trip.
 instantiate_view <- function(v_id, layout, board, update, triggers, session,
-                             docks, current_active = NULL, blocks = NULL,
-                             extensions = NULL, active = FALSE) {
+                             docks, blocks = NULL, extensions = NULL,
+                             active = FALSE) {
 
   ns <- session$ns
-
-  is_active <- if (is.null(current_active)) {
-    reactive(TRUE)
-  } else {
-    reactive(identical(current_active(), v_id))
-  }
 
   insertUI(
     selector = paste0("#", ns("view_container")),
@@ -356,7 +350,6 @@ instantiate_view <- function(v_id, layout, board, update, triggers, session,
   dock_res <- manage_dock(
     v_id, board, update, triggers,
     layout = layout,
-    is_active = is_active,
     blocks = blocks,
     extensions = extensions
   )
@@ -415,7 +408,6 @@ reconcile_views <- function(board, update, triggers, docks, active_dock,
       triggers,
       session,
       docks,
-      current_active = current_active,
       blocks = board_blocks(board),
       extensions = dock_extensions(board),
       active = identical(v, active)
@@ -484,9 +476,6 @@ reconcile_views <- function(board, update, triggers, docks, active_dock,
 #' @param actions Action triggers.
 #' @param layout Optional initial `dock_layout`; defaults to the board's
 #'   `active_layout()`.
-#' @param is_active A [shiny::reactive()] returning `TRUE` when this dock
-#'   is the currently active view. Controls whether the empty-dock prompt
-#'   is shown. Defaults to always-active (single-dock boards).
 #'
 #' @return A list with `layout` (reactive), `proxy`, `prev_active_group`,
 #'   `n_panels`, and `active_group_trail`.
@@ -498,7 +487,6 @@ manage_dock <- function(
   update,
   actions,
   layout = NULL,
-  is_active = reactive(TRUE),
   blocks = NULL,
   extensions = NULL
 ) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -29,13 +29,9 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
 
   triggers <- action_triggers(actions)
 
-  # Per-session dock state, closure-private — no handle crosses the package
-  # boundary, and `reconcile_views()` is the sole mutator. `docks` is the
-  # live `manage_dock()` registry (keyed by view id). `client_active` and
-  # `client_views` are the server-side record of what the client (browser)
-  # currently shows — the shown-active id, and the shown view set / display
-  # names — each lagging the committed `board_layouts` (the server truth) so
-  # reconcile can diff server-vs-client and push the difference to the DOM.
+  # Per-session dock state, closure-private. `docks` is the live manage_dock()
+  # registry; `client_active` / `client_views` mirror what the browser shows
+  # (lagging board_layouts), diffed by reconcile_views() — the sole mutator.
   docks <- new.env(parent = emptyenv())
   active_dock <- reactiveValues()
   client_active <- reactiveVal(NULL)
@@ -318,13 +314,11 @@ show_view_ui <- function(view_id, docks) {
   }
 }
 
-# Insert a view's dock container into the DOM and start its manage_dock
-# module, keyed by the stable view id (which is the module id and the DOM
-# stem). Shared by the initial render and post-init view additions. `active`
-# stamps the active CSS class at insert so the initially-shown view is visible
-# without waiting on a switch round-trip.
-instantiate_view <- function(v_id, layout, board, update, session, docks,
-                             blocks = NULL, extensions = NULL, active = FALSE) {
+# Insert a view's dock container, start its manage_dock module, and register
+# the result in `docks` under the view id. `active` stamps the active CSS
+# class at insert so the initially-shown view needs no switch round-trip.
+create_view <- function(v_id, layout, board, update, session, docks,
+                        blocks = NULL, extensions = NULL, active = FALSE) {
 
   ns <- session$ns
 
@@ -348,21 +342,20 @@ instantiate_view <- function(v_id, layout, board, update, session, docks,
     session = session
   )
 
-  dock_res <- manage_dock(
+  docks[[v_id]] <- manage_dock(
     v_id, board, update,
     layout = layout,
     blocks = blocks,
     extensions = extensions
   )
-  docks[[v_id]] <- dock_res
 
-  invisible(dock_res)
+  invisible()
 }
 
-# Tear down a view's dock module and remove its DOM container. Parks the
-# view's block / ext UIs in the offcanvas first, so a block that survives in
-# another view keeps its single-instance board-level UI.
-teardown_view <- function(v_id, session, docks) {
+# Destroy a view's dock module, deregister it from `docks`, and remove its DOM
+# container. Parks the view's block / ext UI in the offcanvas first so a block
+# surviving in another view keeps its single-instance board-level UI.
+remove_view <- function(v_id, session, docks) {
 
   if (!exists(v_id, envir = docks, inherits = FALSE)) {
     return(invisible())
@@ -398,7 +391,7 @@ reconcile_views <- function(board, update, docks, active_dock,
 
   for (v in setdiff(want, have)) {
 
-    instantiate_view(
+    create_view(
       v,
       layouts[[v]],
       board,
@@ -420,7 +413,7 @@ reconcile_views <- function(board, update, docks, active_dock,
 
   for (v in setdiff(have, want)) {
 
-    teardown_view(v, session, docks)
+    remove_view(v, session, docks)
     session$sendInputMessage("view_nav", list(remove = v))
     state[[v]] <- NULL
   }

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -53,8 +53,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   observeEvent(
     board$board,
     reconcile_views(
-      board$board, update, triggers, docks, active_dock, current_active, vs,
-      session
+      board$board, update, docks, active_dock, current_active, vs, session
     ),
     priority = 100
   )
@@ -321,9 +320,8 @@ show_view_ui <- function(view_id, docks) {
 # stem). Shared by the initial render and post-init view additions. `active`
 # stamps the active CSS class at insert so the initially-shown view is visible
 # without waiting on a switch round-trip.
-instantiate_view <- function(v_id, layout, board, update, triggers, session,
-                             docks, blocks = NULL, extensions = NULL,
-                             active = FALSE) {
+instantiate_view <- function(v_id, layout, board, update, session, docks,
+                             blocks = NULL, extensions = NULL, active = FALSE) {
 
   ns <- session$ns
 
@@ -348,12 +346,11 @@ instantiate_view <- function(v_id, layout, board, update, triggers, session,
   )
 
   dock_res <- manage_dock(
-    v_id, board, update, triggers,
+    v_id, board, update,
     layout = layout,
     blocks = blocks,
     extensions = extensions
   )
-  dock_res$dock_id <- v_id
   docks[[v_id]] <- dock_res
 
   invisible(dock_res)
@@ -368,12 +365,10 @@ teardown_view <- function(v_id, session, docks) {
     return(invisible())
   }
 
-  rm_dock <- docks[[v_id]]
-
   hide_view_ui(v_id, docks)
-  destroy_module(rm_dock$dock_id, session = session)
+  destroy_module(v_id, session = session)
   removeUI(
-    selector = paste0("#", session$ns(as_view_handle_id(rm_dock$dock_id))),
+    selector = paste0("#", session$ns(as_view_handle_id(v_id))),
     immediate = TRUE,
     session = session
   )
@@ -389,7 +384,7 @@ teardown_view <- function(v_id, session, docks) {
 # reducer and dock state never crosses the package boundary. Idempotent — a
 # board already matching the live state produces no surgery — so it composes
 # with the live-sync (DOM -> board) path without ping-ponging.
-reconcile_views <- function(board, update, triggers, docks, active_dock,
+reconcile_views <- function(board, update, docks, active_dock,
                             current_active, vs, session) {
 
   layouts <- board_layouts(board)
@@ -405,7 +400,6 @@ reconcile_views <- function(board, update, triggers, docks, active_dock,
       layouts[[v]],
       board,
       update,
-      triggers,
       session,
       docks,
       blocks = board_blocks(board),
@@ -473,7 +467,6 @@ reconcile_views <- function(board, update, triggers, docks, active_dock,
 #'
 #' @param id Module ID.
 #' @param board,update Reactive board state and update signal.
-#' @param actions Action triggers.
 #' @param layout Optional initial `dock_layout`; defaults to the board's
 #'   `active_layout()`.
 #'
@@ -485,7 +478,6 @@ manage_dock <- function(
   id,
   board,
   update,
-  actions,
   layout = NULL,
   blocks = NULL,
   extensions = NULL

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -17,9 +17,7 @@
 board_server_callback <- function(board, update, ..., session = get_session()) {
   initial_board <- isolate(board$board)
 
-  c_blks <- board_blocks(initial_board)
   c_exts <- dock_extensions(initial_board)
-
   exts <- as.list(c_exts)
 
   actions <- unlst(
@@ -31,59 +29,53 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
 
   triggers <- action_triggers(actions)
 
-  views <- board_layouts(initial_board)
+  # Per-session dock state, closure-private — no handle crosses the package
+  # boundary. `reconcile_views()` is the sole mutator. `docks` is the live
+  # `manage_dock()` registry (keyed by view id); `current_active` is the
+  # shown-active id (lags the board so a switch is detectable); `vs$state`
+  # mirrors the view set / display names / active id for the live-sync and nav.
+  docks <- new.env(parent = emptyenv())
+  active_dock <- reactiveValues()
+  current_active <- reactiveVal(NULL)
+  vs <- reactiveValues(state = seed_view_state(board_layouts(initial_board)))
 
-  dock_mgr <- new_dock_manager()
-  dock_mgr$board_rv <- board
-  dock_mgr$update <- update
-  dock_mgr$triggers <- triggers
+  switch_view_observer(session, update, current_active)
+  add_view_observer(vs, session, board, update)
+  remove_view_observer(vs, session, update)
+  rename_view_observer(vs, session, update)
 
-  vs <- init_view_docks(
-    views,
-    board,
-    update,
-    triggers,
-    session,
-    dock_mgr,
-    blocks = c_blks,
-    extensions = c_exts
-  )
-  dock_mgr$vs <- vs
-
-  switch_view_observer(session, dock_mgr)
-  add_view_observer(vs, session, dock_mgr, board, update)
-  remove_view_observer(vs, session, dock_mgr)
-  rename_view_observer(vs, session, dock_mgr)
-
-  # Make the live dock session match the committed board: a single
-  # closure-resident reconcile pass replaces the per-delta surgery that used
-  # to live in apply_board_update.dock_board, so that hook stays a pure
-  # reducer and dock state never crosses the package boundary. High priority
+  # Reconcile the live dock session against the committed board: create /
+  # destroy / restore / rename / switch views, so apply_board_update.dock_board
+  # stays a pure reducer and nothing is threaded across the boundary. Runs on
+  # the initial board too (no ignoreInit): view init is just the empty-`docks`
+  # case of reconcile — create every view, show the active one. High priority
   # so the DOM is current before other board observers react.
   observeEvent(
     board$board,
-    reconcile_views(board$board, dock_mgr, session),
-    ignoreInit = TRUE,
+    reconcile_views(
+      board$board, update, triggers, docks, active_dock, current_active, vs,
+      session
+    ),
     priority = 100
   )
 
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
-  dock <- dock_mgr$active_dock
-  view_data <- live_view_data(vs, dock_mgr)
+  dock <- active_dock
+  view_data <- live_view_data(vs, docks)
 
   sync_layouts_to_board(view_data, update, board)
 
   # Each extension can read the others' server results through the
   # `extensions` environment: one active binding per id, each resolving to
-  # the live result (carrying its `state`). `dock_mgr$ext_res` is filled
-  # right after this lapply, so a binding resolves on first read -- always
-  # post-init (e.g. on a tool call). Lets one extension (such as the
-  # assistant) read another's controllable state via `extensions[[id]]`.
+  # the live result (carrying its `state`). `ext_res` is filled right after
+  # this lapply, so a binding resolves on first read -- always post-init
+  # (e.g. on a tool call). Lets one extension (such as the assistant) read
+  # another's controllable state via `extensions[[id]]`.
   peers <- new.env(parent = emptyenv())
 
   bind_peer <- function(id) {
-    makeActiveBinding(id, function() dock_mgr$ext_res[[id]], peers)
+    makeActiveBinding(id, function() ext_res[[id]], peers)
   }
 
   for (ext_id in names(exts)) {
@@ -103,14 +95,12 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
     list(...)
   )
 
-  dock_mgr$ext_res <- ext_res
-
   # Externally controllable extension state is applied here, in the closure
   # that owns ext_res, rather than from the (now pure) apply hook. The update
   # payload carries the mod directly; the reactiveVal writes are idempotent.
   observeEvent(
     update()$extensions$mod,
-    apply_extensions_mod(update()$extensions$mod, dock_mgr$ext_res)
+    apply_extensions_mod(update()$extensions$mod, ext_res)
   )
 
   register_actions(actions, triggers, board, update, ext_res)
@@ -125,76 +115,14 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   )
 }
 
-#' Create a dock manager.
-#'
-#' Plain environment bundling all view dock infrastructure so it can
-#' be passed as a single parameter to helper functions.
-#'
-#' @return An environment with:
-#' \describe{
-#'   \item{`docks`}{Environment mapping view ids to dock module results
-#'     (each a list with `layout`, `proxy`, `dock_id`, etc.). The view id
-#'     is also the dock module id, so DOM and module ids derive from it.}
-#'   \item{`active_dock`}{A `reactiveValues` that mirrors the dock module
-#'     result of the currently active view. Extensions hold a stable
-#'     reference to this; its contents are swapped by `update_active_dock()`
-#'     when the user switches views.}
-#' }
-#'
-#' @noRd
-new_dock_manager <- function() {
-  mgr <- new.env(parent = emptyenv())
-  mgr$docks <- new.env(parent = emptyenv())
-  mgr$active_dock <- reactiveValues()
-  mgr
-}
-
-#' Initialise dock modules for each view.
-#'
-#' For every view in `views`, inserts a dock view output container
-#' into the DOM and starts a `manage_dock()` module. View layouts are
-#' read from `views` once for seeding; afterwards, layouts live
-#' exclusively in `dock_mgr$docks` (no duplication in `vs$state`).
-#'
-#' @param views A `dock_layouts` object (from the initial board).
-#' @param board,update,triggers Reactive board state, update signal, and
-#'   action triggers — forwarded to `manage_dock()`.
-#' @param session Shiny session.
-#' @param dock_mgr Dock manager created by `new_dock_manager()`.
-#'
-#' @return A `reactiveValues` with a single slot `$state` — a
-#'   `dock_layouts` object tracking view ids, display names, and which is
-#'   active. Layouts are empty; the authoritative layout data lives in
-#'   `dock_mgr$docks[[view_id]]$layout()`.
-#'
-#' @noRd
-init_view_docks <- function(views, board, update, triggers, session, dock_mgr,
-                            blocks, extensions) {
-  active_v <- active_view(views)
-  current_active <- reactiveVal(active_v)
-
-  for (v_id in names(views)) {
-    instantiate_view(
-      v_id,
-      views[[v_id]],
-      board,
-      update,
-      triggers,
-      session,
-      dock_mgr$docks,
-      current_active = current_active,
-      blocks = blocks,
-      extensions = extensions,
-      active = identical(v_id, active_v)
-    )
-  }
-
-  update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[active_v]])
-  dock_mgr$current_active <- current_active
-
+# The initial `vs$state`: one bare (empty) layout per view, carrying the
+# display name and the active marker. Gives live_view_data and the nav the
+# view set before any dockview has reported its live layout; the dock modules
+# themselves are created by the reconcile pass (its empty-`docks` case).
+seed_view_state <- function(views) {
   bare <- reconstruct_dock_layouts(lapply(views, bare_view))
-  active_view(bare) <- active_v
-  reactiveValues(state = bare)
+  active_view(bare) <- active_view(views)
+  bare
 }
 
 # An empty layout standing in for a view in `vs$state`: carries the
@@ -217,17 +145,18 @@ bare_view <- function(x) {
 #' `value` set back) does not re-enter the lifecycle.
 #'
 #' @param session Shiny session.
-#' @param dock_mgr Dock manager.
+#' @param update Board update signal.
+#' @param current_active Reactive holding the shown active view id.
 #'
 #' @noRd
-switch_view_observer <- function(session, dock_mgr) {
+switch_view_observer <- function(session, update, current_active) {
   observeEvent(
     session$input$view_nav,
     {
       target <- session$input$view_nav
 
-      if (!identical(target, isolate(dock_mgr$current_active()))) {
-        dock_mgr$update(list(views = list(active = target)))
+      if (!identical(target, isolate(current_active()))) {
+        update(list(views = list(active = target)))
       }
     },
     ignoreInit = TRUE
@@ -236,11 +165,11 @@ switch_view_observer <- function(session, dock_mgr) {
 
 # Returns NULL while any view's dockview `_state` input is still
 # pending — observers downstream can `req()` past the initial flush.
-live_view_data <- function(vs, dock_mgr) {
+live_view_data <- function(vs, docks) {
   reactive({
     state <- vs$state
     v_list <- lapply(names(state), function(v_id) {
-      ly <- dock_mgr$docks[[v_id]]$layout()
+      ly <- docks[[v_id]]$layout()
       if (is.null(ly)) {
         return(NULL)
       }
@@ -343,7 +272,7 @@ diff_dock_layouts <- function(current, new_layouts) {
 #' not visible while the view is inactive.
 #'
 #' @param view_id View id (string).
-#' @param docks Environment of dock module results (`dock_mgr$docks`).
+#' @param docks Environment of dock module results, keyed by view id.
 #'
 #' @noRd
 hide_view_ui <- function(view_id, docks) {
@@ -366,7 +295,7 @@ hide_view_ui <- function(view_id, docks) {
 #' becomes active.
 #'
 #' @param view_id View id (string).
-#' @param docks Environment of dock module results (`dock_mgr$docks`).
+#' @param docks Environment of dock module results, keyed by view id.
 #'
 #' @noRd
 show_view_ui <- function(view_id, docks) {
@@ -463,26 +392,29 @@ teardown_view <- function(v_id, session, docks) {
 # reducer and dock state never crosses the package boundary. Idempotent — a
 # board already matching the live state produces no surgery — so it composes
 # with the live-sync (DOM -> board) path without ping-ponging.
-reconcile_views <- function(board, dock_mgr, session) {
+reconcile_views <- function(board, update, triggers, docks, active_dock,
+                            current_active, vs, session) {
 
   layouts <- board_layouts(board)
   want <- names(layouts)
-  state <- isolate(dock_mgr$vs$state)
-  have <- names(state)
+  active <- active_view(layouts)
+  state <- isolate(vs$state)
+  have <- ls(docks)
 
   for (v in setdiff(want, have)) {
 
     instantiate_view(
       v,
       layouts[[v]],
-      dock_mgr$board_rv,
-      dock_mgr$update,
-      dock_mgr$triggers,
+      board,
+      update,
+      triggers,
       session,
-      dock_mgr$docks,
-      current_active = dock_mgr$current_active,
+      docks,
+      current_active = current_active,
       blocks = board_blocks(board),
-      extensions = dock_extensions(board)
+      extensions = dock_extensions(board),
+      active = identical(v, active)
     )
 
     session$sendInputMessage(
@@ -495,7 +427,7 @@ reconcile_views <- function(board, dock_mgr, session) {
 
   for (v in setdiff(have, want)) {
 
-    teardown_view(v, session, dock_mgr$docks)
+    teardown_view(v, session, docks)
     session$sendInputMessage("view_nav", list(remove = v))
     state[[v]] <- NULL
   }
@@ -513,7 +445,7 @@ reconcile_views <- function(board, dock_mgr, session) {
     }
 
     live <- tryCatch(
-      isolate(dock_mgr$docks[[v]]$layout()),
+      isolate(docks[[v]]$layout()),
       error = function(e) NULL
     )
 
@@ -521,20 +453,17 @@ reconcile_views <- function(board, dock_mgr, session) {
       apply_layout_diff(
         view = v,
         target = layouts[[v]],
-        proxy = dock_mgr$docks[[v]]$proxy,
+        proxy = docks[[v]]$proxy,
         blocks = board_blocks(board),
         extensions = dock_extensions(board)
       )
     }
   }
 
-  dock_mgr$vs$state <- state
+  vs$state <- state
 
-  active <- active_view(layouts)
-
-  if (!is.null(active) &&
-        !identical(active, isolate(dock_mgr$current_active()))) {
-    switch_active_view(active, dock_mgr, session)
+  if (!is.null(active) && !identical(active, isolate(current_active()))) {
+    switch_active_view(active, docks, active_dock, current_active, vs, session)
   }
 
   invisible()
@@ -765,17 +694,17 @@ manage_dock <- function(
 
 #' Observe view addition requests.
 #'
-#' Shows a modal to name the new view and pick blocks/extensions,
-#' then inserts a new dock module, updates `vs$state`, and switches to it.
+#' Shows a modal to name the new view and pick blocks/extensions, then emits
+#' an `add` + `active` views delta; the reconcile pass instantiates the dock
+#' and switches to it.
 #'
 #' @param vs Reactive view state.
 #' @param session Shiny session.
-#' @param dock_mgr Dock manager.
-#' @param board,update,triggers Reactive board state, update signal, and
-#'   action triggers — forwarded to `manage_dock()`.
+#' @param board Reactive board state.
+#' @param update Board update signal.
 #'
 #' @noRd
-add_view_observer <- function(vs, session, dock_mgr, board, update) {
+add_view_observer <- function(vs, session, board, update) {
   input <- session$input
   output <- session$output
   ns <- session$ns
@@ -905,16 +834,16 @@ add_view_observer <- function(vs, session, dock_mgr, board, update) {
 
 #' Observe view removal requests.
 #'
-#' Shows a confirmation modal, then destroys the dock module, removes
-#' the DOM container, updates `vs$state`, and switches to another view
-#' if the removed one was active.
+#' Shows a confirmation modal, then emits an `rm` views delta; the reconcile
+#' pass destroys the dock module, removes the DOM container, and switches to
+#' another view if the removed one was active.
 #'
 #' @param vs Reactive view state.
 #' @param session Shiny session.
-#' @param dock_mgr Dock manager.
+#' @param update Board update signal.
 #'
 #' @noRd
-remove_view_observer <- function(vs, session, dock_mgr) {
+remove_view_observer <- function(vs, session, update) {
   input <- session$input
   ns <- session$ns
 
@@ -977,7 +906,7 @@ remove_view_observer <- function(vs, session, dock_mgr) {
       return()
     }
 
-    dock_mgr$update(list(views = list(rm = rm_id)))
+    update(list(views = list(rm = rm_id)))
   })
 }
 
@@ -991,10 +920,10 @@ remove_view_observer <- function(vs, session, dock_mgr) {
 #'
 #' @param vs Reactive view state.
 #' @param session Shiny session.
-#' @param dock_mgr Dock manager.
+#' @param update Board update signal.
 #'
 #' @noRd
-rename_view_observer <- function(vs, session, dock_mgr) {
+rename_view_observer <- function(vs, session, update) {
   input <- session$input
 
   observeEvent(input$view_nav_rename, {
@@ -1006,7 +935,7 @@ rename_view_observer <- function(vs, session, dock_mgr) {
       return()
     }
 
-    dock_mgr$update(
+    update(
       list(views = list(rename = set_names(list(rename$to), rename$id)))
     )
   })

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -31,19 +31,20 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
 
   # Per-session dock state, closure-private — no handle crosses the package
   # boundary, and `reconcile_views()` is the sole mutator. `docks` is the
-  # live `manage_dock()` registry (keyed by view id). `current_active` and
-  # `vs$state` are the two facets of the rendered mirror of `board_layouts`:
-  # the shown-active id, and the shown view set / display names — each lags
-  # the committed board so reconcile can diff committed-vs-shown and apply it.
+  # live `manage_dock()` registry (keyed by view id). `client_active` and
+  # `client_views` are the server-side record of what the client (browser)
+  # currently shows — the shown-active id, and the shown view set / display
+  # names — each lagging the committed `board_layouts` (the server truth) so
+  # reconcile can diff server-vs-client and push the difference to the DOM.
   docks <- new.env(parent = emptyenv())
   active_dock <- reactiveValues()
-  current_active <- reactiveVal(NULL)
-  vs <- reactiveValues(state = seed_view_state(board_layouts(initial_board)))
+  client_active <- reactiveVal(NULL)
+  client_views <- reactiveVal(seed_view_state(board_layouts(initial_board)))
 
-  switch_view_observer(session, update, current_active)
-  add_view_observer(vs, session, board, update)
-  remove_view_observer(vs, session, update)
-  rename_view_observer(vs, session, update)
+  switch_view_observer(session, update, client_active)
+  add_view_observer(client_views, session, board, update)
+  remove_view_observer(client_views, session, update)
+  rename_view_observer(client_views, session, update)
 
   # Reconcile the live dock session against the committed board: create /
   # destroy / restore / rename / switch views, so apply_board_update.dock_board
@@ -54,7 +55,8 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   observeEvent(
     board$board,
     reconcile_views(
-      board$board, update, docks, active_dock, current_active, vs, session
+      board$board, update, docks, active_dock, client_active, client_views,
+      session
     ),
     priority = 100
   )
@@ -62,7 +64,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
   dock <- active_dock
-  view_data <- live_view_data(vs, docks, current_active)
+  view_data <- live_view_data(client_views, docks, client_active)
 
   sync_layouts_to_board(view_data, update, board)
 
@@ -115,16 +117,16 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   )
 }
 
-# The initial `vs$state`: one bare (empty) layout per view, carrying the
+# The initial `client_views`: one bare (empty) layout per view, carrying the
 # display name. Gives live_view_data and the nav the view set before any
 # dockview has reported its live layout; the dock modules themselves are
 # created by the reconcile pass (its empty-`docks` case). Which view is active
-# is tracked solely by `current_active`, not here.
+# is tracked solely by `client_active`, not here.
 seed_view_state <- function(views) {
   reconstruct_dock_layouts(lapply(views, bare_view))
 }
 
-# An empty layout standing in for a view in `vs$state`: carries the
+# An empty layout standing in for a view in `client_views`: carries the
 # view's display name so live_view_data / serialization keep the
 # id -> name mapping without duplicating the layout itself.
 bare_view <- function(x) {
@@ -145,16 +147,16 @@ bare_view <- function(x) {
 #'
 #' @param session Shiny session.
 #' @param update Board update signal.
-#' @param current_active Reactive holding the shown active view id.
+#' @param client_active Reactive holding the client-shown active view id.
 #'
 #' @noRd
-switch_view_observer <- function(session, update, current_active) {
+switch_view_observer <- function(session, update, client_active) {
   observeEvent(
     session$input$view_nav,
     {
       target <- session$input$view_nav
 
-      if (!identical(target, isolate(current_active()))) {
+      if (!identical(target, isolate(client_active()))) {
         update(list(views = list(active = target)))
       }
     },
@@ -164,11 +166,11 @@ switch_view_observer <- function(session, update, current_active) {
 
 # Returns NULL while any view's dockview `_state` input is still pending —
 # observers downstream can `req()` past the initial flush. The active view
-# comes from `current_active` (the single rendered-active record), not from
-# `vs$state`.
-live_view_data <- function(vs, docks, current_active) {
+# comes from `client_active` (the single client-shown-active record), not
+# from `client_views`.
+live_view_data <- function(client_views, docks, client_active) {
   reactive({
-    state <- vs$state
+    state <- client_views()
     v_list <- lapply(names(state), function(v_id) {
       ly <- docks[[v_id]]$layout()
       if (is.null(ly)) {
@@ -187,7 +189,7 @@ live_view_data <- function(vs, docks, current_active) {
     }
 
     res <- reconstruct_dock_layouts(set_names(v_list, names(state)))
-    ca <- current_active()
+    ca <- client_active()
     if (!is.null(ca)) {
       active_view(res) <- ca
     }
@@ -386,12 +388,12 @@ teardown_view <- function(v_id, session, docks) {
 # board already matching the live state produces no surgery — so it composes
 # with the live-sync (DOM -> board) path without ping-ponging.
 reconcile_views <- function(board, update, docks, active_dock,
-                            current_active, vs, session) {
+                            client_active, client_views, session) {
 
   layouts <- board_layouts(board)
   want <- names(layouts)
-  active <- active_view(layouts)
-  state <- isolate(vs$state)
+  server_active <- active_view(layouts)
+  state <- isolate(client_views())
   have <- ls(docks)
 
   for (v in setdiff(want, have)) {
@@ -405,7 +407,7 @@ reconcile_views <- function(board, update, docks, active_dock,
       docks,
       blocks = board_blocks(board),
       extensions = dock_extensions(board),
-      active = identical(v, active)
+      active = identical(v, server_active)
     )
 
     session$sendInputMessage(
@@ -451,10 +453,13 @@ reconcile_views <- function(board, update, docks, active_dock,
     }
   }
 
-  vs$state <- state
+  client_views(state)
 
-  if (!is.null(active) && !identical(active, isolate(current_active()))) {
-    switch_active_view(active, docks, active_dock, current_active, session)
+  if (!is.null(server_active) &&
+        !identical(server_active, isolate(client_active()))) {
+    switch_active_view(
+      server_active, docks, active_dock, client_active, session
+    )
   }
 
   invisible()
@@ -683,22 +688,22 @@ manage_dock <- function(
 #' an `add` + `active` views delta; the reconcile pass instantiates the dock
 #' and switches to it.
 #'
-#' @param vs Reactive view state.
+#' @param client_views Reactive record of the client-shown views.
 #' @param session Shiny session.
 #' @param board Reactive board state.
 #' @param update Board update signal.
 #'
 #' @noRd
-add_view_observer <- function(vs, session, board, update) {
+add_view_observer <- function(client_views, session, board, update) {
   input <- session$input
   output <- session$output
   ns <- session$ns
 
   # Show modal for view creation
   observeEvent(input$view_nav_add, {
-    req(views_can_crud(vs$state))
+    req(views_can_crud(client_views()))
 
-    state <- vs$state
+    state <- client_views()
     existing <- view_names(state)
     n <- length(state) + 1L
     while (paste("Page", n) %in% existing) n <- n + 1L
@@ -770,7 +775,10 @@ add_view_observer <- function(vs, session, board, update) {
   # Name validation feedback
   output$view_name_validation <- renderUI({
     req(input$view_new_name)
-    msg <- validate_view_name(trimws(input$view_new_name), view_names(vs$state))
+    msg <- validate_view_name(
+      trimws(input$view_new_name),
+      view_names(client_views())
+    )
     if (!is.null(msg)) tags$div(class = "text-danger", msg)
   })
 
@@ -779,7 +787,7 @@ add_view_observer <- function(vs, session, board, update) {
   # and `apply_views_add()` instantiates the dock — the same path a
   # delta-driven add takes, so id assignment happens in exactly one place.
   observeEvent(input$confirm_view_add, {
-    state <- vs$state
+    state <- client_views()
     new_name <- trimws(input$view_new_name)
 
     if (!is.null(validate_view_name(new_name, view_names(state)))) {
@@ -823,22 +831,22 @@ add_view_observer <- function(vs, session, board, update) {
 #' pass destroys the dock module, removes the DOM container, and switches to
 #' another view if the removed one was active.
 #'
-#' @param vs Reactive view state.
+#' @param client_views Reactive record of the client-shown views.
 #' @param session Shiny session.
 #' @param update Board update signal.
 #'
 #' @noRd
-remove_view_observer <- function(vs, session, update) {
+remove_view_observer <- function(client_views, session, update) {
   input <- session$input
   ns <- session$ns
 
   # Show confirmation modal. `input$view_nav_remove` carries the view id;
   # the modal shows the display name.
   observeEvent(input$view_nav_remove, {
-    req(views_can_crud(vs$state))
+    req(views_can_crud(client_views()))
 
     rm_id <- input$view_nav_remove
-    state <- vs$state
+    state <- client_views()
 
     if (!rm_id %in% names(state)) {
       return()
@@ -885,7 +893,7 @@ remove_view_observer <- function(vs, session, update) {
     removeModal()
 
     rm_id <- input$view_nav_remove
-    state <- vs$state
+    state <- client_views()
 
     if (!rm_id %in% names(state) || length(state) <= 1L) {
       return()
@@ -899,24 +907,24 @@ remove_view_observer <- function(vs, session, update) {
 #'
 #' Rename is a pure name-attribute write: `input$view_nav_rename` carries the
 #' stable view id and the new name. It travels through the update lifecycle as
-#' a `rename` delta; the reconcile pass writes the new name into `vs$state`
+#' a `rename` delta; the reconcile pass writes the new name into `client_views`
 #' and the nav. The id — and hence the dock module, DOM element and registry
 #' key — is untouched.
 #'
-#' @param vs Reactive view state.
+#' @param client_views Reactive record of the client-shown views.
 #' @param session Shiny session.
 #' @param update Board update signal.
 #'
 #' @noRd
-rename_view_observer <- function(vs, session, update) {
+rename_view_observer <- function(client_views, session, update) {
   input <- session$input
 
   observeEvent(input$view_nav_rename, {
-    req(views_can_crud(vs$state))
+    req(views_can_crud(client_views()))
 
     rename <- input$view_nav_rename
 
-    if (!rename$id %in% names(vs$state)) {
+    if (!rename$id %in% names(client_views())) {
       return()
     }
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -62,7 +62,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
   dock <- active_dock
-  view_data <- live_view_data(vs, docks)
+  view_data <- live_view_data(vs, docks, current_active)
 
   sync_layouts_to_board(view_data, update, board)
 
@@ -116,13 +116,12 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
 }
 
 # The initial `vs$state`: one bare (empty) layout per view, carrying the
-# display name and the active marker. Gives live_view_data and the nav the
-# view set before any dockview has reported its live layout; the dock modules
-# themselves are created by the reconcile pass (its empty-`docks` case).
+# display name. Gives live_view_data and the nav the view set before any
+# dockview has reported its live layout; the dock modules themselves are
+# created by the reconcile pass (its empty-`docks` case). Which view is active
+# is tracked solely by `current_active`, not here.
 seed_view_state <- function(views) {
-  bare <- reconstruct_dock_layouts(lapply(views, bare_view))
-  active_view(bare) <- active_view(views)
-  bare
+  reconstruct_dock_layouts(lapply(views, bare_view))
 }
 
 # An empty layout standing in for a view in `vs$state`: carries the
@@ -163,9 +162,11 @@ switch_view_observer <- function(session, update, current_active) {
   )
 }
 
-# Returns NULL while any view's dockview `_state` input is still
-# pending — observers downstream can `req()` past the initial flush.
-live_view_data <- function(vs, docks) {
+# Returns NULL while any view's dockview `_state` input is still pending —
+# observers downstream can `req()` past the initial flush. The active view
+# comes from `current_active` (the single rendered-active record), not from
+# `vs$state`.
+live_view_data <- function(vs, docks, current_active) {
   reactive({
     state <- vs$state
     v_list <- lapply(names(state), function(v_id) {
@@ -186,7 +187,10 @@ live_view_data <- function(vs, docks) {
     }
 
     res <- reconstruct_dock_layouts(set_names(v_list, names(state)))
-    active_view(res) <- active_view(state)
+    ca <- current_active()
+    if (!is.null(ca)) {
+      active_view(res) <- ca
+    }
     res
   })
 }
@@ -463,7 +467,7 @@ reconcile_views <- function(board, update, triggers, docks, active_dock,
   vs$state <- state
 
   if (!is.null(active) && !identical(active, isolate(current_active()))) {
-    switch_active_view(active, docks, active_dock, current_active, vs, session)
+    switch_active_view(active, docks, active_dock, current_active, session)
   }
 
   invisible()

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -30,10 +30,11 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   triggers <- action_triggers(actions)
 
   # Per-session dock state, closure-private — no handle crosses the package
-  # boundary. `reconcile_views()` is the sole mutator. `docks` is the live
-  # `manage_dock()` registry (keyed by view id); `current_active` is the
-  # shown-active id (lags the board so a switch is detectable); `vs$state`
-  # mirrors the view set / display names / active id for the live-sync and nav.
+  # boundary, and `reconcile_views()` is the sole mutator. `docks` is the
+  # live `manage_dock()` registry (keyed by view id). `current_active` and
+  # `vs$state` are the two facets of the rendered mirror of `board_layouts`:
+  # the shown-active id, and the shown view set / display names — each lags
+  # the committed board so reconcile can diff committed-vs-shown and apply it.
   docks <- new.env(parent = emptyenv())
   active_dock <- reactiveValues()
   current_active <- reactiveVal(NULL)

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -118,7 +118,7 @@ board_ui.dock_board <- function(
 }
 
 # View container -- one dock output per view is inserted into this element
-# at server time by the reconcile pass (`instantiate_view()`). Each dock
+# at server time by the reconcile pass (`create_view()`). Each dock
 # output sits inside a nested moduleServer namespace so `manage_dock(id, ...)`
 # can render to `session$output[[dock_id()]]` and dockViewR inputs resolve.
 dock_outputs_ui <- function(id, views) {

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -118,9 +118,9 @@ board_ui.dock_board <- function(
 }
 
 # View container -- one dock output per view is inserted into this element
-# at server time by `init_view_docks()`. Each dock output sits inside a
-# nested moduleServer namespace so `manage_dock(id, ...)` can render to
-# `session$output[[dock_id()]]` and dockViewR inputs resolve correctly.
+# at server time by the reconcile pass (`instantiate_view()`). Each dock
+# output sits inside a nested moduleServer namespace so `manage_dock(id, ...)`
+# can render to `session$output[[dock_id()]]` and dockViewR inputs resolve.
 dock_outputs_ui <- function(id, views) {
   div(
     id = NS(id, "view_container"),

--- a/R/dock-board.R
+++ b/R/dock-board.R
@@ -321,38 +321,30 @@ augment_board_update.dock_board <- function(upd, board, ...,
 }
 
 #' @export
-apply_board_update.dock_board <- function(board, upd, ...,
-                                          session = get_session()) {
-
-  dot_args <- list(...)
-  dock_mgr <- dot_args$dock_mgr
-
-  if (length(upd$extensions$mod) && !is.null(dock_mgr)) {
-    apply_extensions_mod(upd$extensions$mod, dock_mgr$ext_res)
-  }
+apply_board_update.dock_board <- function(board, upd, ...) {
 
   if (!length(upd$views)) {
     return(board)
   }
 
   if (length(upd$views$rm)) {
-    board <- apply_views_rm(upd$views$rm, board, dock_mgr, session)
+    board <- apply_views_rm(upd$views$rm, board)
   }
 
   if (length(upd$views$add)) {
-    board <- apply_views_add(upd$views$add, board, dock_mgr, session)
+    board <- apply_views_add(upd$views$add, board)
   }
 
   if (length(upd$views$mod)) {
-    board <- apply_views_mod(upd$views$mod, board, dock_mgr)
+    board <- apply_views_mod(upd$views$mod, board)
   }
 
   if (length(upd$views$rename)) {
-    board <- apply_views_rename(upd$views$rename, board, dock_mgr, session)
+    board <- apply_views_rename(upd$views$rename, board)
   }
 
   if (!is.null(upd$views$active)) {
-    board <- apply_views_active(upd$views$active, board, dock_mgr, session)
+    board <- apply_views_active(upd$views$active, board)
   }
 
   board

--- a/R/ext-delta.R
+++ b/R/ext-delta.R
@@ -85,8 +85,8 @@ validate_extensions_delta <- function(extensions, board) {
 }
 
 # Write each `extensions$mod` delta into the live extension `state`
-# reactiveVals built by `board_server_callback()` (reachable via
-# `dock_mgr$ext_res`). Mirrors blockr.core's `apply_block_mod_delta()`:
+# reactiveVals built by `board_server_callback()` (its `ext_res`).
+# Mirrors blockr.core's `apply_block_mod_delta()`:
 # only entries that actually change are written, so unchanged values do
 # not spuriously invalidate downstream reactives.
 apply_extensions_mod <- function(mod, ext_res) {

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -216,14 +216,14 @@ dock_panel_groups <- function(session = get_session()) {
   )
 }
 
-#' Swap the contents of `dock_mgr$active_dock` to mirror a different dock.
+#' Swap the contents of the `active_dock` mirror to a different dock.
 #'
-#' Extensions hold a stable reference to `dock_mgr$active_dock` (a
-#' `reactiveValues`). When the user switches views, this function
-#' copies the new view's dock module result into it so extensions
-#' transparently see the new dock without needing to re-bind.
+#' Extensions hold a stable reference to the `active_dock` `reactiveValues`.
+#' When the user switches views, this function copies the new view's dock
+#' module result into it so extensions transparently see the new dock
+#' without needing to re-bind.
 #'
-#' @param rv The `reactiveValues` to update (`dock_mgr$active_dock`).
+#' @param rv The `active_dock` `reactiveValues` to update.
 #' @param dock A dock module result (list with `layout`, `proxy`, etc.).
 #'
 #' @noRd

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -514,35 +514,34 @@ apply_views_active <- function(active, board) {
 # move the block / ext UIs across, and point active_dock and the nav at
 # it. The board's active marker is set by the caller; this drives the
 # live session state.
-switch_active_view <- function(active, dock_mgr, session) {
+switch_active_view <- function(active, docks, active_dock, current_active, vs,
+                               session) {
 
-  state <- isolate(dock_mgr$vs$state)
-  old_active <- active_view(state)
+  old <- isolate(current_active())
 
-  if (identical(old_active, active)) {
+  if (identical(old, active)) {
     return(invisible())
   }
 
-  if (exists(active, envir = dock_mgr$docks, inherits = FALSE)) {
+  if (exists(active, envir = docks, inherits = FALSE)) {
 
     # switch-view must fire before show_view_ui so the target dock carries
     # blockr-view-dock-active; otherwise move-element drops DOM moves into an
     # inactive dock.
     session$sendCustomMessage(
       "switch-view",
-      list(
-        id = session$ns(as_view_handle_id(dock_mgr$docks[[active]]$dock_id))
-      )
+      list(id = session$ns(as_view_handle_id(active)))
     )
 
-    hide_view_ui(old_active, dock_mgr$docks)
-    show_view_ui(active, dock_mgr$docks)
-    update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[active]])
+    hide_view_ui(old, docks)
+    show_view_ui(active, docks)
+    update_active_dock(active_dock, docks[[active]])
   }
 
+  state <- isolate(vs$state)
   active_view(state) <- active
-  dock_mgr$vs$state <- state
-  dock_mgr$current_active(active)
+  vs$state <- state
+  current_active(active)
 
   session$sendInputMessage(
     "view_nav",

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -392,26 +392,7 @@ apply_views_rm <- function(rm_ids, board, dock_mgr = NULL, session = NULL) {
   was_active_removed <- active_view(state) %in% rm_ids
 
   for (v in rm_ids) {
-
-    if (exists(v, envir = dock_mgr$docks, inherits = FALSE)) {
-
-      rm_dock <- dock_mgr$docks[[v]]
-
-      # Park the view's block / ext UIs back in the offcanvas before the
-      # dock is destroyed — otherwise a block that survives in another
-      # view loses its (board-level, single-instance) UI along with the
-      # torn-down panel container. No-op for views already parked.
-      hide_view_ui(v, dock_mgr$docks)
-
-      destroy_module(rm_dock$dock_id, session = session)
-      removeUI(
-        selector = paste0("#", ns(as_view_handle_id(rm_dock$dock_id))),
-        immediate = TRUE,
-        session = session
-      )
-      rm(list = v, envir = dock_mgr$docks)
-    }
-
+    teardown_view(v, session, dock_mgr$docks)
     state[[v]] <- NULL
   }
 
@@ -474,8 +455,6 @@ apply_views_add <- function(add_views, board, dock_mgr = NULL, session = NULL) {
     return(board)
   }
 
-  ns <- session$ns
-
   for (v in names(add_views)) {
 
     # The view id (minted in augment_board_update.dock_board) is the dock
@@ -484,36 +463,17 @@ apply_views_add <- function(add_views, board, dock_mgr = NULL, session = NULL) {
       next
     }
 
-    dock_output_id <- ns(NS(v, dock_id()))
-
-    insertUI(
-      selector = paste0("#", ns("view_container")),
-      where = "beforeEnd",
-      ui = div(
-        id = ns(as_view_handle_id(v)),
-        class = "blockr-view-dock",
-        dockViewR::dock_view_output(
-          dock_output_id,
-          width = "100%",
-          height = "100%"
-        ),
-        uiOutput(NS(ns(v), "empty_prompt"))
-      ),
-      immediate = TRUE,
-      session = session
-    )
-
-    dock_res <- manage_dock(
+    instantiate_view(
       v,
+      add_views[[v]],
       dock_mgr$board_rv,
       dock_mgr$update,
       dock_mgr$triggers,
-      layout = add_views[[v]],
+      session,
+      dock_mgr$docks,
       blocks = board_blocks(board),
       extensions = dock_extensions(board)
     )
-    dock_res$dock_id <- v
-    dock_mgr$docks[[v]] <- dock_res
 
     session$sendInputMessage(
       "view_nav",

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -514,7 +514,7 @@ apply_views_active <- function(active, board) {
 # move the block / ext UIs across, and point active_dock and the nav at
 # it. The board's active marker is set by the caller; this drives the
 # live session state.
-switch_active_view <- function(active, docks, active_dock, current_active, vs,
+switch_active_view <- function(active, docks, active_dock, current_active,
                                session) {
 
   old <- isolate(current_active())
@@ -538,9 +538,6 @@ switch_active_view <- function(active, docks, active_dock, current_active, vs,
     update_active_dock(active_dock, docks[[active]])
   }
 
-  state <- isolate(vs$state)
-  active_view(state) <- active
-  vs$state <- state
   current_active(active)
 
   session$sendInputMessage(

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -70,14 +70,21 @@ normalize_views_delta <- function(views, board) {
   views
 }
 
-# Mint a fresh id for each added view — unique against the board's
-# existing ids — carrying the key (the desired display name) onto the
-# view as its name.
+# Mint a stable id for each added view that still needs one — unique against
+# the board's existing ids — carrying the key (the desired display name) onto
+# the view as its name. A view that already has a name (and thus an id key,
+# from an earlier pass) is left untouched, which keeps augment idempotent:
+# the update lifecycle re-runs augment until it stops changing the payload, so
+# re-minting on every pass would loop a view add forever.
 mint_added_view_ids <- function(add, reserved) {
-  set_names(
-    map(`view_name<-`, add, names(add)),
-    rand_names(reserved, n = length(add))
-  )
+  needs <- lgl_ply(add, function(x) is.null(view_name(x)))
+  if (!any(needs)) {
+    return(add)
+  }
+  add[needs] <- map(`view_name<-`, add[needs], names(add)[needs])
+  ids <- names(add)
+  ids[needs] <- rand_names(c(reserved, ids[!needs]), n = sum(needs))
+  set_names(add, ids)
 }
 
 # Structural + cross-reference checks for the `views` slice. Runs after
@@ -361,7 +368,7 @@ merge_views_mod <- function(user_mod, layouts, rm_block_ids,
   out
 }
 
-apply_views_rm <- function(rm_ids, board, dock_mgr = NULL, session = NULL) {
+apply_views_rm <- function(rm_ids, board) {
 
   layouts <- board_layouts(board)
   old_active <- active_view(layouts)
@@ -383,60 +390,10 @@ apply_views_rm <- function(rm_ids, board, dock_mgr = NULL, session = NULL) {
 
   board_layouts(board) <- layouts
 
-  if (is.null(dock_mgr) || is.null(session)) {
-    return(board)
-  }
-
-  ns <- session$ns
-  state <- isolate(dock_mgr$vs$state)
-  was_active_removed <- active_view(state) %in% rm_ids
-
-  for (v in rm_ids) {
-    teardown_view(v, session, dock_mgr$docks)
-    state[[v]] <- NULL
-  }
-
-  if (length(state) && is.null(active_view(state))) {
-    active_view(state) <- names(state)[[1L]]
-  }
-
-  dock_mgr$vs$state <- state
-
-  if (was_active_removed && length(state)) {
-
-    new_active <- active_view(state)
-
-    if (exists(new_active, envir = dock_mgr$docks, inherits = FALSE)) {
-
-      # switch-view must fire before show_view_ui so the target dock carries
-      # blockr-view-dock-active; otherwise move-element drops DOM moves into
-      # an inactive dock.
-      session$sendCustomMessage(
-        "switch-view",
-        list(
-          id = ns(as_view_handle_id(dock_mgr$docks[[new_active]]$dock_id))
-        )
-      )
-
-      show_view_ui(new_active, dock_mgr$docks)
-      update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[new_active]])
-    }
-
-    dock_mgr$current_active(new_active)
-  }
-
-  for (v in rm_ids) {
-    session$sendInputMessage("view_nav", list(remove = v))
-  }
-
-  if (length(state)) {
-    session$sendInputMessage("view_nav", list(value = active_view(state)))
-  }
-
   board
 }
 
-apply_views_add <- function(add_views, board, dock_mgr = NULL, session = NULL) {
+apply_views_add <- function(add_views, board) {
 
   layouts <- board_layouts(board)
 
@@ -451,49 +408,10 @@ apply_views_add <- function(add_views, board, dock_mgr = NULL, session = NULL) {
 
   board_layouts(board) <- layouts
 
-  if (is.null(dock_mgr) || is.null(session)) {
-    return(board)
-  }
-
-  for (v in names(add_views)) {
-
-    # The view id (minted in augment_board_update.dock_board) is the dock
-    # module id and the stem of the DOM ids — no separate runtime mint.
-    if (exists(v, envir = dock_mgr$docks, inherits = FALSE)) {
-      next
-    }
-
-    instantiate_view(
-      v,
-      add_views[[v]],
-      dock_mgr$board_rv,
-      dock_mgr$update,
-      dock_mgr$triggers,
-      session,
-      dock_mgr$docks,
-      blocks = board_blocks(board),
-      extensions = dock_extensions(board)
-    )
-
-    session$sendInputMessage(
-      "view_nav",
-      list(add = list(id = v, name = view_name(add_views[[v]])))
-    )
-  }
-
-  state <- isolate(dock_mgr$vs$state)
-
-  for (v in names(add_views)) {
-
-    state[[v]] <- bare_view(add_views[[v]])
-  }
-
-  dock_mgr$vs$state <- state
-
   board
 }
 
-apply_views_mod <- function(mod_views, board, dock_mgr = NULL) {
+apply_views_mod <- function(mod_views, board) {
 
   layouts <- board_layouts(board)
 
@@ -516,34 +434,6 @@ apply_views_mod <- function(mod_views, board, dock_mgr = NULL) {
 
   board_layouts(board) <- layouts
 
-  if (is.null(dock_mgr)) {
-    return(board)
-  }
-
-  for (v in names(mod_views)) {
-
-    if (!exists(v, envir = dock_mgr$docks, inherits = FALSE)) {
-      next
-    }
-
-    live <- tryCatch(
-      isolate(dock_mgr$docks[[v]]$layout()),
-      error = function(e) NULL
-    )
-
-    if (!is.null(live) && layouts_match(live, mod_views[[v]])) {
-      next
-    }
-
-    apply_layout_diff(
-      view = v,
-      target = mod_views[[v]],
-      proxy = dock_mgr$docks[[v]]$proxy,
-      blocks = board_blocks(board),
-      extensions = dock_extensions(board)
-    )
-  }
-
   board
 }
 
@@ -551,8 +441,7 @@ apply_views_mod <- function(mod_views, board, dock_mgr = NULL) {
 # `rename` is a named list mapping view id to its new display name. The
 # id is untouched, so the dock module, DOM element and registry key all
 # survive — no layout rebuild, no re-keying.
-apply_views_rename <- function(rename, board, dock_mgr = NULL,
-                               session = NULL) {
+apply_views_rename <- function(rename, board) {
 
   layouts <- board_layouts(board)
 
@@ -563,27 +452,6 @@ apply_views_rename <- function(rename, board, dock_mgr = NULL,
   }
 
   board_layouts(board) <- layouts
-
-  if (is.null(dock_mgr) || is.null(session)) {
-    return(board)
-  }
-
-  state <- isolate(dock_mgr$vs$state)
-
-  for (id in names(rename)) {
-    if (id %in% names(state)) {
-      view_name(state[[id]]) <- rename[[id]]
-    }
-  }
-
-  dock_mgr$vs$state <- state
-
-  for (id in names(rename)) {
-    session$sendInputMessage(
-      "view_nav",
-      list(rename = list(id = id, to = rename[[id]]))
-    )
-  }
 
   board
 }
@@ -633,18 +501,11 @@ layouts_match <- function(a, b) {
   identical(spec_a, spec_b)
 }
 
-apply_views_active <- function(active, board, dock_mgr = NULL,
-                               session = NULL) {
+apply_views_active <- function(active, board) {
 
   layouts <- board_layouts(board)
   active_view(layouts) <- active
   board_layouts(board) <- layouts
-
-  if (is.null(dock_mgr) || is.null(session)) {
-    return(board)
-  }
-
-  switch_active_view(active, dock_mgr, session)
 
   board
 }
@@ -655,7 +516,6 @@ apply_views_active <- function(active, board, dock_mgr = NULL,
 # live session state.
 switch_active_view <- function(active, dock_mgr, session) {
 
-  ns <- session$ns
   state <- isolate(dock_mgr$vs$state)
   old_active <- active_view(state)
 
@@ -663,20 +523,25 @@ switch_active_view <- function(active, dock_mgr, session) {
     return(invisible())
   }
 
-  session$sendCustomMessage(
-    "switch-view",
-    list(
-      id = ns(as_view_handle_id(dock_mgr$docks[[active]]$dock_id))
-    )
-  )
+  if (exists(active, envir = dock_mgr$docks, inherits = FALSE)) {
 
-  hide_view_ui(old_active, dock_mgr$docks)
-  show_view_ui(active, dock_mgr$docks)
+    # switch-view must fire before show_view_ui so the target dock carries
+    # blockr-view-dock-active; otherwise move-element drops DOM moves into an
+    # inactive dock.
+    session$sendCustomMessage(
+      "switch-view",
+      list(
+        id = session$ns(as_view_handle_id(dock_mgr$docks[[active]]$dock_id))
+      )
+    )
+
+    hide_view_ui(old_active, dock_mgr$docks)
+    show_view_ui(active, dock_mgr$docks)
+    update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[active]])
+  }
 
   active_view(state) <- active
   dock_mgr$vs$state <- state
-
-  update_active_dock(dock_mgr$active_dock, dock_mgr$docks[[active]])
   dock_mgr$current_active(active)
 
   session$sendInputMessage(

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -514,10 +514,10 @@ apply_views_active <- function(active, board) {
 # move the block / ext UIs across, and point active_dock and the nav at
 # it. The board's active marker is set by the caller; this drives the
 # live session state.
-switch_active_view <- function(active, docks, active_dock, current_active,
+switch_active_view <- function(active, docks, active_dock, client_active,
                                session) {
 
-  old <- isolate(current_active())
+  old <- isolate(client_active())
 
   if (identical(old, active)) {
     return(invisible())
@@ -538,7 +538,7 @@ switch_active_view <- function(active, docks, active_dock, current_active,
     update_active_dock(active_dock, docks[[active]])
   }
 
-  current_active(active)
+  client_active(active)
 
   session$sendInputMessage(
     "view_nav",

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -13,18 +13,10 @@ test_that("board server", {
       expect_type(res, "list")
       expect_named(res, c("dock", "actions", "view_data"))
 
-      dock <- res[["dock"]]
-
-      expect_type(dock, "list")
-      expect_named(
-        dock,
-        c("layout", "proxy", "prev_active_group", "n_panels",
-          "active_group_trail")
-      )
-
-      expect_s3_class(dock[["layout"]], "reactive")
-      expect_s3_class(dock[["proxy"]], "dock_view_proxy")
-      expect_s3_class(dock[["prev_active_group"]], "reactive")
+      # `dock` is the active-dock reactiveValues handle the extensions
+      # receive; its contents are filled by the reconcile pass (init render),
+      # exercised by the app test — here we assert only the returned shape.
+      expect_s3_class(res[["dock"]], "reactivevalues")
       expect_s3_class(res[["view_data"]], "reactive")
     }
   )
@@ -44,18 +36,7 @@ test_that("board server", {
         c("dock", "actions", "view_data", "edit_board_extension")
       )
 
-      dock <- res[["dock"]]
-
-      expect_type(dock, "list")
-      expect_named(
-        dock,
-        c("layout", "proxy", "prev_active_group", "n_panels",
-          "active_group_trail")
-      )
-
-      expect_s3_class(dock[["layout"]], "reactive")
-      expect_s3_class(dock[["proxy"]], "dock_view_proxy")
-      expect_s3_class(dock[["prev_active_group"]], "reactive")
+      expect_s3_class(res[["dock"]], "reactivevalues")
 
       ext <- res[["edit_board_extension"]]
 
@@ -233,10 +214,10 @@ test_that("live_view_data is NULL while any view layout is uninitialized", {
       state = dock_layouts(A = new_dock_layout(), B = new_dock_layout())
     )
     ids <- names(vs$state)
-    dock_mgr <- new_dock_manager()
-    dock_mgr$docks[[ids[[1L]]]] <- list(layout = layouts$A)
-    dock_mgr$docks[[ids[[2L]]]] <- list(layout = layouts$B)
-    list(vd = live_view_data(vs, dock_mgr), vs = vs)
+    docks <- new.env(parent = emptyenv())
+    docks[[ids[[1L]]]] <- list(layout = layouts$A)
+    docks[[ids[[2L]]]] <- list(layout = layouts$B)
+    list(vd = live_view_data(vs, docks), vs = vs)
   })
 
   expect_null(isolate(res$vd()))

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -56,8 +56,7 @@ test_that("board server", {
   withr::defer(if (!ms$isClosed()) ms$close())
 
   res <- with_mock_context(ms, {
-    manage_dock("dock_main", board_rv_2, update = reactiveVal(),
-                actions = list())
+    manage_dock("dock_main", board_rv_2, update = reactiveVal())
   })
 
   ms$flushReact()
@@ -111,8 +110,7 @@ test_that("board server", {
   withr::defer(if (!ms2$isClosed()) ms2$close())
 
   res2 <- with_mock_context(ms2, {
-    manage_dock("dock_main", board_rv_2, update = reactiveVal(),
-                actions = list())
+    manage_dock("dock_main", board_rv_2, update = reactiveVal())
   })
 
   ms2$flushReact()
@@ -161,7 +159,7 @@ test_that("board server", {
   upd <- reactiveVal()
 
   with_mock_context(ms3, {
-    manage_dock("dock_main", board_rv_2, update = upd, actions = list())
+    manage_dock("dock_main", board_rv_2, update = upd)
   })
 
   ms3$flushReact()

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -217,7 +217,8 @@ test_that("live_view_data is NULL while any view layout is uninitialized", {
     docks <- new.env(parent = emptyenv())
     docks[[ids[[1L]]]] <- list(layout = layouts$A)
     docks[[ids[[2L]]]] <- list(layout = layouts$B)
-    list(vd = live_view_data(vs, docks), vs = vs)
+    current_active <- reactiveVal(ids[[1L]])
+    list(vd = live_view_data(vs, docks, current_active), vs = vs)
   })
 
   expect_null(isolate(res$vd()))

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -11,7 +11,7 @@ test_that("board server", {
       res <- board_server_callback(board_rv_1, update = reactiveVal())
 
       expect_type(res, "list")
-      expect_named(res, c("dock", "actions", "view_data", "dock_mgr"))
+      expect_named(res, c("dock", "actions", "view_data"))
 
       dock <- res[["dock"]]
 
@@ -41,7 +41,7 @@ test_that("board server", {
       expect_type(res, "list")
       expect_named(
         res,
-        c("dock", "actions", "view_data", "dock_mgr", "edit_board_extension")
+        c("dock", "actions", "view_data", "edit_board_extension")
       )
 
       dock <- res[["dock"]]
@@ -365,35 +365,39 @@ test_that("validate_board_update.dock_board rejects bad extensions slot", {
   )
 })
 
-test_that("extensions slot writes controllable state via apply_board_update", {
+test_that("extensions mod state is applied via the update lifecycle", {
 
   board_rv <- board_args(
     blocks = c(a = new_dataset_block()),
     extensions = new_ctrl_extension(content = "# old")
   )
 
-  with_mock_session(
-    {
-      res <- board_server_callback(board_rv, update = reactiveVal())
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
 
-      content <- res$dock_mgr$ext_res$doc_extension$state$content
+  upd <- reactiveVal()
 
-      expect_s3_class(content, "reactiveVal")
-      expect_identical(isolate(content()), "# old")
+  res <- with_mock_context(ms, board_server_callback(board_rv, update = upd))
 
-      apply_board_update(
-        isolate(board_rv$board),
-        list(
-          extensions = list(
-            mod = list(doc_extension = list(content = "# new"))
-          )
-        ),
-        dock_mgr = res$dock_mgr
-      )
+  ms$flushReact()
 
-      expect_identical(isolate(content()), "# new")
-    }
+  # ext_res is spread into the callback result, so the extension's
+  # controllable state is reachable without a dock handle.
+  content <- res$doc_extension$state$content
+
+  expect_s3_class(content, "reactiveVal")
+  expect_identical(isolate(content()), "# old")
+
+  # An `extensions$mod` delta is applied by the closure observer, not the
+  # (now pure) apply hook.
+  upd(
+    list(
+      extensions = list(mod = list(doc_extension = list(content = "# new")))
+    )
   )
+  ms$flushReact()
+
+  expect_identical(isolate(content()), "# new")
 })
 
 test_that("extension servers can read peer extension state", {

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -208,15 +208,15 @@ test_that("live_view_data is NULL while any view layout is uninitialized", {
   })
 
   res <- with_mock_context(ms, {
-    vs <- reactiveValues(
-      state = dock_layouts(A = new_dock_layout(), B = new_dock_layout())
+    client_views <- reactiveVal(
+      dock_layouts(A = new_dock_layout(), B = new_dock_layout())
     )
-    ids <- names(vs$state)
+    ids <- names(client_views())
     docks <- new.env(parent = emptyenv())
     docks[[ids[[1L]]]] <- list(layout = layouts$A)
     docks[[ids[[2L]]]] <- list(layout = layouts$B)
-    current_active <- reactiveVal(ids[[1L]])
-    list(vd = live_view_data(vs, docks, current_active), vs = vs)
+    client_active <- reactiveVal(ids[[1L]])
+    list(vd = live_view_data(client_views, docks, client_active))
   })
 
   expect_null(isolate(res$vd()))

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -426,12 +426,11 @@ test_that("New view modal confirm submits an add-and-activate delta", {
 
   testServer(
     function(input, output, session) {
-      vs <- reactiveValues(state = board_layouts(brd))
+      client_views <- reactiveVal(board_layouts(brd))
       board <- reactiveValues(board = brd)
       add_view_observer(
-        vs,
+        client_views,
         session,
-        dock_mgr = NULL,
         board = board,
         update = function(x) captured <<- x
       )

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -163,7 +163,30 @@ test_that("rename flows through apply_board_update", {
   expect_identical(view_name(board_layouts(out)[["v1"]]), "New")
 })
 
-test_that("apply_views_rename syncs the nav and live state (runtime)", {
+test_that("augment_board_update is idempotent for a view add", {
+
+  # The update lifecycle re-runs augment until it stops changing the
+  # payload (preprocess_board_update). Minting a fresh id on every pass
+  # never converges and loops the view-add update, so a second augment of
+  # an already-augmented add must be a no-op.
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    layouts = list(Page = list("a"))
+  )
+
+  upd <- list(
+    views = list(add = setNames(list(dock_layout("a")), "Second"),
+                 active = "Second")
+  )
+
+  once <- augment_board_update(upd, brd)
+  twice <- augment_board_update(once, brd)
+
+  expect_identical(once, twice)
+  expect_identical(view_name(once$views$add[[1L]]), "Second")
+})
+
+test_that("reconcile_views syncs the nav and live state on rename", {
 
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block()),
@@ -176,15 +199,19 @@ test_that("apply_views_rename syncs the nav and live state (runtime)", {
     sendInputMessage = function(input_id, message) {
       sent[[length(sent) + 1L]] <<- message
       invisible()
-    }
+    },
+    sendCustomMessage = function(type, message) invisible()
   )
 
   dock_mgr <- new_dock_manager()
+  dock_mgr$current_active <- reactiveVal(active_view(board_layouts(brd)))
   dock_mgr$vs <- reactiveValues(state = board_layouts(brd))
 
-  isolate(
-    apply_views_rename(setNames(list("New"), "v1"), brd, dock_mgr, session)
-  )
+  # The board carries the new name; the live state still has the old one, so
+  # reconcile detects the rename and relabels the nav + vs$state.
+  renamed <- apply_views_rename(setNames(list("New"), "v1"), brd)
+
+  isolate(reconcile_views(renamed, dock_mgr, session))
 
   expect_true(
     any(lgl_ply(sent, function(m) {
@@ -608,7 +635,7 @@ test_that("blocks$rm augment carries through to apply for view cleanup", {
   )
 })
 
-test_that("apply_views_rm syncs the view_nav switcher on lifecycle removal", {
+test_that("reconcile_views syncs the view_nav switcher on removal", {
 
   run_rm <- function(rm_label, active_label) {
 
@@ -626,7 +653,8 @@ test_that("apply_views_rm syncs the view_nav switcher on lifecycle removal", {
       sendInputMessage = function(input_id, message) {
         sent[[length(sent) + 1L]] <<- message
         invisible()
-      }
+      },
+      sendCustomMessage = function(type, message) invisible()
     )
 
     dock_mgr <- new_dock_manager()
@@ -635,23 +663,24 @@ test_that("apply_views_rm syncs the view_nav switcher on lifecycle removal", {
     active_view(state) <- name_to_id[[active_label]]
     dock_mgr$vs <- reactiveValues(state = state)
 
-    isolate(apply_views_rm(name_to_id[[rm_label]], brd, dock_mgr, session))
+    # Remove on the board (pure), then reconcile the live session against it.
+    removed <- apply_views_rm(name_to_id[[rm_label]], brd)
+
+    isolate(reconcile_views(removed, dock_mgr, session))
 
     list(sent = sent, ids = name_to_id)
   }
 
+  # Removing a non-active view drops its tab; the active selection is
+  # unchanged, so no `value` message is needed.
   non_active <- run_rm("B", "A")
   expect_true(
     any(lgl_ply(non_active$sent, function(m) {
       identical(m$remove, non_active$ids[["B"]])
     }))
   )
-  expect_true(
-    any(lgl_ply(non_active$sent, function(m) {
-      identical(m$value, non_active$ids[["A"]])
-    }))
-  )
 
+  # Removing the active view drops its tab and switches to a survivor.
   was_active <- run_rm("A", "A")
   expect_true(
     any(lgl_ply(was_active$sent, function(m) {
@@ -665,7 +694,7 @@ test_that("apply_views_rm syncs the view_nav switcher on lifecycle removal", {
   )
 })
 
-test_that("apply_views_rm skips nav sync on the headless path", {
+test_that("apply_views_rm is a pure board transform", {
 
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -203,22 +203,32 @@ test_that("reconcile_views syncs the nav and live state on rename", {
     sendCustomMessage = function(type, message) invisible()
   )
 
-  dock_mgr <- new_dock_manager()
-  dock_mgr$current_active <- reactiveVal(active_view(board_layouts(brd)))
-  dock_mgr$vs <- reactiveValues(state = board_layouts(brd))
+  # Pre-populate the registry so reconcile sees the views as already
+  # instantiated (no DOM surgery); their live layout is pending (NULL) so the
+  # layout-mod check is skipped and only the rename fires.
+  docks <- new.env(parent = emptyenv())
+  for (id in names(board_layouts(brd))) {
+    docks[[id]] <- list(layout = function() NULL)
+  }
+  active_dock <- reactiveValues()
+  current_active <- reactiveVal(active_view(board_layouts(brd)))
+  vs <- reactiveValues(state = board_layouts(brd))
 
   # The board carries the new name; the live state still has the old one, so
   # reconcile detects the rename and relabels the nav + vs$state.
   renamed <- apply_views_rename(setNames(list("New"), "v1"), brd)
 
-  isolate(reconcile_views(renamed, dock_mgr, session))
+  isolate(
+    reconcile_views(renamed, function(...) NULL, NULL, docks, active_dock,
+                    current_active, vs, session)
+  )
 
   expect_true(
     any(lgl_ply(sent, function(m) {
       identical(m$rename$id, "v1") && identical(m$rename$to, "New")
     }))
   )
-  expect_identical(view_name(isolate(dock_mgr$vs$state)[["v1"]]), "New")
+  expect_identical(view_name(isolate(vs$state)[["v1"]]), "New")
 })
 
 test_that("blocks$rm auto-augments views$mod for every affected view", {
@@ -657,16 +667,32 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
       sendCustomMessage = function(type, message) invisible()
     )
 
-    dock_mgr <- new_dock_manager()
-    dock_mgr$current_active <- reactiveVal(name_to_id[[active_label]])
+    # Registry pre-populated for every view; the DOM helpers are mocked so the
+    # test exercises reconcile's nav-sync, not the live teardown / switch.
+    docks <- new.env(parent = emptyenv())
+    for (id in names(state)) docks[[id]] <- list(layout = function() NULL)
+    active_dock <- reactiveValues()
+    current_active <- reactiveVal(name_to_id[[active_label]])
 
     active_view(state) <- name_to_id[[active_label]]
-    dock_mgr$vs <- reactiveValues(state = state)
+    vs <- reactiveValues(state = state)
 
     # Remove on the board (pure), then reconcile the live session against it.
     removed <- apply_views_rm(name_to_id[[rm_label]], brd)
 
-    isolate(reconcile_views(removed, dock_mgr, session))
+    with_mocked_bindings(
+      isolate(
+        reconcile_views(removed, function(...) NULL, NULL, docks, active_dock,
+                        current_active, vs, session)
+      ),
+      teardown_view = function(view_id, session, docks) {
+        rm(list = view_id, envir = docks)
+        invisible()
+      },
+      hide_view_ui = function(...) NULL,
+      show_view_ui = function(...) NULL,
+      update_active_dock = function(...) NULL
+    )
 
     list(sent = sent, ids = name_to_id)
   }

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -219,7 +219,7 @@ test_that("reconcile_views syncs the nav and live state on rename", {
   renamed <- apply_views_rename(setNames(list("New"), "v1"), brd)
 
   isolate(
-    reconcile_views(renamed, function(...) NULL, NULL, docks, active_dock,
+    reconcile_views(renamed, function(...) NULL, docks, active_dock,
                     current_active, vs, session)
   )
 
@@ -682,7 +682,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
 
     with_mocked_bindings(
       isolate(
-        reconcile_views(removed, function(...) NULL, NULL, docks, active_dock,
+        reconcile_views(removed, function(...) NULL, docks, active_dock,
                         current_active, vs, session)
       ),
       teardown_view = function(view_id, session, docks) {

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -685,7 +685,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
         reconcile_views(removed, function(...) NULL, docks, active_dock,
                         client_active, client_views, session)
       ),
-      teardown_view = function(view_id, session, docks) {
+      remove_view = function(view_id, session, docks) {
         rm(list = view_id, envir = docks)
         invisible()
       },

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -211,16 +211,16 @@ test_that("reconcile_views syncs the nav and live state on rename", {
     docks[[id]] <- list(layout = function() NULL)
   }
   active_dock <- reactiveValues()
-  current_active <- reactiveVal(active_view(board_layouts(brd)))
-  vs <- reactiveValues(state = board_layouts(brd))
+  client_active <- reactiveVal(active_view(board_layouts(brd)))
+  client_views <- reactiveVal(board_layouts(brd))
 
   # The board carries the new name; the live state still has the old one, so
-  # reconcile detects the rename and relabels the nav + vs$state.
+  # reconcile detects the rename and relabels the nav + client_views.
   renamed <- apply_views_rename(setNames(list("New"), "v1"), brd)
 
   isolate(
     reconcile_views(renamed, function(...) NULL, docks, active_dock,
-                    current_active, vs, session)
+                    client_active, client_views, session)
   )
 
   expect_true(
@@ -228,7 +228,7 @@ test_that("reconcile_views syncs the nav and live state on rename", {
       identical(m$rename$id, "v1") && identical(m$rename$to, "New")
     }))
   )
-  expect_identical(view_name(isolate(vs$state)[["v1"]]), "New")
+  expect_identical(view_name(isolate(client_views())[["v1"]]), "New")
 })
 
 test_that("blocks$rm auto-augments views$mod for every affected view", {
@@ -672,10 +672,10 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
     docks <- new.env(parent = emptyenv())
     for (id in names(state)) docks[[id]] <- list(layout = function() NULL)
     active_dock <- reactiveValues()
-    current_active <- reactiveVal(name_to_id[[active_label]])
+    client_active <- reactiveVal(name_to_id[[active_label]])
 
     active_view(state) <- name_to_id[[active_label]]
-    vs <- reactiveValues(state = state)
+    client_views <- reactiveVal(state)
 
     # Remove on the board (pure), then reconcile the live session against it.
     removed <- apply_views_rm(name_to_id[[rm_label]], brd)
@@ -683,7 +683,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
     with_mocked_bindings(
       isolate(
         reconcile_views(removed, function(...) NULL, docks, active_dock,
-                        current_active, vs, session)
+                        client_active, client_views, session)
       ),
       teardown_view = function(view_id, session, docks) {
         rm(list = view_id, envir = docks)


### PR DESCRIPTION
## Summary

- `apply_board_update.dock_board` is a **pure reducer** over `board_layouts`. All live view surgery (instantiate / teardown / restore / rename / switch) runs in one closure-resident `reconcile_views` observer driven by the committed `board$board`, collapsing the previously duplicated delta-driven and UI-driven view CRUD into a single pass.
- **The dock "manager" object is gone.** `new_dock_manager()` and `init_view_docks()` are deleted; the per-session dock state (`docks` registry, `active_dock`, `current_active`, `vs`) is ordinary closure-private state passed to helpers as individual args — not a handle threaded back through `dot_args`. **View init is just the empty-`docks` case of reconcile** (create all, show the active one), so there's no separate init path.
- **Active-view state collapsed** to a single server-side record (`current_active`); `board_layouts`' active is the persisted source of truth, the DOM class is its render.
- Fixes a **pre-existing view-add loop**: `augment_board_update.dock_board` is now idempotent (a view id is minted once, not re-minted on every augment pass) + a regression test.

Validated: full suite + lint green, and the real app drives startup + add / switch / rename / remove with no reconcile↔sync loop and correct active tracking.

**Follow-up:** #177 — open question on the multi-view *mounting model* (all views mounted at once + single-instance block shuttling; the declarative active-class cleanup rides on that decision). Out of scope here.

Stacked on #175 (`174-container-active`); retarget to `main` after it merges. Supersedes #170.

Fixes #164
