### PR TITLE
Stop the view nav dropdown rendering each view twice

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Suggests:
     methods,
     withr,
     shinytest2,
+    xml2,
     knitr,
     rmarkdown
 Config/testthat/edition: 3

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -385,9 +385,11 @@ reconcile_views <- function(board, update, docks, active_dock,
 
   layouts <- board_layouts(board)
   want <- names(layouts)
+  labels <- view_names(layouts)
   server_active <- active_view(layouts)
   state <- isolate(client_views())
   have <- ls(docks)
+  shown <- names(state)
 
   for (v in setdiff(want, have)) {
 
@@ -403,12 +405,19 @@ reconcile_views <- function(board, update, docks, active_dock,
       active = identical(v, server_active)
     )
 
+    state[[v]] <- bare_view(layouts[[v]])
+  }
+
+  # Add a nav item only for views the nav doesn't already show. `board_ui`
+  # renders every seeded view statically, so this set is empty on init;
+  # gating on `docks` (also empty on init) instead re-adds each as a
+  # blank-labelled duplicate (#189). Label from the container `view_names()`,
+  # which resolves whether the name sits on the layout or is derived from id.
+  for (v in setdiff(want, shown)) {
     session$sendInputMessage(
       "view_nav",
-      list(add = list(id = v, name = view_name(layouts[[v]])))
+      list(add = list(id = v, name = labels[[v]]))
     )
-
-    state[[v]] <- bare_view(layouts[[v]])
   }
 
   for (v in setdiff(have, want)) {

--- a/inst/examples/multi-view/app.R
+++ b/inst/examples/multi-view/app.R
@@ -1,0 +1,11 @@
+library(blockr.core)
+library(blockr.dock)
+
+serve(
+  new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_dataset_block()),
+    layouts = list(First = dock_layout("a"), Second = dock_layout("b")),
+    active = "First"
+  ),
+  "my_board"
+)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -54,3 +54,33 @@ new_ctrl_extension <- function(content = "") {
     external_ctrl = TRUE
   )
 }
+
+# Parse the live view-nav dropdown of a running app into one row per view
+# (id, display label, active flag), so a browser test can state the nav
+# contract directly: one entry per view, unique ids, no blank labels. Reads
+# the rendered DOM (post static UI + any client-side `add`/`remove`), which
+# is where the two layers compose -- the seam a unit test can't observe.
+#
+# `blockr-view-item` is a prefix of the child `-name` / `-actions` classes,
+# so match the class token exactly (space-padded) rather than by substring.
+read_view_nav <- function(app, board_id = "my_board") {
+  by_class <- function(axis, token) {
+    sprintf(
+      "%s*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]",
+      axis, token
+    )
+  }
+
+  nav <- xml2::read_html(app$get_html(paste0("#", board_id, "-view_nav")))
+  items <- xml2::xml_find_all(nav, by_class("//", "blockr-view-item"))
+  name_nodes <- xml2::xml_find_first(
+    items, by_class(".//", "blockr-view-item-name")
+  )
+
+  data.frame(
+    id = xml2::xml_attr(items, "data-view-id"),
+    label = trimws(xml2::xml_text(name_nodes)),
+    active = grepl("(^| )active( |$)", xml2::xml_attr(items, "class")),
+    stringsAsFactors = FALSE
+  )
+}

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -291,6 +291,109 @@ test_that("layouts_to_board_observer is idempotent when nothing changed", {
   expect_identical(fire_count, 0L)
 })
 
