### PR TITLE
Restore a view's layout only on a committed-layout change (#196)

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -32,7 +32,11 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   # Per-session dock state, closure-private. `docks` is the live manage_dock()
   # registry; `client_active` / `client_views` mirror what the browser shows
   # (lagging board_layouts), diffed by reconcile_views() — the sole mutator.
+  # `committed_layouts` records, per view, the board_layouts the live dock was
+  # last reconciled to, so reconcile pushes a layout back to the dock only when
+  # the committed layout genuinely changed (#196).
   docks <- new.env(parent = emptyenv())
+  committed_layouts <- new.env(parent = emptyenv())
   active_dock <- reactiveValues()
   client_active <- reactiveVal(NULL)
   client_views <- reactiveVal(seed_view_state(board_layouts(initial_board)))
@@ -49,7 +53,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
     board$board,
     reconcile_views(
       board, update, docks, active_dock, client_active, client_views,
-      session
+      committed_layouts, session
     )
   )
 
@@ -375,16 +379,17 @@ remove_view <- function(v_id, session, docks) {
 
 # Make the live dock session match the committed board's view set:
 # instantiate added views, tear down removed ones, restore views whose
-# layout changed, relabel renamed ones, and switch to the active view.
-# Takes the reactive board handle (not a snapshot) so the live list reaches
-# manage_dock, whose interaction observers read board$board after the fact
-# (#194); the committed board is snapshotted once here for this pass's reads.
-# Driven by board$board so apply_board_update.dock_board stays a pure
+# committed layout changed, relabel renamed ones, and switch to the active
+# view. Takes the reactive board handle (not a snapshot) so the live list
+# reaches manage_dock, whose interaction observers read board$board after the
+# fact (#194); the committed board is snapshotted once here for this pass's
+# reads. Driven by board$board so apply_board_update.dock_board stays a pure
 # reducer and dock state never crosses the package boundary. Idempotent — a
 # board already matching the live state produces no surgery — so it composes
 # with the live-sync (DOM -> board) path without ping-ponging.
 reconcile_views <- function(board, update, docks, active_dock,
-                            client_active, client_views, session) {
+                            client_active, client_views, committed_layouts,
+                            session) {
 
   brd <- board$board
 
@@ -411,6 +416,7 @@ reconcile_views <- function(board, update, docks, active_dock,
     )
 
     state[[v]] <- bare_view(layouts[[v]])
+    committed_layouts[[v]] <- layouts[[v]]
   }
 
   # Add a nav item only for views the nav doesn't already show. `board_ui`
@@ -430,6 +436,10 @@ reconcile_views <- function(board, update, docks, active_dock,
     remove_view(v, session, docks)
     session$sendInputMessage("view_nav", list(remove = v))
     state[[v]] <- NULL
+
+    if (exists(v, envir = committed_layouts, inherits = FALSE)) {
+      rm(list = v, envir = committed_layouts)
+    }
   }
 
   for (v in intersect(want, have)) {
@@ -444,19 +454,33 @@ reconcile_views <- function(board, update, docks, active_dock,
       )
     }
 
-    live <- tryCatch(
-      isolate(docks[[v]]$layout()),
-      error = function(e) NULL
-    )
+    # Restore the live dock from board_layouts only when this view's committed
+    # layout actually changed (a views$mod, a board restore). A block add
+    # touches the live dock through insert_block_ui without changing
+    # board_layouts, and the live-sync mirrors it back later; reconciling that
+    # drift here would restore the dock to a board_layouts that lags it, wiping
+    # the just-added block panels (#196).
+    prev <- get0(v, envir = committed_layouts, inherits = FALSE,
+                 ifnotfound = NULL)
 
-    if (!is.null(live) && !layouts_match(live, layouts[[v]])) {
-      apply_layout_diff(
-        view = v,
-        target = layouts[[v]],
-        proxy = docks[[v]]$proxy,
-        blocks = board_blocks(brd),
-        extensions = dock_extensions(brd)
+    committed_layouts[[v]] <- layouts[[v]]
+
+    if (is.null(prev) || !layouts_match(layouts[[v]], prev)) {
+
+      live <- tryCatch(
+        isolate(docks[[v]]$layout()),
+        error = function(e) NULL
       )
+
+      if (!is.null(live) && !layouts_match(live, layouts[[v]])) {
+        apply_layout_diff(
+          view = v,
+          target = layouts[[v]],
+          proxy = docks[[v]]$proxy,
+          blocks = board_blocks(brd),
+          extensions = dock_extensions(brd)
+        )
+      }
     }
   }
 

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -392,6 +392,7 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
   }
 
   docks <- new.env(parent = emptyenv())
+  committed_layouts <- new.env(parent = emptyenv())
   client_views <- with_mock_context(
     ms,
     reactiveVal(seed_view_state(board_layouts(board)))
@@ -407,7 +408,7 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
         ms,
         reconcile_views(
           board, update, docks, active_dock, client_active, client_views,
-          rec_session
+          committed_layouts, rec_session
         )
       ),
       create_view = stub_create,
@@ -464,6 +465,7 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   }
 
   docks <- new.env(parent = emptyenv())
