### PR TITLE
Relabel the dock panel from the rename delta

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -655,11 +655,13 @@ manage_dock <- function(
 
         for (blk_id in names(blks)) {
 
-          if (!"block_name" %in% names(blks[[blk_id]])) {
+          delta <- blks[[blk_id]]
+
+          if (!"block_name" %in% names(delta)) {
             next
           }
 
-          new_name <- block_name(board_blocks(board$board)[[blk_id]])
+          new_name <- delta[["block_name"]]
           blk_panel_id <- as_block_panel_id(blk_id)
 
           old_title <- get_dock_panel(blk_panel_id, dock)$title

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -199,6 +199,56 @@ test_that("board server", {
   expect_identical(panel_lookups, 1L)
 })
 
+test_that("renaming a block refreshes the dock panel title (#193)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  # The rename observer runs before the board update is applied, so board$board
+  # still carries the old name; the new name lives only in the mod delta. A
+  # board read would relabel to the old title and no-op -- assert the panel
+  # picks up the delta's name instead.
+  board_rv <- board_args(blocks = c(a = new_dataset_block()))
+  old_name <- with_mock_context(
+    ms,
+    isolate(block_name(board_blocks(board_rv$board)[["a"]]))
+  )
+  upd <- reactiveVal()
+
+  with_mock_context(ms, {
+    manage_dock("dock_main", board_rv, update = upd)
+  })
+
+  ms$flushReact()
+
+  title_set <- NULL
+
+  with_mocked_bindings(
+    with_mocked_bindings(
+      {
+        with_mock_context(ms, {
+          upd(
+            list(
+              blocks = list(
+                mod = list(a = list(block_name = "Renamed"))
+              )
+            )
+          )
+        })
+        ms$flushReact()
+      },
+      set_panel_title = function(proxy, id, title, ...) {
+        title_set <<- title
+        invisible(proxy)
+      },
+      .package = "dockViewR"
+    ),
+    get_dock_panel = function(...) list(title = old_name)
+  )
+
+  expect_identical(title_set, "Renamed")
+})
+
 test_that("live_view_data is NULL while any view layout is uninitialized", {
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())


### PR DESCRIPTION
## Summary

Follow-up to #200 (merged), which fixed the rename/add-panel crash by forwarding the live board into `manage_dock`. This addresses the one thing it left behind: after a rename, the block's dock panel keeps its old tab title.

- `manage_dock`'s rename observer relabels the panel, but it runs at `priority 0` while core's apply runs at `priority -Inf`. So when it reads `board_blocks(board$board)[[blk_id]]` the rename hasn't been applied yet and it sees the *old* name — `identical(old, old)` skips `set_panel_title`, and nothing else relabels a block panel, so the tab stays stale.
- Read the new name from the `blocks$mod` delta instead — the same value `apply_block_mod_delta()` applies. No board read, no dependence on apply ordering.
- Added a regression test: it fails against the unfixed observer (title not refreshed) and passes with the delta read.

Follows up #200 / #193.
