### PR TITLE
Clean up the Edit board extension UI

### DIFF
--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -25,84 +25,90 @@ new_edit_board_extension <- function(...) {
 }
 
 blk_ext_ui <- function(id, board) {
-  tagList(
-    fluidRow(
-      column(
-        4,
-        selectInput(
-          NS(id, "registry_select"),
-          "Select block from registry",
-          choices = list_blocks()
-        )
-      ),
-      column(
-        4,
-        textInput(
-          inputId = NS(id, "block_id"),
-          label = "Block ID",
-          value = rand_names(board_block_ids(board))
-        )
-      ),
-      column(
-        4,
+
+  div(
+    class = "blockr-ext-edit",
+    div(
+      class = "blockr-ext-edit-section",
+      div(
+        class = "blockr-ext-edit-row",
+        div(
+          class = "flex-grow-1",
+          selectInput(
+            NS(id, "registry_select"),
+            "Select block from registry",
+            choices = list_blocks(),
+            width = "100%"
+          )
+        ),
+        div(
+          class = "flex-grow-1",
+          textInput(
+            NS(id, "block_id"),
+            "Block ID",
+            value = rand_names(board_block_ids(board)),
+            width = "100%"
+          )
+        ),
         actionButton(
           NS(id, "confirm_add"),
           "Add block",
-          class = "btn-success"
-        )
-      )
-    ),
-    fluidRow(
-      column(
-        4,
-        selectInput(
-          NS(id, "block_select"),
-          "Select block(s) from board",
-          choices = board_block_ids(board),
-          multiple = TRUE
+          icon = icon("plus"),
+          class = "btn-primary"
         )
       ),
-      column(
-        4,
+      div(
+        class = "blockr-ext-edit-row",
+        div(
+          class = "flex-grow-1",
+          selectInput(
+            NS(id, "block_select"),
+            "Select block(s) from board",
+            choices = board_block_ids(board),
+            multiple = TRUE,
+            width = "100%"
+          )
+        ),
         actionButton(
           NS(id, "confirm_rm"),
           "Remove block",
+          icon = icon("trash"),
           class = "btn-danger"
         )
       )
     ),
-    DT::dataTableOutput(NS(id, "links_dt")),
-    fluidRow(
-      column(
-        3,
-        textInput(
-          NS(id, "new_link_id"),
-          "Next link ID",
-          value = rand_names(board_link_ids(board))
-        )
+    div(
+      class = "blockr-ext-edit-section",
+      div(
+        class = "blockr-ext-edit-links",
+        DT::dataTableOutput(NS(id, "links_dt"))
       ),
-      column(
-        3,
+      div(
+        class = "blockr-ext-edit-row",
+        div(
+          class = "flex-grow-1",
+          textInput(
+            NS(id, "new_link_id"),
+            "Next link ID",
+            value = rand_names(board_link_ids(board)),
+            width = "100%"
+          )
+        ),
         actionButton(
           NS(id, "add_link"),
           "Add link row",
           icon = icon("plus")
-        )
-      ),
-      column(
-        3,
+        ),
         actionButton(
           NS(id, "rm_link"),
           "Remove row(s)",
           icon = icon("minus")
-        )
-      ),
-      column(
-        3,
+        ),
         actionButton(
           NS(id, "modify_links"),
           "Apply changes",
-          class = "btn-success"
+          icon = icon("check"),
+          class = "btn-primary"
         )
       )
     )
@@ -282,8 +288,9 @@ link_dt <- function(dat, ns, board) {
       ),
       dom = "tp",
       ordering = FALSE,
+      autoWidth = FALSE,
       columnDefs = list(
-        list(targets = 0, width = "125px")
+        list(targets = 0, width = "90px")
       )
     ),
     rownames = FALSE,
@@ -369,7 +376,7 @@ dt_selectize <- function(id, val, choices, create = FALSE) {
   res <- htmltools::tagQuery(
     res
   )$addAttrs(
-    style = "width: 175px; margin-bottom: 0;"
+    style = "min-width: 120px; width: 100%; margin-bottom: 0;"
   )$allTags()
 
   as.character(res)

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -103,7 +103,10 @@ blk_ext_ui <- function(id, board) {
           NS(id, "rm_link"),
           "Remove row(s)",
           icon = icon("minus")
-        ),
+        )
+      ),
+      div(
+        class = "blockr-ext-edit-apply",
         actionButton(
           NS(id, "modify_links"),
           "Apply changes",
@@ -124,6 +127,7 @@ blk_ext_srv <- function(id, board, update, ...) {
       add_block_observer(input, board, update, session)
       remove_block_observer(input, board, update, session)
       update_block_select_observer(board, session)
+      toggle_remove_block_observer(input, session)
 
       upd <- reactiveValues(
         add = links(),
@@ -152,6 +156,9 @@ blk_ext_srv <- function(id, board, update, ...) {
       add_link_observer(input, board, upd, session)
       rm_link_observer(input, board, upd, session)
       modify_link_observer(input, board, upd, session, links_proxy, update)
+
+      toggle_remove_link_observer(input, session)
+      toggle_apply_changes_observer(upd, session)
 
       NULL
     }
@@ -233,6 +240,36 @@ update_block_select_observer <- function(board, session) {
       session,
       "block_select",
       choices = board_block_ids(board$board)
+    )
+  )
+}
+
+toggle_remove_block_observer <- function(input, session) {
+  observe(
+    updateActionButton(
+      session,
+      "confirm_rm",
+      disabled = !length(input$block_select)
+    )
+  )
+}
+
+toggle_remove_link_observer <- function(input, session) {
+  observe(
+    updateActionButton(
+      session,
+      "rm_link",
+      disabled = !length(input$links_dt_rows_selected)
+    )
+  )
+}
+
+toggle_apply_changes_observer <- function(upd, session) {
+  observe(
+    updateActionButton(
+      session,
+      "modify_links",
+      disabled = !length(upd$add) && !length(upd$rm)
     )
   )
 }

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -97,21 +97,20 @@ blk_ext_ui <- function(id, board) {
         actionButton(
           NS(id, "add_link"),
           "Add link row",
-          icon = icon("plus")
+          icon = icon("plus"),
+          class = "btn-primary"
         ),
         actionButton(
           NS(id, "rm_link"),
           "Remove row(s)",
-          icon = icon("minus")
-        )
-      ),
-      div(
-        class = "blockr-ext-edit-apply",
+          icon = icon("minus"),
+          class = "btn-danger"
+        ),
         actionButton(
           NS(id, "modify_links"),
           "Apply changes",
           icon = icon("check"),
-          class = "btn-primary"
+          class = "btn-success"
         )
       )
     )

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -996,6 +996,22 @@ label:has(input[type="file"]) {
   gap: 8px;
 }
 
+/* Match the action buttons' height to the inputs they sit beside. */
+.blockr-ext-edit .btn {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+/* "Apply changes" commits the staged link edits -- a distinct step from the
+   per-row staging controls, so it sits on its own right-aligned line. */
+.blockr-ext-edit-apply {
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* The flex gaps are the single source of spacing within the extension. */
 .blockr-ext-edit .form-group {
   margin-bottom: 0;
@@ -1017,6 +1033,12 @@ label:has(input[type="file"]) {
 .blockr-ext-edit table.dataTable td,
 .blockr-ext-edit table.dataTable th {
   padding: 8px 10px;
+}
+
+/* Give the pagination room from the table above and the controls below. */
+.blockr-ext-edit .dataTables_paginate {
+  margin-top: 12px;
+  padding: 4px 0;
 }
 
 /* Semantic action buttons must win over the .btn-default that Shiny's

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -56,6 +56,7 @@
   --blockr-color-primary-hover: var(--blockr-blue-700);
   --blockr-color-primary-bg: var(--blockr-blue-50);
   --blockr-color-error: #dc2626;
+  --blockr-color-success: #16a34a;
 }
 
 /* ============================================
@@ -1005,13 +1006,6 @@ label:has(input[type="file"]) {
   gap: 6px;
 }
 
-/* "Apply changes" commits the staged link edits -- a distinct step from the
-   per-row staging controls, so it sits on its own right-aligned line. */
-.blockr-ext-edit-apply {
-  display: flex;
-  justify-content: flex-end;
-}
-
 /* The flex gaps are the single source of spacing within the extension. */
 .blockr-ext-edit .form-group {
   margin-bottom: 0;
@@ -1035,10 +1029,20 @@ label:has(input[type="file"]) {
   padding: 8px 10px;
 }
 
-/* Give the pagination room from the table above and the controls below. */
-.blockr-ext-edit .dataTables_paginate {
-  margin-top: 12px;
-  padding: 4px 0;
+/* A small gap above the table (DataTables resets this margin with a
+   higher-specificity rule, so scope through .dataTables_wrapper to win). */
+.blockr-ext-edit .dataTables_wrapper .dataTables_paginate {
+  margin-top: 6px;
+}
+
+/* Space the page buttons; Bootstrap butts them together with collapsed
+   borders by default. */
+.blockr-ext-edit .dataTables_paginate .pagination {
+  gap: 4px;
+}
+
+.blockr-ext-edit .dataTables_paginate .pagination .page-link {
+  margin-left: 0;
 }
 
 /* Semantic action buttons must win over the .btn-default that Shiny's
@@ -1067,5 +1071,18 @@ label:has(input[type="file"]) {
 .blockr-ext-edit .btn-danger:focus {
   background-color: #b91c1c;
   border-color: #b91c1c;
+  color: #ffffff;
+}
+
+.blockr-ext-edit .btn-success {
+  background-color: var(--blockr-color-success);
+  border-color: var(--blockr-color-success);
+  color: #ffffff;
+}
+
+.blockr-ext-edit .btn-success:hover,
+.blockr-ext-edit .btn-success:focus {
+  background-color: #15803d;
+  border-color: #15803d;
   color: #ffffff;
 }

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -967,3 +967,83 @@ label:has(input[type="file"]) {
   margin: 0;
   font-size: var(--blockr-font-size-sm, 14px);
 }
+
+/* ============================================
+   Edit Board Extension
+   ============================================ */
+
+/* Padded container with consistent vertical rhythm so content does not hug
+   the panel borders, matching a block panel's internal gutter. */
+.blockr-ext-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 16px;
+}
+
+.blockr-ext-edit-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+/* Inputs and the buttons that act on them share a baseline-aligned row, so
+   action buttons no longer float above their inputs' labels. */
+.blockr-ext-edit-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+/* The flex gaps are the single source of spacing within the extension. */
+.blockr-ext-edit .form-group {
+  margin-bottom: 0;
+}
+
+/* Keep the links table within the panel: the selectize cells flex to fit
+   instead of overflowing at a fixed width and clipping the Input column. At
+   panel widths too narrow for the cells' min-width, the table scrolls
+   horizontally rather than clipping. */
+.blockr-ext-edit-links {
+  overflow-x: auto;
+}
+
+.blockr-ext-edit table.dataTable {
+  width: 100% !important;
+  margin: 0 !important;
+}
+
+.blockr-ext-edit table.dataTable td,
+.blockr-ext-edit table.dataTable th {
+  padding: 8px 10px;
+}
+
+/* Semantic action buttons must win over the .btn-default that Shiny's
+   actionButton() always carries; these scoped rules out-specify it so the
+   constructive and destructive actions are visually distinguishable. */
+.blockr-ext-edit .btn-primary {
+  background-color: var(--blockr-color-primary);
+  border-color: var(--blockr-color-primary);
+  color: #ffffff;
+}
+
+.blockr-ext-edit .btn-primary:hover,
+.blockr-ext-edit .btn-primary:focus {
+  background-color: var(--blockr-color-primary-hover);
+  border-color: var(--blockr-color-primary-hover);
+  color: #ffffff;
+}
+
+.blockr-ext-edit .btn-danger {
+  background-color: var(--blockr-color-error);
+  border-color: var(--blockr-color-error);
+  color: #ffffff;
+}
+
+.blockr-ext-edit .btn-danger:hover,
+.blockr-ext-edit .btn-danger:focus {
+  background-color: #b91c1c;
+  border-color: #b91c1c;
+  color: #ffffff;
+}

--- a/tests/testthat/test-ext-edit.R
+++ b/tests/testthat/test-ext-edit.R
@@ -258,6 +258,6 @@ test_that("dummy edit extension ui test", {
     new_dock_board(blocks = c(a = new_dataset_block()))
   )
 
-  expect_s3_class(ui, "shiny.tag.list")
-  expect_length(ui, 4L)
+  expect_s3_class(ui, "shiny.tag")
+  expect_identical(htmltools::tagGetAttribute(ui, "class"), "blockr-ext-edit")
 })


### PR DESCRIPTION
## Summary

- Wrap `blk_ext_ui()` in a padded, section-grouped flex container so content no longer hugs the panel border and each action button baseline-aligns with the input it acts on — removing the label-height offset and seating "Remove block" next to its select.
- Make the links-table selectizes fluid (`min-width` + `width: 100%`, `autoWidth = FALSE`, narrower ID column) so the table fits the panel at typical split widths and the Input column is never clipped, with an `overflow-x` fallback for very narrow panels.
- Distinguish constructive (Add block / Apply changes → primary) from destructive (Remove block → danger) actions via scoped CSS that out-specifies the `.btn-default` Shiny's `actionButton()` always carries.

Fixes #178