+  committed_layouts <- new.env(parent = emptyenv())
   client_views <- with_mock_context(ms, reactiveVal(list()))
   client_active <- with_mock_context(ms, reactiveVal(NULL))
   active_dock <- with_mock_context(ms, reactiveValues())
@@ -478,7 +480,7 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
       ms,
       reconcile_views(
         rv, update, docks, active_dock, client_active, client_views,
-        rec_session
+        committed_layouts, rec_session
       )
     ),
     create_view = capture_create,
@@ -492,6 +494,131 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   # board_blocks() with `is_board(x) is not TRUE` on the next add-panel click.
   expect_true(is_dock_board(isolate(forwarded$board)))
   expect_silent(isolate(board_block_ids(forwarded$board)))
+})
+
+test_that("reconcile skips a view with unchanged committed layout (#196)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  session <- list(
+    ns = identity,
+    sendInputMessage = function(input_id, message) invisible(),
+    sendCustomMessage = function(type, message) invisible()
+  )
+
+  # One view holding block `a`. The live dock is ahead -- block `b`'s panel was
+  # just added through insert_block_ui, but board_layouts has not caught up
+  # (the live-sync is debounced). reconcile must not restore the dock to
+  # board_layouts here: that would wipe the just-added panel (#196).
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(V = dock_layout("a"))
+  )
+  board <- with_mock_context(ms, reactiveValues(board = brd))
+
+  target <- board_layouts(brd)[["V"]]
+  ahead <- board_layouts(
+    new_dock_board(
+      blocks = c(a = new_dataset_block(), b = new_head_block()),
+      layouts = list(V = dock_layout("a", "b"))
+    )
+  )[["V"]]
+
+  docks <- new.env(parent = emptyenv())
+  docks[["V"]] <- list(layout = function() ahead, proxy = NULL)
+
+  committed_layouts <- new.env(parent = emptyenv())
+  committed_layouts[["V"]] <- target
+
+  client_views <- with_mock_context(
+    ms,
+    reactiveVal(seed_view_state(board_layouts(brd)))
+  )
+  client_active <- with_mock_context(ms, reactiveVal("V"))
+  active_dock <- with_mock_context(ms, reactiveValues())
+  update <- with_mock_context(ms, reactiveVal())
+
+  diffed <- 0L
+
+  with_mocked_bindings(
+    with_mock_context(
+      ms,
+      reconcile_views(
+        board, update, docks, active_dock, client_active, client_views,
+        committed_layouts, session
+      )
+    ),
+    apply_layout_diff = function(...) diffed <<- diffed + 1L,
+    switch_active_view = function(...) invisible(),
+    .package = "blockr.dock"
+  )
+
+  expect_identical(diffed, 0L)
+})
+
+test_that("reconcile_views restores a view whose committed layout changed", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  session <- list(
+    ns = identity,
+    sendInputMessage = function(input_id, message) invisible(),
+    sendCustomMessage = function(type, message) invisible()
+  )
+
+  # The committed layout (and the live dock) hold block `a`; the board now
+  # carries `a` + `b` (a views$mod / restore). reconcile must push the new
+  # layout to the lagging live dock.
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(V = dock_layout("a", "b"))
+  )
+  board <- with_mock_context(ms, reactiveValues(board = brd))
+
+  target <- board_layouts(brd)[["V"]]
+  behind <- board_layouts(
+    new_dock_board(
+      blocks = c(a = new_dataset_block(), b = new_head_block()),
+      layouts = list(V = dock_layout("a"))
+    )
+  )[["V"]]
+
+  docks <- new.env(parent = emptyenv())
+  docks[["V"]] <- list(layout = function() behind, proxy = NULL)
+
+  committed_layouts <- new.env(parent = emptyenv())
+  committed_layouts[["V"]] <- behind
+
+  client_views <- with_mock_context(
+    ms,
+    reactiveVal(seed_view_state(board_layouts(brd)))
+  )
+  client_active <- with_mock_context(ms, reactiveVal("V"))
+  active_dock <- with_mock_context(ms, reactiveValues())
+  update <- with_mock_context(ms, reactiveVal())
+
+  captured <- NULL
+
+  with_mocked_bindings(
+    with_mock_context(
+      ms,
+      reconcile_views(
+        board, update, docks, active_dock, client_active, client_views,
+        committed_layouts, session
+      )
+    ),
+    apply_layout_diff = function(view, target, ...) {
+      captured <<- list(view = view, target = target)
+    },
+    switch_active_view = function(...) invisible(),
+    .package = "blockr.dock"
+  )
+
+  expect_false(is.null(captured))
+  expect_identical(captured$view, "V")
+  expect_true(layouts_match(captured$target, target))
 })
 
 test_that("apply_board_update.dock_board switches active view", {

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -96,6 +96,52 @@ test_that("edit board extension links blocks (e2e)", {
   app$stop()
 })
 
+test_that("adding a second block keeps both block panels (#196)", {
+
+  skip_on_cran()
+
+  app <- shinytest2::AppDriver$new(
+    system.file("examples", "empty", "app.R", package = "blockr.dock"),
+    name = "panel-visibility",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 20 * 1000
+  )
+  withr::defer(app$stop())
+
+  app$wait_for_idle()
+
+  # A block panel's open tab outlives the panel content, which dockview
+  # detaches while inactive -- so the tab strip, not the (detached) card, is
+  # where panel presence is observable. Each tab carries its panel id as
+  # `...-dock-tab-block_panel-<id>`; read them straight off the live DOM.
+  block_panel_tabs <- function() {
+    html <- xml2::read_html(app$get_html("#my_board-view_container"))
+    nodes <- xml2::xml_find_all(html, "//*[contains(@id, '-tab-block_panel-')]")
+    sort(sub(".*-tab-(block_panel-.+)$", "\\1", xml2::xml_attr(nodes, "id")))
+  }
+
+  add_block <- function(registry, id) {
+    app$set_inputs(
+      `my_board-edit_board_extension-registry_select` = registry,
+      `my_board-edit_board_extension-block_id` = id
+    )
+    app$click("my_board-edit_board_extension-confirm_add")
+    app$wait_for_idle()
+  }
+
+  add_block("dataset_block", "a")
+  expect_identical(block_panel_tabs(), "block_panel-a")
+
+  # Pre-fix, the second add fired reconcile_views against a board_layouts that
+  # lagged the live dock, restoring it and wiping both block panels -- leaving
+  # only the extension (#196). Both block tabs must survive.
+  add_block("head_block", "b")
+  expect_identical(block_panel_tabs(), c("block_panel-a", "block_panel-b"))
+
+  app$stop()
+})
+
 test_that("edit board extension stacks (e2e)", {
 
   skip_on_cran()

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -207,6 +207,7 @@ test_that("reconcile_views syncs the nav and live state on rename", {
   # instantiated (no DOM surgery); their live layout is pending (NULL) so the
   # layout-mod check is skipped and only the rename fires.
   docks <- new.env(parent = emptyenv())
+  committed_layouts <- new.env(parent = emptyenv())
   for (id in names(board_layouts(brd))) {
     docks[[id]] <- list(layout = function() NULL)
   }
@@ -221,7 +222,7 @@ test_that("reconcile_views syncs the nav and live state on rename", {
 
   isolate(
     reconcile_views(board, function(...) NULL, docks, active_dock,
-                    client_active, client_views, session)
+                    client_active, client_views, committed_layouts, session)
   )
 
   expect_true(
@@ -671,6 +672,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
     # Registry pre-populated for every view; the DOM helpers are mocked so the
     # test exercises reconcile's nav-sync, not the live teardown / switch.
     docks <- new.env(parent = emptyenv())
+    committed_layouts <- new.env(parent = emptyenv())
     for (id in names(state)) docks[[id]] <- list(layout = function() NULL)
     active_dock <- reactiveValues()
     client_active <- reactiveVal(name_to_id[[active_label]])
@@ -685,7 +687,8 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
     with_mocked_bindings(
       isolate(
         reconcile_views(board, function(...) NULL, docks, active_dock,
-                        client_active, client_views, session)
+                        client_active, client_views, committed_layouts,
+                        session)
       ),
       remove_view = function(view_id, session, docks) {
         rm(list = view_id, envir = docks)


### PR DESCRIPTION
## Summary

- `reconcile_views()` restored a view's live dock from `board_layouts()` whenever the two diverged. A block add reaches the live dock through `insert_block_ui()` without changing `board_layouts` — the debounced DOM→board live-sync mirrors it back only later — so `board_layouts` lags the live dock. The next `board$board` change then fired reconcile, which restored the dock to the stale `board_layouts` and wiped the just-added block panels, leaving only the extension panel. This is the disappearing-panel behaviour from the videos.
- Fix: track the committed layout per view (a closure-private `committed_layouts` env) and run the destructive `apply_layout_diff()` restore only when that committed layout actually changed (a `views$mod`, a board restore) — never on the block-add drift the live-sync already reconciles back. This is a tolerance-of-the-lag workaround, not a root fix; making `board_layouts` updates synchronous (removing the lag, after which this gating can be dropped) is tracked in #217.
- Regression coverage: two deterministic `reconcile_views()` unit tests (no restore when the committed layout is unchanged; restore when it changes) plus a thin shinytest2 test that adds two blocks via the edit-board extension and asserts both block-panel tabs survive (DOM facts, not snapshots). All three were confirmed to fail against the unfixed code.
- Out of scope: adding a block *before* the dock finishes initialising throws `argument is of length zero` (`determine_active_views()` on a `NULL` layout) and the block gets no panel. It reproduces on `main` independently of this change — split out as #211.

Fixes #196
