### PR TITLE
Pin shinytest2 to the navigate-before-bind fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     jsonlite
 Remotes:
     BristolMyersSquibb/blockr.ui,
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core,
+    nbenn/shinytest2@wait-for-app-serving
 Suggests:
     testthat (>= 3.0.0),
     DT,


### PR DESCRIPTION
## Summary

- The intermittent "did not become stable" failures that eject PRs from the merge queue come from shinytest2 navigating before the app's port is bound: shiny prints "Listening on ..." before binding the socket (rstudio/shiny#4400), so on the loaded R-devel queue leg the navigation hits the browser error page and the recovery navigation races init's readiness/idle checks.
- Pins `nbenn/shinytest2@wait-for-app-serving`, which waits for the port to accept a connection (`pingr::is_up`, already a shinytest2 dependency) before navigating — fixing it at the source. Verified locally: a deterministic reproducer goes 0/3 → 3/3, with no regression (the dock e2e suite is green against the patched build).
- Supersedes the retry stopgap that previously sat on this branch. Temporary until the upstream shinytest2 PR merges, then drop the pin. `setup-idle-debug.R` is kept for now to confirm the fix on the queue.

Refs #205



```deps
BristolMyersSquibb/blockr.dag#125
```
