### PR TITLE
Report on-screen blocks to core's visibility channel

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -7,6 +7,8 @@
 #'
 #' @param board Reactive board state (list with `$board`).
 #' @param update Reactive update signal from blockr.core.
+#' @param visible Reactive write-channel from blockr.core, fed the set of
+#'   on-screen block ids so core can gate off-screen blocks.
 #' @param ... Extension server arguments.
 #' @param session Shiny session.
 #'
@@ -14,7 +16,8 @@
 #'   results.
 #'
 #' @noRd
-board_server_callback <- function(board, update, ..., session = get_session()) {
+board_server_callback <- function(board, update, visible, ...,
+                                  session = get_session()) {
   initial_board <- isolate(board$board)
 
   c_exts <- dock_extensions(initial_board)
@@ -58,6 +61,12 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
       session
     )
   )
+
+  # Gate off-screen blocks from the first flush, before the client reports its
+  # layout (else core's all-visible default evaluates every block at startup).
+  visible(visible_block_ids(active_layout(initial_board)))
+
+  report_visible_observer(visible, client_active, docks)
 
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
@@ -159,6 +168,25 @@ switch_view_observer <- function(session, update, client_active) {
       }
     },
     ignoreInit = TRUE
+  )
+}
+
+report_visible_observer <- function(visible, client_active, docks) {
+
+  active_layout <- reactive({
+    active <- req(client_active())
+    req(docks[[active]])$layout()
+  })
+
+  observeEvent(
+    active_layout(),
+    {
+      ids <- visible_block_ids(active_layout())
+
+      if (!setequal(ids, visible())) {
+        visible(ids)
+      }
+    }
   )
 }
 

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -64,6 +64,14 @@ determine_active_views <- function(layout) {
   rapply(xtr_leaf_id(root), identity, "character")
 }
 
