### PR TITLE
Forward the reactive board, not a snapshot, to dock modules

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -48,7 +48,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   observeEvent(
     board$board,
     reconcile_views(
-      board$board, update, docks, active_dock, client_active, client_views,
+      board, update, docks, active_dock, client_active, client_views,
       session
     )
   )
@@ -376,6 +376,9 @@ remove_view <- function(v_id, session, docks) {
 # Make the live dock session match the committed board's view set:
 # instantiate added views, tear down removed ones, restore views whose
 # layout changed, relabel renamed ones, and switch to the active view.
+# Takes the reactive board handle (not a snapshot) so the live list reaches
+# manage_dock, whose interaction observers read board$board after the fact
+# (#194); the committed board is snapshotted once here for this pass's reads.
 # Driven by board$board so apply_board_update.dock_board stays a pure
 # reducer and dock state never crosses the package boundary. Idempotent — a
 # board already matching the live state produces no surgery — so it composes
@@ -383,7 +386,9 @@ remove_view <- function(v_id, session, docks) {
 reconcile_views <- function(board, update, docks, active_dock,
                             client_active, client_views, session) {
 
-  layouts <- board_layouts(board)
+  brd <- board$board
+
+  layouts <- board_layouts(brd)
   want <- names(layouts)
   labels <- view_names(layouts)
   server_active <- active_view(layouts)
@@ -400,8 +405,8 @@ reconcile_views <- function(board, update, docks, active_dock,
       update,
       session,
       docks,
-      blocks = board_blocks(board),
-      extensions = dock_extensions(board),
+      blocks = board_blocks(brd),
+      extensions = dock_extensions(brd),
       active = identical(v, server_active)
     )
 
@@ -449,8 +454,8 @@ reconcile_views <- function(board, update, docks, active_dock,
         view = v,
         target = layouts[[v]],
         proxy = docks[[v]]$proxy,
-        blocks = board_blocks(board),
-        extensions = dock_extensions(board)
+        blocks = board_blocks(brd),
+        extensions = dock_extensions(brd)
       )
     }
   }

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -351,11 +351,12 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
   update <- with_mock_context(ms, reactiveVal())
 
   reconcile <- function(brd) {
+    board <- with_mock_context(ms, reactiveValues(board = brd))
     with_mocked_bindings(
       with_mock_context(
         ms,
         reconcile_views(
-          brd, update, docks, active_dock, client_active, client_views,
+          board, update, docks, active_dock, client_active, client_views,
           rec_session
         )
       ),
@@ -392,6 +393,55 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
   expect_length(rt, 1L)
   expect_identical(rt[[1L]]$add$id, "Third")
   expect_identical(rt[[1L]]$add$name, "Third")
+})
+
+test_that("reconcile_views forwards the live board to created views (#194)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  board <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    layouts = list(Page = dock_layout())
+  )
+
+  rv <- with_mock_context(ms, reactiveValues(board = board))
+
+  forwarded <- NULL
+  capture_create <- function(v_id, layout, board, update, session, docks, ...) {
+    forwarded <<- board
+    assign(v_id, list(layout = function() NULL), envir = docks)
+  }
+
+  docks <- new.env(parent = emptyenv())
+  client_views <- with_mock_context(ms, reactiveVal(list()))
+  client_active <- with_mock_context(ms, reactiveVal(NULL))
+  active_dock <- with_mock_context(ms, reactiveValues())
+  update <- with_mock_context(ms, reactiveVal())
+  rec_session <- list(
+    ns = identity,
+    sendInputMessage = function(...) invisible()
+  )
+
+  with_mocked_bindings(
+    with_mock_context(
+      ms,
+      reconcile_views(
+        rv, update, docks, active_dock, client_active, client_views,
+        rec_session
+      )
+    ),
+    create_view = capture_create,
+    switch_active_view = function(...) invisible(),
+    .package = "blockr.dock"
+  )
+
+  # manage_dock's interaction observers (add panel, rename block) read
+  # board$board after the fact, so reconcile must forward the reactive handle.
+  # The bug forwarded the snapshot object, whose $board is NULL — crashing
+  # board_blocks() with `is_board(x) is not TRUE` on the next add-panel click.
+  expect_true(is_dock_board(isolate(forwarded$board)))
+  expect_silent(isolate(board_block_ids(forwarded$board)))
 })
 
 test_that("apply_board_update.dock_board switches active view", {

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -217,9 +217,10 @@ test_that("reconcile_views syncs the nav and live state on rename", {
   # The board carries the new name; the live state still has the old one, so
   # reconcile detects the rename and relabels the nav + client_views.
   renamed <- apply_views_rename(setNames(list("New"), "v1"), brd)
+  board <- reactiveValues(board = renamed)
 
   isolate(
-    reconcile_views(renamed, function(...) NULL, docks, active_dock,
+    reconcile_views(board, function(...) NULL, docks, active_dock,
                     client_active, client_views, session)
   )
 
@@ -679,10 +680,11 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
 
     # Remove on the board (pure), then reconcile the live session against it.
     removed <- apply_views_rm(name_to_id[[rm_label]], brd)
+    board <- reactiveValues(board = removed)
 
     with_mocked_bindings(
       isolate(
-        reconcile_views(removed, function(...) NULL, docks, active_dock,
+        reconcile_views(board, function(...) NULL, docks, active_dock,
                         client_active, client_views, session)
       ),
       remove_view = function(view_id, session, docks) {


### PR DESCRIPTION
## Summary

- `reconcile_views` runs as the `board$board` observer and was handing the bare board *object* down through `create_view` to `manage_dock`. But `manage_dock` — like every other board-threading helper in this file — reads `board$board` to reach the *live* board when its interaction observers fire (add panel, rename block). On a bare object that field is `NULL`, so `board_blocks()` aborted with `is_board(x) is not TRUE` on the next add-panel click or block rename.
- Forward the reactive board handle instead. `reconcile_views` now snapshots `brd <- board$board` once for its own reads and passes the live list down to the dock modules, matching the convention used by `board_server_callback`, `add_view_observer`, and the rest.
- Added a regression test at the forwarding seam — `reconcile_views` must hand `create_view` a handle whose `$board` is a live board — and updated the existing `reconcile_views` call sites in the tests to the reactive-list contract.

Fixes #194
Fixes #193
