### PR TITLE
Handle uninitialised dock layout when adding a block

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # blockr.dock (development version)
 
+* Adding a block before the dock view has finished initialising no
+  longer throws `argument is of length zero`. While the dock is
+  uninitialised its layout is `NULL`; `determine_active_views()` now
+  treats that as an empty dock, so the block's panel is placed freely
+  instead of being stranded in the offcanvas.
+
 * `add_link_action()` now mounts the `blockr.ui` link-menu module and
   is bidirectional: right-clicking a downstream block now lets you pick
   an upstream source, not just a target. The handler passes the board

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -46,6 +46,12 @@ move_dom_element <- function(from, to, session = get_session()) {
 
 determine_active_views <- function(layout) {
 
+  root <- layout[["grid"]][["root"]]
+
+  if (is.null(root)) {
+    return(character())
+  }
+
   xtr_leaf_id <- function(x) {
 
     if (x$type == "leaf") {
@@ -55,11 +61,7 @@ determine_active_views <- function(layout) {
     lapply(x$data, xtr_leaf_id)
   }
 
-  rapply(
-    xtr_leaf_id(layout[["grid"]][["root"]]),
-    identity,
-    "character"
-  )
+  rapply(xtr_leaf_id(root), identity, "character")
 }
 
 visible_exts <- function() {

--- a/tests/testthat/test-utils-ui.R
+++ b/tests/testthat/test-utils-ui.R
@@ -1,0 +1,35 @@
+test_that("determine_active_views handles an uninitialised layout", {
+
+  expect_identical(determine_active_views(NULL), character())
+
+  leaf <- function(id, view) {
+    list(type = "leaf", data = list(id = id, activeView = view))
+  }
+
+  layout <- list(
+    grid = list(
+      root = list(
+        type = "branch",
+        data = list(leaf("grp1", "view_a"), leaf("grp2", "view_b"))
+      )
+    )
+  )
+
+  expect_identical(
+    determine_active_views(layout),
+    c(grp1 = "view_a", grp2 = "view_b")
+  )
+})
+
+test_that("determine_panel_pos places freely before the dock initialises", {
+
+  dock <- list(
+    layout = function() NULL,
+    prev_active_group = function() NULL
+  )
+
+  expect_identical(
+    determine_panel_pos(dock),
+    list(direction = "right")
+  )
+})


### PR DESCRIPTION
## Summary

- Adding a block *before the dockview has finished initialising* threw `argument is of length zero` and left the block's card stranded in the offcanvas. Until the dock reports its state its layout is `NULL`, and the add path called `determine_active_views(NULL)`, which dereferences `layout[["grid"]][["root"]]` and errors.
- `determine_active_views()` now treats a `NULL` (uninitialised) layout as an empty dock and returns no active views. `determine_panel_pos()` then falls through to its existing no-candidate-groups branch and places the panel freely.
- Guarding at `determine_active_views()` also covers the other caller — the board server's `n_panels` count, which reads the initial layout.
- Adds regression tests for `determine_active_views(NULL)` and `determine_panel_pos()` against an uninitialised dock; both fail on `main` with the reported error and pass with the fix.

Fixes #211