+test_that("view nav renders one labelled item per view (#189)", {
+
+  board <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(First = dock_layout("a"), Second = dock_layout("b")),
+    active = "First"
+  )
+
+  ui <- view_nav_ui("brd", board_layouts(board))
+
+  items <- htmltools::tagQuery(ui)$find(".blockr-view-item")$selectedTags()
+  spans <- htmltools::tagQuery(ui)$find(".blockr-view-item-name")$selectedTags()
+
+  labels <- chr_ply(
+    spans,
+    function(span) {
+      txt <- span$children
+      if (length(txt)) as.character(txt[[1L]]) else ""
+    }
+  )
+
+  expect_length(items, 2L)
+  expect_setequal(labels, c("First", "Second"))
+})
+
+test_that("reconcile_views adds a nav item only for unshown views (#189)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  board <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(First = dock_layout("a"), Second = dock_layout("b")),
+    active = "First"
+  )
+
+  sent <- list()
+  rec_session <- list(
+    sendInputMessage = function(input_id, message) {
+      sent[[length(sent) + 1L]] <<- message
+    }
+  )
+
+  # Stand in for create_view: register the dock without the DOM / module
+  # machinery so `ls(docks)` tracks created views. The add decision under test
+  # keys off client_views, not docks.
+  stub_create <- function(v_id, layout, board, update, session, docks, ...) {
+    assign(v_id, list(layout = function() NULL), envir = docks)
+  }
+
+  docks <- new.env(parent = emptyenv())
+  client_views <- with_mock_context(
+    ms,
+    reactiveVal(seed_view_state(board_layouts(board)))
+  )
+  client_active <- with_mock_context(ms, reactiveVal(NULL))
+  active_dock <- with_mock_context(ms, reactiveValues())
+  update <- with_mock_context(ms, reactiveVal())
+
+  reconcile <- function(brd) {
+    with_mocked_bindings(
+      with_mock_context(
+        ms,
+        reconcile_views(
+          brd, update, docks, active_dock, client_active, client_views,
+          rec_session
+        )
+      ),
+      create_view = stub_create,
+      switch_active_view = function(...) invisible(),
+      .package = "blockr.dock"
+    )
+  }
+
+  adds <- function() Filter(function(m) "add" %in% names(m), sent)
+
+  # Init: board_ui has statically rendered both views, so reconcile must add
+  # none (the bug re-added each as a blank-labelled duplicate).
+  reconcile(board)
+  expect_length(adds(), 0L)
+
+  # A view added at runtime (named only by its list-key id) reaches the nav
+  # exactly once, labelled from the id rather than the empty layout name.
+  board <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(
+      First = dock_layout("a"),
+      Second = dock_layout("b"),
+      Third = dock_layout("a")
+    ),
+    active = "First"
+  )
+
+  sent <- list()
+  reconcile(board)
+
+  rt <- adds()
+
+  expect_length(rt, 1L)
+  expect_identical(rt[[1L]]$add$id, "Third")
+  expect_identical(rt[[1L]]$add$name, "Third")
+})
+
 test_that("apply_board_update.dock_board switches active view", {
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -80,3 +80,47 @@ test_that("dock app", {
 
   app$stop()
 })
+
+test_that("multi-view nav renders one labelled entry per view (#189)", {
+
+  skip_on_cran()
+
+  app <- shinytest2::AppDriver$new(
+    system.file("examples", "multi-view", "app.R", package = "blockr.dock"),
+    name = "multi-view",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 20 * 1000
+  )
+  withr::defer(app$stop())
+
+  app$wait_for_idle()
+
+  # The bug rendered 2N entries: board_ui drew N items statically and the
+  # reconcile pass re-added each as a blank-labelled duplicate sharing the
+  # same id. Asserting on the composed DOM is what a unit test can't reach.
+  nav <- read_view_nav(app)
+
+  expect_identical(nrow(nav), 2L)
+  expect_false(anyDuplicated(nav$id) > 0L)
+  expect_setequal(nav$label, c("First", "Second"))
+  expect_identical(nav$label[nav$active], "First")
+
+  # Drive a runtime add through the nav UI: the client `add` handler must
+  # render the new view once, correctly labelled.
+  app$run_js(
+    "document.querySelector('#my_board-view_nav .blockr-view-add').click()"
+  )
+  app$wait_for_idle()
+
+  app$set_inputs(`my_board-view_new_name` = "Third")
+  app$click("my_board-confirm_view_add")
+  app$wait_for_idle()
+
+  nav <- read_view_nav(app)
+
+  expect_identical(nrow(nav), 3L)
+  expect_false(anyDuplicated(nav$id) > 0L)
+  expect_true("Third" %in% nav$label)
+  expect_false(any(nav$label == ""))
+})


### PR DESCRIPTION
## Summary

- An `N`-view board rendered `2N` entries in the view-nav dropdown: `board_ui.dock_board()` statically draws one labelled item per view, then `reconcile_views()` re-added every view on initial load — each as a blank-labelled duplicate.
- Root cause: the `view_nav` `add` was gated on the live `docks` set (dock containers, legitimately empty on init) rather than on `client_views` (what the nav already shows, seeded with all views at startup). The duplicate's blank label came from sourcing the name via the per-layout `view_name()`, which is `NULL` for a view named by its list key.
- Fix: separate the two concerns `reconcile_views()` conflated — create a dock container for views missing from `docks`, but send a nav `add` only for views missing from `client_views`. On init that set is empty; a runtime add still fires exactly once. Source the label from the container `view_names()`, which resolves whether the name sits on the layout or is derived from the id.
- Regression tests cover the nav item set: the static UI renders one labelled item per view, and `reconcile_views()` emits zero adds on init and exactly one correctly-labelled add for a view added at runtime.

Fixes #189
