### PR TITLE
Read new block name from update delta to fix rename loop

### DIFF
--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -462,6 +462,29 @@ edit_block_server <- function(callbacks = list()) {
       id,
       function(input, output, session) {
 
+        cur_name <- reactive(
+          {
+            blk <- board_blocks(board$board)[[block_id]]
+            if (is_block(blk)) block_name(blk) else NULL
+          }
+        )
+
+        observeEvent(
+          cur_name(),
+          {
+            if (identical(cur_name(), input$block_name_in)) {
+              return()
+            }
+
+            updateTextInput(
+              session,
+              "block_name_in",
+              "Block name",
+              cur_name()
+            )
+          }
+        )
+
         observeEvent(
           input$block_name_in,
           {
@@ -470,9 +493,7 @@ edit_block_server <- function(callbacks = list()) {
               block_id %in% board_block_ids(board$board)
             )
 
-            cur <- block_name(board_blocks(board$board)[[block_id]])
-
-            if (identical(cur, input$block_name_in)) {
+            if (identical(cur_name(), input$block_name_in)) {
               return()
             }
 
@@ -485,35 +506,6 @@ edit_block_server <- function(callbacks = list()) {
                   )
                 )
               )
-            )
-          }
-        )
-
-        observeEvent(
-          update(),
-          {
-            upd <- update()
-
-            continue <- "blocks" %in% names(upd) &&
-              "mod" %in% names(upd$blocks) &&
-              block_id %in% names(upd$blocks$mod) &&
-              "block_name" %in% names(upd$blocks$mod[[block_id]])
-
-            if (!continue) {
-              return()
-            }
-
-            new <- block_name(board_blocks(board$board)[[block_id]])
-
-            if (identical(new, input$block_name_in)) {
-              return()
-            }
-
-            updateTextInput(
-              session,
-              "block_name_in",
-              "Block name",
-              new
             )
           }
         )

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -50,6 +50,67 @@ test_that("edit block server", {
   )
 })
 
+test_that("renaming a block does not loop (#181)", {
+
+  pushed <- character()
+
+  local_mocked_bindings(
+    updateTextInput = function(session, input_id, label, value) {
+      pushed <<- c(pushed, value)
+    }
+  )
+
+  board_named <- function(nm) {
+    blk <- new_dataset_block()
+    block_name(blk) <- nm
+    new_dock_board(blocks = c(a = blk))
+  }
+
+  board <- reactiveValues(board = board_named("Dataset"))
+
+  testServer(
+    edit_block_server(),
+    {
+      session$flushReact()
+
+      expect_identical(pushed, "Dataset")
+
+      n_before <- length(pushed)
+
+      session$setInputs(block_name_in = "Renamed block")
+      session$flushReact()
+
+      expect_identical(
+        update()$blocks$mod$a,
+        list(block_name = "Renamed block")
+      )
+
+      # The input sync reads the applied board, not the pending request.
+      # Core applies updates last (priority = -Inf), so board$board still
+      # holds the old name here -> the sync does not fire and no stale name
+      # is pushed back to loop (#181).
+      expect_length(pushed, n_before)
+
+      board$board <- board_named("Renamed block")
+      session$flushReact()
+
+      # Applied name now matches the input -> still no spurious push.
+      expect_length(pushed, n_before)
+
+      board$board <- board_named("External")
+      session$flushReact()
+
+      # A rename originating elsewhere still flows into the text input.
+      expect_identical(pushed, c("Dataset", "External"))
+    },
+    args = list(
+      block_id = "a",
+      board = board,
+      update = reactiveVal()
+    )
+  )
+})
+
 test_that("condition ui test", {
 
   insert_count <- 0L


### PR DESCRIPTION
## Summary

- Renaming a block in a `dock_board` triggered an infinite reactive loop: a single rename fired ~328 board updates, oscillating the name old↔new and re-rendering every board-update consumer (e.g. the `blockr.dag` canvas "blinking").
- Root cause: `edit_block_server()` synced the name text input from an observer that fired on the *pending* `update()` request but read the block name from the **live, not-yet-applied** board. `blockr.core` applies board updates last (`priority = -Inf`), so it read the stale old name and pushed it back into the input, which resubmitted it and looped.
- Fix: mirror `blockr.core::edit_block_server()` — derive a `cur_name()` reactive from the **applied** board and drive `updateTextInput()` off that, so the echo fires only once the rename is applied (by which point it already matches the input). Dock keeps its existing early-return guard so the echo stays a no-op for unchanged blocks — a plain `reactive()` does not dedupe, so without the guard it would re-push every block's name on each board change.
- Regression test (verified to fail on the pending-trigger bug) drives the full rename→apply cycle: no stale echo while pending, no oscillation once applied, and an externally-originated rename still syncs into the input.

Fixes #181