+visible_block_ids <- function(layout) {
+
+  front_panels <- as.character(determine_active_views(layout))
+  block_panels <- front_panels[maybe_block_panel_id(front_panels)]
+
+  as_obj_id(new_block_panel_id(block_panels))
+}
+
 visible_exts <- function() {
   blockr_option("visible_extensions", "dag_extension")
 }

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -8,7 +8,11 @@ test_that("board server", {
 
   with_mock_session(
     {
-      res <- board_server_callback(board_rv_1, update = reactiveVal())
+      res <- board_server_callback(
+        board_rv_1,
+        update = reactiveVal(),
+        visible = reactiveVal()
+      )
 
       expect_type(res, "list")
       expect_named(res, c("dock", "actions", "view_data"))
@@ -28,7 +32,11 @@ test_that("board server", {
 
   with_mock_session(
     {
-      res <- board_server_callback(board_rv_2, update = reactiveVal())
+      res <- board_server_callback(
+        board_rv_2,
+        update = reactiveVal(),
+        visible = reactiveVal()
+      )
 
       expect_type(res, "list")
       expect_named(
@@ -339,7 +347,12 @@ test_that("view_data() tracks a reported layout despite flush order (#243)", {
   withr::defer(if (!ms$isClosed()) ms$close())
 
   res <- with_mock_context(
-    ms, board_server_callback(board_rv, update = reactiveVal())
+    ms,
+    board_server_callback(
+      board_rv,
+      update = reactiveVal(),
+      visible = reactiveVal()
+    )
   )
 
   # Force the first read before reconcile runs: docks empty, so NULL.
@@ -363,6 +376,120 @@ test_that("view_data() tracks a reported layout despite flush order (#243)", {
     layout_panel_ids(vd[["Page"]]),
     c("block_panel-b", "block_panel-a")
   )
+})
+
+test_that("visible_block_ids returns the front-tab block of each group", {
+
+  two_groups <- dock_layout(panels("block_panel-a"), panels("block_panel-b"))
+  expect_setequal(visible_block_ids(two_groups), c("a", "b"))
+
+  background_tab <- dock_layout(
+    panels("block_panel-a", "block_panel-b", active = "block_panel-a")
+  )
+  expect_identical(visible_block_ids(background_tab), "a")
+
+  ext_front <- dock_layout(panels("ext_panel-editor"))
+  expect_identical(visible_block_ids(ext_front), character())
+
+  nested <- dock_layout(
+    panels("block_panel-a"),
+    group(panels("block_panel-b"), panels("ext_panel-editor"))
+  )
+  expect_setequal(visible_block_ids(nested), c("a", "b"))
+
+  expect_identical(visible_block_ids(dock_layout()), character())
+})
+
+test_that("report_visible_observer publishes the active view's blocks", {
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  env <- with_mock_context(ms, {
+    layout_a <- reactiveVal(NULL)
+    layout_b <- reactiveVal(NULL)
+
+    docks <- new.env(parent = emptyenv())
+    docks[["A"]] <- list(layout = layout_a)
+    docks[["B"]] <- list(layout = layout_b)
+
+    visible <- reactiveVal()
+    client_active <- reactiveVal("A")
+
+    report_visible_observer(visible, client_active, docks)
+
+    list(a = layout_a, b = layout_b, active = client_active, visible = visible)
+  })
+
+  ms$flushReact()
+  expect_null(isolate(env$visible()))
+
+  with_mock_context(ms, env$a(
+    dock_layout(panels("block_panel-a"), panels("block_panel-b"))
+  ))
+  ms$flushReact()
+  expect_setequal(isolate(env$visible()), c("a", "b"))
+
+  with_mock_context(ms, env$b(dock_layout(panels("block_panel-d"))))
+  ms$flushReact()
+  expect_setequal(isolate(env$visible()), c("a", "b"))
+
+  with_mock_context(ms, env$a(
+    dock_layout(panels("ext_panel-editor"), panels("block_panel-b"))
+  ))
+  ms$flushReact()
+  expect_identical(isolate(env$visible()), "b")
+
+  with_mock_context(ms, env$active("B"))
+  ms$flushReact()
+  expect_identical(isolate(env$visible()), "d")
+})
+
+test_that("report_visible_observer coalesces set-equal reports", {
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  env <- with_mock_context(ms, {
+    layout <- reactiveVal(NULL)
+
+    docks <- new.env(parent = emptyenv())
+    docks[["A"]] <- list(layout = layout)
+
+    visible <- reactiveVal()
+    client_active <- reactiveVal("A")
+
+    report_visible_observer(visible, client_active, docks)
+
+    list(layout = layout, visible = visible)
+  })
+
+  with_mock_context(ms, env$layout(
+    dock_layout(panels("block_panel-a"), panels("block_panel-b"))
+  ))
+  ms$flushReact()
+
+  first <- isolate(env$visible())
+  expect_setequal(first, c("a", "b"))
+
+  with_mock_context(ms, env$layout(
+    dock_layout(panels("block_panel-b"), panels("block_panel-a"))
+  ))
+  ms$flushReact()
+
+  expect_identical(isolate(env$visible()), first)
+})
+
+test_that("board_server_callback seeds visibility before the client reports", {
+
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block(), b = new_head_block())
+  )
+
+  with_mock_session({
+    visible <- reactiveVal()
+    board_server_callback(board_rv, update = reactiveVal(), visible = visible)
+
+    expect_identical(isolate(visible()), "a")
+  })
 })
 
 test_that("layouts_to_board_observer fires update views on divergence", {
@@ -738,7 +865,10 @@ test_that("extensions mod state is applied via the update lifecycle", {
 
   upd <- reactiveVal()
 
-  res <- with_mock_context(ms, board_server_callback(board_rv, update = upd))
+  res <- with_mock_context(
+    ms,
+    board_server_callback(board_rv, update = upd, visible = reactiveVal())
+  )
 
   ms$flushReact()
 
@@ -772,7 +902,10 @@ test_that("a live-only panel add folds into board_layouts (#217)", {
   withr::defer(if (!ms$isClosed()) ms$close())
 
   upd <- reactiveVal()
-  res <- with_mock_context(ms, board_server_callback(board_rv, update = upd))
+  res <- with_mock_context(
+    ms,
+    board_server_callback(board_rv, update = upd, visible = reactiveVal())
+  )
   ms$flushReact()
 
   live_panels <- isolate(res$dock$live_panels)
@@ -818,7 +951,11 @@ test_that("extension servers can read peer extension state", {
 
   with_mock_session(
     {
-      board_server_callback(board_rv, update = reactiveVal())
+      board_server_callback(
+        board_rv,
+        update = reactiveVal(),
+        visible = reactiveVal()
+      )
 
       expect_true("doc_extension" %in% ls(peers))
       expect_identical(


### PR DESCRIPTION
## Summary

- Producer side of blockr.core#203: `board_server_callback` publishes the active view's on-screen block ids to core's `visible` write-channel so core can suspend evaluation and rendering of off-screen blocks. A block is on screen when its panel is the active (front) tab of its dockview group in the active view — per-tab, so a block on a background tab counts as off-screen.
- `report_visible_observer` recomputes on view switch (`client_active`) and on any active-view layout change — tab switch, panel add/remove/move — since dockview re-emits its serialized state on each. The channel is left untouched until the active view's dock first reports a layout, so core's no-producer default (all blocks visible) holds through startup.
- Pins `blockr.core` to the `203-visibility-gating` branch (#206) until it merges; revert the Remotes line to plain `blockr.core` then.
- The `dock app` serdes e2e snapshots block results, but per-tab gating (core#206's default) suspends the blocks it parks on background tabs, so that test now runs against a `dock-serdes` fixture with `gate_visibility = FALSE`. Gating is orthogonal to the serialization it checks and is covered by the new producer unit tests.

Fixes #195
Fixes #219

