### PR TITLE
Instrument flaky e2e tests to capture the swallowed JS exception

### DIFF
--- a/tests/testthat/setup-idle-debug.R
+++ b/tests/testthat/setup-idle-debug.R
@@ -1,0 +1,70 @@
+# Temporary diagnostic for the intermittent e2e "did not become stable"
+# failures. shinytest2 evaluates its init readiness / idle checks through
+# `chromote_eval()` and collapses any browser-side exception into one opaque
+# message, so a CI failure tells us nothing actionable. Trace that function's
+# exit: whenever one of those checks returns a JS exception, print the real
+# exception text and a snapshot of jQuery / readiness / page state at that
+# instant. Fires only on failure; no behavioural change. Remove once a failing
+# run has been captured.
+
+if (requireNamespace("shinytest2", quietly = TRUE)) {
+
+  install_idle_trace <- function() {
+    trace(
+      "chromote_eval",
+      where = asNamespace("shinytest2"),
+      print = FALSE,
+      exit = quote({
+        rv <- returnValue()
+        errored <- length(rv$exceptionDetails) > 0 ||
+          identical(rv$result$subtype, "error")
+
+        if (errored && grepl("shiny:busy|shinytest2\\.ready", js)) {
+
+          probe <- function(expr) {
+            tryCatch(
+              chromote_session$Runtime$evaluate(
+                expr, returnByValue = TRUE, timeout_ = 3000
+              )$result$value,
+              error = function(e) "<probe-failed>"
+            )
+          }
+
+          exc <- rv$exceptionDetails$exception$description
+          if (is.null(exc)) exc <- rv$exceptionDetails$text
+          if (is.null(exc)) exc <- rv$result$description
+
+          message("\n--- [idle-debug] init check threw a JS exception ---")
+          message("js   : ", substr(gsub("\\s+", " ", js), 1, 80))
+          message("exc  : ", exc)
+          message(
+            "$=", probe("typeof window.$"),
+            " jQuery=", probe("typeof window.jQuery"),
+            " $===jQuery=", probe("window.$ === window.jQuery")
+          )
+          message(
+            "ready=", probe("(window.shinytest2||{}).ready"),
+            " readyState=", probe("document.readyState"),
+            " frames=", probe("frames.length")
+          )
+          message("href : ", probe("window.location.href"))
+          message("----------------------------------------------------")
+        }
+      })
+    )
+  }
+
+  tryCatch(
+    suppressMessages(install_idle_trace()),
+    error = function(e) {
+      message("[idle-debug] trace not installed: ", conditionMessage(e))
+    }
+  )
+
+  withr::defer(
+    suppressMessages(suppressWarnings(
+      untrace("chromote_eval", where = asNamespace("shinytest2"))
+    )),
+    teardown_env()
+  )
+}


### PR DESCRIPTION
## Summary

The intermittent e2e "did not become stable" failures in `test-utils-serve.R` that eject PRs from the merge queue carry no actionable detail. shinytest2 runs its init readiness and idle checks through `chromote_eval()` and collapses any browser-side exception into one opaque message, so the CI artifact only ever says "did not become stable in 30000ms".

This adds a temporary `tests/testthat/setup-idle-debug.R` that traces `chromote_eval()`'s exit and, whenever one of those init checks comes back with a JS exception, prints the real exception text plus a snapshot of `$` / `jQuery` / `$ === jQuery` / `readyState` / `location.href` / frame count at that instant. It fires only on failure and changes no behaviour, so the next natural failure on the queue `ci / check` leg surfaces the actual cause.

Already ruled out from the existing failure artifact: this is **not** the port collision the issue first suspected (one failing run had a clean bind, no `address already in use`, and failed identically), not cross-runner contention (isolated VMs), and not a crash or a real 30s timeout — the abort fires in ~0.1s, i.e. a synchronous JS exception inside the check. Locally that signature only reproduces by forcing `$` undefined (`TypeError: $ is not a function`), but the natural trigger doesn't reproduce off the constrained runner — hence capturing it in situ.

Diagnostic only; no fix, since the trigger is still unconfirmed. Remove once a failing run has been captured.

Refs #205