### PR TITLE
Update board_layouts membership synchronously, drop committed_layouts

### DIFF
--- a/R/block-ui.R
+++ b/R/block-ui.R
@@ -89,7 +89,7 @@ remove_block_ui.dock_board <- function(id, x, blocks, dock, ...,
 
   for (blk in blocks) {
     if (as_block_panel_id(blk) %in% block_panel_ids(dock$proxy)) {
-      hide_block_panel(blk, proxy = dock$proxy)
+      hide_block_panel(blk, dock = dock)
     }
 
     removeUI(
@@ -118,36 +118,35 @@ insert_block_ui.dock_board <- function(id, x, blocks, dock, ...,
       session = session
     )
 
-    show_block_panel(blocks[i], determine_panel_pos(dock), dock$proxy)
+    show_block_panel(blocks[i], determine_panel_pos(dock), dock)
   }
 
   invisible(x)
 }
 
-show_block_panel <- function(block, add_panel = TRUE,
-                             proxy = dock_proxy(), ...) {
+show_block_panel <- function(block, add_panel = TRUE, dock, ...) {
 
   if (isTRUE(add_panel)) {
-    add_block_panel(block, proxy = proxy)
+    add_block_panel(block, dock = dock)
   } else if (isFALSE(add_panel)) {
-    select_block_panel(block, proxy)
+    select_block_panel(block, dock$proxy)
   } else {
-    add_block_panel(block, position = add_panel, proxy = proxy)
+    add_block_panel(block, position = add_panel, dock = dock)
   }
 
-  show_block_ui(block, proxy$session,
-                board_ns = proxy_board_ns(proxy), ...)
+  show_block_ui(block, dock$proxy$session,
+                board_ns = dock_board_ns(dock), ...)
 
   invisible(NULL)
 }
 
-hide_block_panel <- function(id, rm_panel = TRUE, proxy = dock_proxy(), ...) {
+hide_block_panel <- function(id, rm_panel = TRUE, dock, ...) {
 
-  hide_block_ui(id, proxy$session,
-                board_ns = proxy_board_ns(proxy), ...)
+  hide_block_ui(id, dock$proxy$session,
+                board_ns = dock_board_ns(dock), ...)
 
   if (isTRUE(rm_panel)) {
-    remove_block_panel(id, proxy)
+    remove_block_panel(id, dock)
   }
 
   invisible(NULL)

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -284,13 +284,13 @@ hide_view_ui <- function(view_id, docks) {
   if (is.null(view_id) || !exists(view_id, envir = docks, inherits = FALSE)) {
     return()
   }
-  proxy <- docks[[view_id]]$proxy
-  bns <- proxy_board_ns(proxy)
-  for (bid in as_obj_id(block_panel_ids(proxy))) {
-    hide_block_ui(bid, proxy$session, board_ns = bns)
+  dock <- docks[[view_id]]
+  bns <- dock_board_ns(dock)
+  for (bid in as_obj_id(block_panel_ids(dock$proxy))) {
+    hide_block_ui(bid, dock$proxy$session, board_ns = bns)
   }
-  for (eid in as_obj_id(ext_panel_ids(proxy))) {
-    hide_ext_ui(eid, proxy$session, board_ns = bns)
+  for (eid in as_obj_id(ext_panel_ids(dock$proxy))) {
+    hide_ext_ui(eid, dock$proxy$session, board_ns = bns)
   }
 }
 
@@ -307,13 +307,13 @@ show_view_ui <- function(view_id, docks) {
   if (is.null(view_id) || !exists(view_id, envir = docks, inherits = FALSE)) {
     return()
   }
-  proxy <- docks[[view_id]]$proxy
-  bns <- proxy_board_ns(proxy)
-  for (bid in as_obj_id(block_panel_ids(proxy))) {
-    show_block_ui(bid, proxy$session, board_ns = bns)
+  dock <- docks[[view_id]]
+  bns <- dock_board_ns(dock)
+  for (bid in as_obj_id(block_panel_ids(dock$proxy))) {
+    show_block_ui(bid, dock$proxy$session, board_ns = bns)
   }
-  for (eid in as_obj_id(ext_panel_ids(proxy))) {
-    show_ext_ui(eid, proxy$session, board_ns = bns)
+  for (eid in as_obj_id(ext_panel_ids(dock$proxy))) {
+    show_ext_ui(eid, dock$proxy$session, board_ns = bns)
   }
 }
 
@@ -479,21 +479,20 @@ reconcile_views <- function(board, update, docks, active_dock,
 # and force a needless rebuild (#196).
 reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
 
-  proxy <- dock$proxy
   target_ids <- layout_panel_ids(target)
-  live_ids <- isolate(proxy$live_panels())
+  live_ids <- isolate(dock$live_panels())
 
   if (!setequal(live_ids, target_ids)) {
 
     apply_layout_diff(
       view = view,
       target = target,
-      proxy = proxy,
+      dock = dock,
       blocks = blocks,
       extensions = extensions
     )
 
-    proxy$live_panels(target_ids)
+    dock$live_panels(target_ids)
 
     return(invisible())
   }
@@ -508,7 +507,7 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
     apply_layout_diff(
       view = view,
       target = target,
-      proxy = proxy,
+      dock = dock,
       blocks = blocks,
       extensions = extensions
     )
@@ -528,8 +527,9 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
 #' @param layout Optional initial `dock_layout`; defaults to the board's
 #'   `active_layout()`.
 #'
-#' @return A list with `layout` (reactive), `proxy`, `prev_active_group`,
-#'   `n_panels`, and `active_group_trail`.
+#' @return The view's `dock` handle: a list holding the dockViewR `proxy`
+#'   alongside `board_ns`, `live_panels`, `layout` (reactive), `n_panels`,
+#'   `prev_active_group`, and `active_group_trail`.
 #'
 #' @noRd
 manage_dock <- function(
@@ -549,9 +549,28 @@ manage_dock <- function(
   board_ns <- get_session()$ns
 
   moduleServer(id, function(input, output, session) {
-    dock <- set_dock_view_output(session = session)
-    dock$board_ns <- board_ns
-    dock$live_panels <- reactiveVal(as.character(layout_panel_ids(init_layout)))
+
+    # `dock` is our handle for this view's live dock: it *contains* the
+    # dockViewR proxy alongside the server-side state the dock helpers need --
+    # the board-level namespace, the authoritative panel-membership set, and the
+    # module's reactive outputs. The proxy itself is never mutated. n_panels
+    # derives from the membership set, so the empty-dock prompt no longer waits
+    # on the browser's `n-panels` echo.
+    proxy <- set_dock_view_output(session = session)
+    live_panels <- reactiveVal(as.character(layout_panel_ids(init_layout)))
+    prev_active_group <- reactiveVal()
+    active_group_trail <- reactiveVal()
+    n_panels <- reactive(length(live_panels()))
+
+    dock <- list(
+      proxy = proxy,
+      board_ns = board_ns,
+      live_panels = live_panels,
+      layout = reactive(dockViewR::get_dock(proxy)),
+      n_panels = n_panels,
+      prev_active_group = prev_active_group,
+      active_group_trail = active_group_trail
+    )
 
     # Fold live-only membership changes — the add-panel modal, a closed tab, an
     # extension show / hide — back into board_layouts in the same flush, so the
@@ -559,13 +578,13 @@ manage_dock <- function(
     # restores a layout that lags the live dock. Block add / remove fold through
     # the update lifecycle already; this catches the dock-only paths.
     observeEvent(
-      dock$live_panels(),
+      live_panels(),
       {
         layouts <- board_layouts(board$board)
 
         if (id %in% names(layouts)) {
 
-          folded <- fold_live_membership(layouts[[id]], dock$live_panels())
+          folded <- fold_live_membership(layouts[[id]], live_panels())
 
           if (!is.null(folded)) {
             update(list(views = list(mod = set_names(list(folded), id))))
@@ -589,14 +608,14 @@ manage_dock <- function(
     observeEvent(
       req(input[[dock_input("initialized")]]),
       {
-        restore_layout(init_layout, dock,
+        restore_layout(init_layout, dock$proxy,
                        blocks = init_blocks, extensions = init_exts)
 
         for (pid in as_dock_panel_id(init_layout)) {
           if (is_block_panel_id(pid)) {
-            show_block_panel(pid, add_panel = FALSE, proxy = dock)
+            show_block_panel(pid, add_panel = FALSE, dock = dock)
           } else if (is_ext_panel_id(pid)) {
-            show_ext_panel(pid, add_panel = FALSE, proxy = dock)
+            show_ext_panel(pid, add_panel = FALSE, dock = dock)
           } else {
             blockr_abort(
               "Unknown panel type {class(pid)}.",
@@ -608,15 +627,6 @@ manage_dock <- function(
       once = TRUE
     )
 
-    n_panels <- reactiveVal(
-      length(determine_active_views(init_layout))
-    )
-
-    observeEvent(
-      req(input[[dock_input("n-panels")]]),
-      n_panels(input[[dock_input("n-panels")]])
-    )
-
     observeEvent(
       input[[dock_input("panel-to-remove")]],
       {
@@ -625,11 +635,9 @@ manage_dock <- function(
         )
 
         if (is_block_panel_id(pid)) {
-          hide_block_panel(pid, rm_panel = TRUE, proxy = dock)
-          n_panels(n_panels() - 1L)
+          hide_block_panel(pid, rm_panel = TRUE, dock = dock)
         } else if (is_ext_panel_id(pid)) {
-          hide_ext_panel(pid, rm_panel = TRUE, proxy = dock)
-          n_panels(n_panels() - 1L)
+          hide_ext_panel(pid, rm_panel = TRUE, dock = dock)
         } else {
           blockr_abort(
             "Unknown panel type {class(pid)}.",
@@ -674,20 +682,16 @@ manage_dock <- function(
             show_block_panel(
               board_blocks(board$board)[as_obj_id(new_block_panel_id(pid))],
               add_panel = pos,
-              proxy = dock
+              dock = dock
             )
-
-            n_panels(n_panels() + 1L)
           } else if (maybe_ext_panel_id(pid)) {
             exts <- as.list(dock_extensions(board$board))
 
             show_ext_panel(
               exts[[as_obj_id(new_ext_panel_id(pid))]],
               add_panel = pos,
-              proxy = dock
+              dock = dock
             )
-
-            n_panels(n_panels() + 1L)
           } else {
             blockr_abort(
               "Unknown panel specification {pid}.",
@@ -699,9 +703,6 @@ manage_dock <- function(
         removeModal()
       }
     )
-
-    prev_active_group <- reactiveVal()
-    active_group_trail <- reactiveVal()
 
     observeEvent(
       input[[dock_input("active-group")]],
@@ -732,7 +733,7 @@ manage_dock <- function(
           new_name <- delta[["block_name"]]
           blk_panel_id <- as_block_panel_id(blk_id)
 
-          old_title <- get_dock_panel(blk_panel_id, dock)$title
+          old_title <- get_dock_panel(blk_panel_id, dock$proxy)$title
 
           if (identical(new_name, old_title)) {
             next
@@ -741,7 +742,7 @@ manage_dock <- function(
           log_debug("setting panel title {blk_panel_id} to '{new_name}'")
 
           dockViewR::set_panel_title(
-            dock,
+            dock$proxy,
             blk_panel_id,
             new_name
           )
@@ -749,13 +750,7 @@ manage_dock <- function(
       }
     )
 
-    list(
-      layout = reactive(dockViewR::get_dock(dock)),
-      proxy = dock,
-      prev_active_group = prev_active_group,
-      n_panels = n_panels,
-      active_group_trail = active_group_trail
-    )
+    dock
   })
 }
 
@@ -1034,7 +1029,7 @@ suggest_panels_to_add <- function(
   ns <- session$ns
 
   if (is.null(panels)) {
-    panels <- dock_panel_ids(dock)
+    panels <- dock_panel_ids(dock$proxy)
   }
 
   stopifnot(is.list(panels), all(lgl_ply(panels, is_dock_panel_id)))

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -30,13 +30,12 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   triggers <- action_triggers(actions)
 
   # Per-session dock state, closure-private. `docks` is the live manage_dock()
-  # registry; `client_active` / `client_views` mirror what the browser shows
-  # (lagging board_layouts), diffed by reconcile_views() — the sole mutator.
-  # `committed_layouts` records, per view, the board_layouts the live dock was
-  # last reconciled to, so reconcile pushes a layout back to the dock only when
-  # the committed layout genuinely changed (#196).
+  # registry; `client_active` / `client_views` mirror which views the browser
+  # shows, diffed by reconcile_views() — the sole mutator. Per-view panel
+  # membership lives on each dock proxy (`live_panels`), kept authoritative by
+  # the add/remove touchpoints, so reconcile compares against it rather than the
+  # lagging browser echo.
   docks <- new.env(parent = emptyenv())
-  committed_layouts <- new.env(parent = emptyenv())
   active_dock <- reactiveValues()
   client_active <- reactiveVal(NULL)
   client_views <- reactiveVal(seed_view_state(board_layouts(initial_board)))
@@ -53,7 +52,7 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
     board$board,
     reconcile_views(
       board, update, docks, active_dock, client_active, client_views,
-      committed_layouts, session
+      session
     )
   )
 
@@ -378,18 +377,17 @@ remove_view <- function(v_id, session, docks) {
 }
 
 # Make the live dock session match the committed board's view set:
-# instantiate added views, tear down removed ones, restore views whose
-# committed layout changed, relabel renamed ones, and switch to the active
-# view. Takes the reactive board handle (not a snapshot) so the live list
-# reaches manage_dock, whose interaction observers read board$board after the
-# fact (#194); the committed board is snapshotted once here for this pass's
-# reads. Driven by board$board so apply_board_update.dock_board stays a pure
-# reducer and dock state never crosses the package boundary. Idempotent — a
-# board already matching the live state produces no surgery — so it composes
-# with the live-sync (DOM -> board) path without ping-ponging.
+# instantiate added views, tear down removed ones, push layout changes to
+# surviving views, relabel renamed ones, and switch to the active view. Takes
+# the reactive board handle (not a snapshot) so the live list reaches
+# manage_dock, whose interaction observers read board$board after the fact
+# (#194); the committed board is snapshotted once here for this pass's reads.
+# Driven by board$board so apply_board_update.dock_board stays a pure reducer
+# and dock state never crosses the package boundary. Idempotent — a board
+# already matching the live state produces no surgery — so it composes with the
+# live-sync (DOM -> board) path without ping-ponging.
 reconcile_views <- function(board, update, docks, active_dock,
-                            client_active, client_views, committed_layouts,
-                            session) {
+                            client_active, client_views, session) {
 
   brd <- board$board
 
@@ -416,7 +414,6 @@ reconcile_views <- function(board, update, docks, active_dock,
     )
 
     state[[v]] <- bare_view(layouts[[v]])
-    committed_layouts[[v]] <- layouts[[v]]
   }
 
   # Add a nav item only for views the nav doesn't already show. `board_ui`
@@ -436,10 +433,6 @@ reconcile_views <- function(board, update, docks, active_dock,
     remove_view(v, session, docks)
     session$sendInputMessage("view_nav", list(remove = v))
     state[[v]] <- NULL
-
-    if (exists(v, envir = committed_layouts, inherits = FALSE)) {
-      rm(list = v, envir = committed_layouts)
-    }
   }
 
   for (v in intersect(want, have)) {
@@ -454,34 +447,13 @@ reconcile_views <- function(board, update, docks, active_dock,
       )
     }
 
-    # Restore the live dock from board_layouts only when this view's committed
-    # layout actually changed (a views$mod, a board restore). A block add
-    # touches the live dock through insert_block_ui without changing
-    # board_layouts, and the live-sync mirrors it back later; reconciling that
-    # drift here would restore the dock to a board_layouts that lags it, wiping
-    # the just-added block panels (#196).
-    prev <- get0(v, envir = committed_layouts, inherits = FALSE,
-                 ifnotfound = NULL)
-
-    committed_layouts[[v]] <- layouts[[v]]
-
-    if (is.null(prev) || !layouts_match(layouts[[v]], prev)) {
-
-      live <- tryCatch(
-        isolate(docks[[v]]$layout()),
-        error = function(e) NULL
-      )
-
-      if (!is.null(live) && !layouts_match(live, layouts[[v]])) {
-        apply_layout_diff(
-          view = v,
-          target = layouts[[v]],
-          proxy = docks[[v]]$proxy,
-          blocks = board_blocks(brd),
-          extensions = dock_extensions(brd)
-        )
-      }
-    }
+    reconcile_view_layout(
+      docks[[v]],
+      v,
+      layouts[[v]],
+      board_blocks(brd),
+      dock_extensions(brd)
+    )
   }
 
   client_views(state)
@@ -490,6 +462,55 @@ reconcile_views <- function(board, update, docks, active_dock,
         !identical(server_active, isolate(client_active()))) {
     switch_active_view(
       server_active, docks, active_dock, client_active, session
+    )
+  }
+
+  invisible()
+}
+
+# Push one view's committed layout to its live dock. Panel membership is tracked
+# authoritatively on the proxy (`live_panels`), kept in lockstep by the
+# add/remove touchpoints, so a mismatch there is a programmatic add / remove the
+# dock has not been told about (a views$mod, a board restore) — restore it and
+# record the new membership. When membership already agrees, only the
+# arrangement can differ; reconcile that against the browser's echoed state, but
+# skip until the echo has caught up to the current membership, so a just-added
+# panel (live_panels ahead of the echo) does not read as an arrangement change
+# and force a needless rebuild (#196).
+reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
+
+  proxy <- dock$proxy
+  target_ids <- layout_panel_ids(target)
+  live_ids <- isolate(proxy$live_panels())
+
+  if (!setequal(live_ids, target_ids)) {
+
+    apply_layout_diff(
+      view = view,
+      target = target,
+      proxy = proxy,
+      blocks = blocks,
+      extensions = extensions
+    )
+
+    proxy$live_panels(target_ids)
+
+    return(invisible())
+  }
+
+  live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
+
+  if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
+    return(invisible())
+  }
+
+  if (!layouts_match(live, target)) {
+    apply_layout_diff(
+      view = view,
+      target = target,
+      proxy = proxy,
+      blocks = blocks,
+      extensions = extensions
     )
   }
 
@@ -530,6 +551,7 @@ manage_dock <- function(
   moduleServer(id, function(input, output, session) {
     dock <- set_dock_view_output(session = session)
     dock$board_ns <- board_ns
+    dock$live_panels <- reactiveVal(as.character(layout_panel_ids(init_layout)))
 
     if (get_log_level() >= debug_log_level) {
       observeEvent(

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -553,6 +553,28 @@ manage_dock <- function(
     dock$board_ns <- board_ns
     dock$live_panels <- reactiveVal(as.character(layout_panel_ids(init_layout)))
 
+    # Fold live-only membership changes — the add-panel modal, a closed tab, an
+    # extension show / hide — back into board_layouts in the same flush, so the
+    # panel set stays authoritative server-side and a later board change never
+    # restores a layout that lags the live dock. Block add / remove fold through
+    # the update lifecycle already; this catches the dock-only paths.
+    observeEvent(
+      dock$live_panels(),
+      {
+        layouts <- board_layouts(board$board)
+
+        if (id %in% names(layouts)) {
+
+          folded <- fold_live_membership(layouts[[id]], dock$live_panels())
+
+          if (!is.null(folded)) {
+            update(list(views = list(mod = set_names(list(folded), id))))
+          }
+        }
+      },
+      ignoreInit = TRUE
+    )
+
     if (get_log_level() >= debug_log_level) {
       observeEvent(
         input[[dock_input("active-group")]],

--- a/R/dock-board.R
+++ b/R/dock-board.R
@@ -333,8 +333,41 @@ augment_board_update.dock_board <- function(upd, board, ...,
   upd
 }
 
+# Record added blocks' panels in the active view's layout, in the same update
+# that adds the blocks. insert_block_ui() places them in the live dock; folding
+# them into board_layouts here -- rather than waiting for the debounced live
+# sync -- keeps the panel set authoritative server-side, so reconcile never
+# restores a board_layouts that lags the dock (#196) and serialization never
+# drops an added panel.
+add_block_panels_to_view <- function(board, block_ids) {
+
+  layouts <- board_layouts(board)
+  active <- active_view(layouts)
+
+  if (is.null(active)) {
+    return(board)
+  }
+
+  layout <- layouts[[active]]
+
+  for (bid in block_ids) {
+    layout <- append_panel_to_layout(
+      layout, as.character(as_block_panel_id(bid))
+    )
+  }
+
+  layouts[[active]] <- layout
+  board_layouts(board) <- layouts
+
+  board
+}
+
 #' @export
 apply_board_update.dock_board <- function(board, upd, ...) {
+
+  if (length(upd$blocks$add)) {
+    board <- add_block_panels_to_view(board, names(upd$blocks$add))
+  }
 
   if (!length(upd$views)) {
     return(board)

--- a/R/ext-ui.R
+++ b/R/ext-ui.R
@@ -1,26 +1,26 @@
-show_ext_panel <- function(ext, add_panel = TRUE, proxy = dock_proxy(), ...) {
+show_ext_panel <- function(ext, add_panel = TRUE, dock, ...) {
 
   if (isTRUE(add_panel)) {
-    add_ext_panel(ext, proxy = proxy)
+    add_ext_panel(ext, dock = dock)
   } else if (isFALSE(add_panel)) {
-    select_ext_panel(ext, proxy)
+    select_ext_panel(ext, dock$proxy)
   } else {
-    add_ext_panel(ext, position = add_panel, proxy = proxy)
+    add_ext_panel(ext, position = add_panel, dock = dock)
   }
 
-  show_ext_ui(ext, proxy$session,
-              board_ns = proxy_board_ns(proxy), ...)
+  show_ext_ui(ext, dock$proxy$session,
+              board_ns = dock_board_ns(dock), ...)
 
   invisible(NULL)
 }
 
-hide_ext_panel <- function(id, rm_panel = TRUE, proxy = dock_proxy(), ...) {
+hide_ext_panel <- function(id, rm_panel = TRUE, dock, ...) {
 
-  hide_ext_ui(id, proxy$session,
-              board_ns = proxy_board_ns(proxy), ...)
+  hide_ext_ui(id, dock$proxy$session,
+              board_ns = dock_board_ns(dock), ...)
 
   if (isTRUE(rm_panel)) {
-    remove_ext_panel(id, proxy)
+    remove_ext_panel(id, dock)
   }
 
   invisible(NULL)

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -24,58 +24,57 @@ block_panel_ids <- function(proxy = dock_proxy()) {
   )
 }
 
-# Authoritative server-side panel membership, carried on the dock proxy. Every
-# panel add / remove flows through these helpers, so the set stays in lockstep
-# with the live dock without waiting for the browser's debounced state echo --
-# which is what lets reconcile tell a just-added panel from a stale layout. A
-# bare dock_proxy() (no manage_dock backing) carries no tracker and is left be.
-track_panel_added <- function(proxy, id) {
-  lp <- proxy[["live_panels"]]
+# Maintain the authoritative server-side panel-membership set. Every panel add /
+# remove flows through add_*_panel() / remove_*_panel(), so updating here keeps
+# `live_panels` in lockstep with the live dock without waiting for the browser's
+# debounced state echo -- which is what lets reconcile tell a just-added panel
+# from a stale layout. `live_panels` is NULL for a dock with no tracker (a bare
+# test stub), in which case tracking is a no-op.
+track_panel_added <- function(live_panels, id) {
 
-  if (is.null(lp)) {
+  if (is.null(live_panels)) {
     return(invisible())
   }
 
   pid <- as.character(id)
-  cur <- isolate(lp())
+  cur <- isolate(live_panels())
 
   if (!pid %in% cur) {
-    lp(c(cur, pid))
+    live_panels(c(cur, pid))
   }
 
   invisible()
 }
 
-track_panel_removed <- function(proxy, id) {
-  lp <- proxy[["live_panels"]]
+track_panel_removed <- function(live_panels, id) {
 
-  if (is.null(lp)) {
+  if (is.null(live_panels)) {
     return(invisible())
   }
 
-  lp(setdiff(isolate(lp()), as.character(id)))
+  live_panels(setdiff(isolate(live_panels()), as.character(id)))
 
   invisible()
 }
 
-remove_block_panel <- function(id, proxy = dock_proxy()) {
+remove_block_panel <- function(id, dock) {
   pid <- as_block_panel_id(id)
 
   log_debug("removing block panel {pid}")
 
-  dockViewR::remove_panel(proxy, pid)
-  track_panel_removed(proxy, pid)
+  dockViewR::remove_panel(dock$proxy, pid)
+  track_panel_removed(dock$live_panels, pid)
 
   invisible(NULL)
 }
 
-add_block_panel <- function(block, ..., proxy = dock_proxy()) {
+add_block_panel <- function(block, ..., dock) {
   pid <- as_block_panel_id(block)
 
   log_debug("adding block panel {pid}")
 
-  dockViewR::add_panel(proxy, panel = block_panel(block, ...))
-  track_panel_added(proxy, pid)
+  dockViewR::add_panel(dock$proxy, panel = block_panel(block, ...))
+  track_panel_added(dock$live_panels, pid)
 
   invisible(NULL)
 }
@@ -99,26 +98,26 @@ block_panel <- function(block, ...) {
   dock_panel(id = pid, title = name, ...)
 }
 
-remove_ext_panel <- function(id, proxy = dock_proxy()) {
+remove_ext_panel <- function(id, dock) {
   pid <- as_ext_panel_id(id)
 
   log_debug("removing extension panel {pid}")
 
-  dockViewR::remove_panel(proxy, pid)
-  track_panel_removed(proxy, pid)
+  dockViewR::remove_panel(dock$proxy, pid)
+  track_panel_removed(dock$live_panels, pid)
 
   invisible(NULL)
 }
 
-add_ext_panel <- function(ext, ..., proxy = dock_proxy()) {
+add_ext_panel <- function(ext, ..., dock) {
   stopifnot(is_dock_extension(ext))
 
   pid <- as_ext_panel_id(ext)
 
   log_debug("adding extension panel {pid}")
 
-  dockViewR::add_panel(proxy, panel = ext_panel(ext, ...))
-  track_panel_added(proxy, pid)
+  dockViewR::add_panel(dock$proxy, panel = ext_panel(ext, ...))
+  track_panel_added(dock$live_panels, pid)
 
   invisible(NULL)
 }
@@ -201,8 +200,8 @@ dock_proxy <- function(session = get_session()) {
   dockViewR::dock_view_proxy(dock_id(), session = session)
 }
 
-proxy_board_ns <- function(proxy) {
-  coal(proxy$board_ns, proxy$session$ns)
+dock_board_ns <- function(dock) {
+  coal(dock$board_ns, dock$proxy$session$ns)
 }
 
 dock_panel <- function(...) {
@@ -266,12 +265,15 @@ dock_panel_groups <- function(session = get_session()) {
 #' without needing to re-bind.
 #'
 #' @param rv The `active_dock` `reactiveValues` to update.
-#' @param dock A dock module result (list with `layout`, `proxy`, etc.).
+#' @param dock A dock module result (list with `proxy`, `board_ns`,
+#'   `live_panels`, `layout`, etc.).
 #'
 #' @noRd
 update_active_dock <- function(rv, dock) {
-  rv$layout <- dock$layout
   rv$proxy <- dock$proxy
+  rv$board_ns <- dock$board_ns
+  rv$live_panels <- dock$live_panels
+  rv$layout <- dock$layout
   rv$prev_active_group <- dock$prev_active_group
   rv$n_panels <- dock$n_panels
   rv$active_group_trail <- dock$active_group_trail

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -24,20 +24,58 @@ block_panel_ids <- function(proxy = dock_proxy()) {
   )
 }
 
+# Authoritative server-side panel membership, carried on the dock proxy. Every
+# panel add / remove flows through these helpers, so the set stays in lockstep
+# with the live dock without waiting for the browser's debounced state echo --
+# which is what lets reconcile tell a just-added panel from a stale layout. A
+# bare dock_proxy() (no manage_dock backing) carries no tracker and is left be.
+track_panel_added <- function(proxy, id) {
+  lp <- proxy[["live_panels"]]
+
+  if (is.null(lp)) {
+    return(invisible())
+  }
+
+  pid <- as.character(id)
+  cur <- isolate(lp())
+
+  if (!pid %in% cur) {
+    lp(c(cur, pid))
+  }
+
+  invisible()
+}
+
+track_panel_removed <- function(proxy, id) {
+  lp <- proxy[["live_panels"]]
+
+  if (is.null(lp)) {
+    return(invisible())
+  }
+
+  lp(setdiff(isolate(lp()), as.character(id)))
+
+  invisible()
+}
+
 remove_block_panel <- function(id, proxy = dock_proxy()) {
   pid <- as_block_panel_id(id)
 
   log_debug("removing block panel {pid}")
 
   dockViewR::remove_panel(proxy, pid)
+  track_panel_removed(proxy, pid)
 
   invisible(NULL)
 }
 
 add_block_panel <- function(block, ..., proxy = dock_proxy()) {
-  log_debug("adding block panel {as_block_panel_id(block)}")
+  pid <- as_block_panel_id(block)
+
+  log_debug("adding block panel {pid}")
 
   dockViewR::add_panel(proxy, panel = block_panel(block, ...))
+  track_panel_added(proxy, pid)
 
   invisible(NULL)
 }
@@ -67,6 +105,7 @@ remove_ext_panel <- function(id, proxy = dock_proxy()) {
   log_debug("removing extension panel {pid}")
 
   dockViewR::remove_panel(proxy, pid)
+  track_panel_removed(proxy, pid)
 
   invisible(NULL)
 }
@@ -74,9 +113,12 @@ remove_ext_panel <- function(id, proxy = dock_proxy()) {
 add_ext_panel <- function(ext, ..., proxy = dock_proxy()) {
   stopifnot(is_dock_extension(ext))
 
-  log_debug("adding extension panel {as_ext_panel_id(ext)}")
+  pid <- as_ext_panel_id(ext)
+
+  log_debug("adding extension panel {pid}")
 
   dockViewR::add_panel(proxy, panel = ext_panel(ext, ...))
+  track_panel_added(proxy, pid)
 
   invisible(NULL)
 }

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -108,7 +108,6 @@ show_panel <- function(id, board, dock, type = c("block", "extension")) {
   stopifnot(is_string(id))
 
   type <- match.arg(type)
-  proxy <- dock$proxy
 
   if (identical(type, "block")) {
     stopifnot(id %in% board_block_ids(board))
@@ -116,7 +115,7 @@ show_panel <- function(id, board, dock, type = c("block", "extension")) {
     stopifnot(id %in% dock_ext_ids(board))
   }
 
-  panels <- dock_panel_ids(proxy)
+  panels <- dock_panel_ids(dock$proxy)
 
   if (identical(type, "block")) {
     panels <- panels[lgl_ply(panels, is_block_panel_id)]
@@ -128,9 +127,9 @@ show_panel <- function(id, board, dock, type = c("block", "extension")) {
 
   if (id %in% panels) {
     if (identical(type, "block")) {
-      select_block_panel(id, proxy)
+      select_block_panel(id, dock$proxy)
     } else {
-      select_ext_panel(id, proxy)
+      select_ext_panel(id, dock$proxy)
     }
 
     return(invisible())
@@ -140,13 +139,13 @@ show_panel <- function(id, board, dock, type = c("block", "extension")) {
 
   if (identical(type, "block")) {
     blocks <- board_blocks(board)
-    add_block_panel(blocks[id], position = pos, proxy = proxy)
-    show_block_ui(id, proxy$session, board_ns = proxy_board_ns(proxy))
+    add_block_panel(blocks[id], position = pos, dock = dock)
+    show_block_ui(id, dock$proxy$session, board_ns = dock_board_ns(dock))
   } else {
     exts <- dock_extensions(board)
 
-    add_ext_panel(exts[[id]], position = pos, proxy = proxy)
-    show_ext_ui(id, proxy$session, board_ns = proxy_board_ns(proxy))
+    add_ext_panel(exts[[id]], position = pos, dock = dock)
+    show_ext_ui(id, dock$proxy$session, board_ns = dock_board_ns(dock))
   }
 
   invisible()

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -341,6 +341,47 @@ drop_panels_from_layout <- function(layout, panel_ids) {
   result
 }
 
+# Add a panel to a view's layout as a new tab in its last group (an empty view
+# gets a single-panel grid), making it the open tab. Mirrors the live
+# `determine_panel_pos()` placement closely enough for the structural sync; the
+# exact arrangement is reconciled by the debounced geometry echo.
+append_panel_to_layout <- function(layout, panel_id) {
+
+  nm <- view_name(layout)
+  grid <- layout[["grid"]]
+
+  if (!length(grid_panel_ids(grid))) {
+
+    out <- new_dock_layout(grid = build_grid_tree(list(panel_id)))
+
+  } else {
+
+    leaves <- grid_leaves(grid)
+    last_id <- leaves[[length(leaves)]][["id"]]
+
+    append_to_last <- function(leaf) {
+
+      if (identical(leaf[["data"]][["id"]], last_id)) {
+        leaf[["data"]][["views"]] <- c(
+          leaf[["data"]][["views"]], list(panel_id)
+        )
+        leaf[["data"]][["activeView"]] <- panel_id
+      }
+
+      leaf
+    }
+
+    out <- layout
+    out[["grid"]] <- grid_map_leaves(grid, append_to_last)
+  }
+
+  if (!is.null(nm)) {
+    view_name(out) <- nm
+  }
+
+  validate_dock_layout(out)
+}
+
 # Merge user-supplied `views$mod` with the block-removal cleanup: when
 # both touch a view, the cleanup drops the removed block from whatever
 # layout the user submitted; otherwise the present one wins.

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -382,6 +382,31 @@ append_panel_to_layout <- function(layout, panel_id) {
   validate_dock_layout(out)
 }
 
+# Reconcile a view's stored layout to the panel set the live dock now holds,
+# dropping removed panels and appending added ones. Returns `NULL` when the
+# membership already matches, so the caller can skip a no-op update. Lets the
+# dock-only mutation paths (the add-panel modal, a closed tab, an extension
+# show/hide) fold their change into board_layouts without each re-deriving it.
+fold_live_membership <- function(layout, live_ids) {
+
+  current <- layout_panel_ids(layout)
+
+  added <- setdiff(live_ids, current)
+  removed <- setdiff(current, live_ids)
+
+  if (!length(added) && !length(removed)) {
+    return(NULL)
+  }
+
+  out <- drop_panels_from_layout(layout, removed)
+
+  for (pid in added) {
+    out <- append_panel_to_layout(out, pid)
+  }
+
+  out
+}
+
 # Merge user-supplied `views$mod` with the block-removal cleanup: when
 # both touch a view, the cleanup drops the removed block from whatever
 # layout the user submitted; otherwise the present one wins.

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -617,7 +617,7 @@ switch_active_view <- function(active, docks, active_dock, client_active,
 # Apply one view's layout change. v1 unconditionally restores the target
 # layout; surgical diff paths (noop / active-tab / reorder) are a
 # deferred follow-up that can dispatch here without touching callers.
-apply_layout_diff <- function(view, target, proxy, blocks, extensions) {
+apply_layout_diff <- function(view, target, dock, blocks, extensions) {
 
   log_debug("applying layout diff for view {view}")
 
@@ -629,20 +629,20 @@ apply_layout_diff <- function(view, target, proxy, blocks, extensions) {
   # (b) reattach them to the freshly-rendered panels afterwards. Iterate
   # object ids (as `hide_view_ui()` does): `for` over the classed id
   # vector would drop the class and double-prefix the move target.
-  for (oid in as_obj_id(block_panel_ids(proxy))) {
-    hide_block_panel(oid, rm_panel = FALSE, proxy = proxy)
+  for (oid in as_obj_id(block_panel_ids(dock$proxy))) {
+    hide_block_panel(oid, rm_panel = FALSE, dock = dock)
   }
-  for (oid in as_obj_id(ext_panel_ids(proxy))) {
-    hide_ext_panel(oid, rm_panel = FALSE, proxy = proxy)
+  for (oid in as_obj_id(ext_panel_ids(dock$proxy))) {
+    hide_ext_panel(oid, rm_panel = FALSE, dock = dock)
   }
 
-  restore_layout(target, proxy, blocks = blocks, extensions = extensions)
+  restore_layout(target, dock$proxy, blocks = blocks, extensions = extensions)
 
   for (pid in as_dock_panel_id(target)) {
     if (is_block_panel_id(pid)) {
-      show_block_panel(pid, add_panel = FALSE, proxy = proxy)
+      show_block_panel(pid, add_panel = FALSE, dock = dock)
     } else if (is_ext_panel_id(pid)) {
-      show_ext_panel(pid, add_panel = FALSE, proxy = proxy)
+      show_ext_panel(pid, add_panel = FALSE, dock = dock)
     } else {
       blockr_abort(
         "Unknown panel type {class(pid)}.",

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -747,6 +747,39 @@ test_that("extensions mod state is applied via the update lifecycle", {
   expect_identical(isolate(content()), "# new")
 })
 
+test_that("a live-only panel add folds into board_layouts (#217)", {
+
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(Page = list("a"))
+  )
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  upd <- reactiveVal()
+  res <- with_mock_context(ms, board_server_callback(board_rv, update = upd))
+  ms$flushReact()
+
+  proxy <- isolate(res$dock$proxy)
+  expect_false(is.null(proxy$live_panels))
+
+  # The add-panel modal / show_panel touch only the live dock; board_layouts
+  # must catch up in the same flush (via the fold observer), not the debounced
+  # echo, or a later reconcile would restore a layout missing the new panel.
+  cur <- isolate(proxy$live_panels())
+  isolate(proxy$live_panels(c(cur, "block_panel-b")))
+  ms$flushReact()
+
+  delta <- isolate(upd())
+
+  expect_false(is.null(delta$views$mod))
+  expect_setequal(
+    layout_panel_ids(delta$views$mod[[1L]]),
+    c("block_panel-a", "block_panel-b")
+  )
+})
+
 test_that("extension servers can read peer extension state", {
 
   peers <- NULL

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -388,11 +388,13 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
   # machinery so `ls(docks)` tracks created views. The add decision under test
   # keys off client_views, not docks.
   stub_create <- function(v_id, layout, board, update, session, docks, ...) {
-    assign(v_id, list(layout = function() NULL), envir = docks)
+    proxy <- list(
+      live_panels = reactiveVal(as.character(layout_panel_ids(layout)))
+    )
+    assign(v_id, list(layout = function() NULL, proxy = proxy), envir = docks)
   }
 
   docks <- new.env(parent = emptyenv())
-  committed_layouts <- new.env(parent = emptyenv())
   client_views <- with_mock_context(
     ms,
     reactiveVal(seed_view_state(board_layouts(board)))
@@ -408,7 +410,7 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
         ms,
         reconcile_views(
           board, update, docks, active_dock, client_active, client_views,
-          committed_layouts, rec_session
+          rec_session
         )
       ),
       create_view = stub_create,
@@ -465,7 +467,6 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   }
 
   docks <- new.env(parent = emptyenv())
-  committed_layouts <- new.env(parent = emptyenv())
   client_views <- with_mock_context(ms, reactiveVal(list()))
   client_active <- with_mock_context(ms, reactiveVal(NULL))
   active_dock <- with_mock_context(ms, reactiveValues())
@@ -480,7 +481,7 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
       ms,
       reconcile_views(
         rv, update, docks, active_dock, client_active, client_views,
-        committed_layouts, rec_session
+        rec_session
       )
     ),
     create_view = capture_create,
@@ -496,7 +497,7 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   expect_silent(isolate(board_block_ids(forwarded$board)))
 })
 
-test_that("reconcile skips a view with unchanged committed layout (#196)", {
+test_that("reconcile_views skips an added panel pending its echo (#196)", {
 
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
@@ -507,29 +508,32 @@ test_that("reconcile skips a view with unchanged committed layout (#196)", {
     sendCustomMessage = function(type, message) invisible()
   )
 
-  # One view holding block `a`. The live dock is ahead -- block `b`'s panel was
-  # just added through insert_block_ui, but board_layouts has not caught up
-  # (the live-sync is debounced). reconcile must not restore the dock to
-  # board_layouts here: that would wipe the just-added panel (#196).
+  # board_layouts holds both panels synchronously (the block-add fold) and the
+  # proxy's live_panels tracker has caught `b` from insert_block_ui, but the
+  # browser has not yet echoed `b` back through get_dock. reconcile must not
+  # restore here: membership agrees, so the only apparent difference is the
+  # not-yet-echoed panel insert_block_ui already placed -- restoring would wipe
+  # it (#196).
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
-    layouts = list(V = dock_layout("a"))
+    layouts = list(V = dock_layout("a", "b"))
   )
   board <- with_mock_context(ms, reactiveValues(board = brd))
 
-  target <- board_layouts(brd)[["V"]]
-  ahead <- board_layouts(
+  target_ids <- layout_panel_ids(board_layouts(brd)[["V"]])
+
+  behind <- board_layouts(
     new_dock_board(
-      blocks = c(a = new_dataset_block(), b = new_head_block()),
-      layouts = list(V = dock_layout("a", "b"))
+      blocks = c(a = new_dataset_block()),
+      layouts = list(V = dock_layout("a"))
     )
   )[["V"]]
 
   docks <- new.env(parent = emptyenv())
-  docks[["V"]] <- list(layout = function() ahead, proxy = NULL)
-
-  committed_layouts <- new.env(parent = emptyenv())
-  committed_layouts[["V"]] <- target
+  docks[["V"]] <- list(
+    layout = function() behind,
+    proxy = list(live_panels = with_mock_context(ms, reactiveVal(target_ids)))
+  )
 
   client_views <- with_mock_context(
     ms,
@@ -546,7 +550,7 @@ test_that("reconcile skips a view with unchanged committed layout (#196)", {
       ms,
       reconcile_views(
         board, update, docks, active_dock, client_active, client_views,
-        committed_layouts, session
+        session
       )
     ),
     apply_layout_diff = function(...) diffed <<- diffed + 1L,
@@ -557,7 +561,7 @@ test_that("reconcile skips a view with unchanged committed layout (#196)", {
   expect_identical(diffed, 0L)
 })
 
-test_that("reconcile_views restores a view whose committed layout changed", {
+test_that("reconcile_views pushes a programmatic membership change", {
 
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
@@ -568,9 +572,9 @@ test_that("reconcile_views restores a view whose committed layout changed", {
     sendCustomMessage = function(type, message) invisible()
   )
 
-  # The committed layout (and the live dock) hold block `a`; the board now
-  # carries `a` + `b` (a views$mod / restore). reconcile must push the new
-  # layout to the lagging live dock.
+  # board_layouts now carries `a` + `b`, but the dock's tracked membership is
+  # only `a`: a programmatic views$mod added `b`'s panel with no live op, so
+  # reconcile must push the new layout to the dock and record the new set.
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
     layouts = list(V = dock_layout("a", "b"))
@@ -578,18 +582,23 @@ test_that("reconcile_views restores a view whose committed layout changed", {
   board <- with_mock_context(ms, reactiveValues(board = brd))
 
   target <- board_layouts(brd)[["V"]]
-  behind <- board_layouts(
-    new_dock_board(
-      blocks = c(a = new_dataset_block(), b = new_head_block()),
-      layouts = list(V = dock_layout("a"))
-    )
-  )[["V"]]
+
+  behind_ids <- layout_panel_ids(
+    board_layouts(
+      new_dock_board(
+        blocks = c(a = new_dataset_block()),
+        layouts = list(V = dock_layout("a"))
+      )
+    )[["V"]]
+  )
+
+  live_panels <- with_mock_context(ms, reactiveVal(behind_ids))
 
   docks <- new.env(parent = emptyenv())
-  docks[["V"]] <- list(layout = function() behind, proxy = NULL)
-
-  committed_layouts <- new.env(parent = emptyenv())
-  committed_layouts[["V"]] <- behind
+  docks[["V"]] <- list(
+    layout = function() NULL,
+    proxy = list(live_panels = live_panels)
+  )
 
   client_views <- with_mock_context(
     ms,
@@ -606,7 +615,7 @@ test_that("reconcile_views restores a view whose committed layout changed", {
       ms,
       reconcile_views(
         board, update, docks, active_dock, client_active, client_views,
-        committed_layouts, session
+        session
       )
     ),
     apply_layout_diff = function(view, target, ...) {
@@ -619,6 +628,9 @@ test_that("reconcile_views restores a view whose committed layout changed", {
   expect_false(is.null(captured))
   expect_identical(captured$view, "V")
   expect_true(layouts_match(captured$target, target))
+
+  # The push records the new membership, so a later pass is a no-op.
+  expect_setequal(isolate(live_panels()), layout_panel_ids(target))
 })
 
 test_that("apply_board_update.dock_board switches active view", {
@@ -631,6 +643,31 @@ test_that("apply_board_update.dock_board switches active view", {
 
   expect_true(is_dock_board(out))
   expect_identical(active_name(out), "B")
+})
+
+test_that("apply_board_update folds an added block into the active view", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    layouts = list(A = list("a"), B = list("a"))
+  )
+
+  active <- active_view(board_layouts(brd))
+  other <- setdiff(names(board_layouts(brd)), active)
+
+  out <- apply_board_update(
+    brd,
+    list(blocks = list(add = as_blocks(c(b = new_head_block()))))
+  )
+
+  # The added block's panel lands in the active view synchronously -- not via
+  # the debounced live sync -- and nowhere else (#196, persistence gap).
+  expect_true(
+    "block_panel-b" %in% layout_panel_ids(board_layouts(out)[[active]])
+  )
+  expect_false(
+    "block_panel-b" %in% layout_panel_ids(board_layouts(out)[[other]])
+  )
 })
 
 test_that("validate_board_update.dock_board rejects malformed views slot", {

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -388,10 +388,11 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
   # machinery so `ls(docks)` tracks created views. The add decision under test
   # keys off client_views, not docks.
   stub_create <- function(v_id, layout, board, update, session, docks, ...) {
-    proxy <- list(
+    dock <- list(
+      layout = function() NULL,
       live_panels = reactiveVal(as.character(layout_panel_ids(layout)))
     )
-    assign(v_id, list(layout = function() NULL, proxy = proxy), envir = docks)
+    assign(v_id, dock, envir = docks)
   }
 
   docks <- new.env(parent = emptyenv())
@@ -532,7 +533,7 @@ test_that("reconcile_views skips an added panel pending its echo (#196)", {
   docks <- new.env(parent = emptyenv())
   docks[["V"]] <- list(
     layout = function() behind,
-    proxy = list(live_panels = with_mock_context(ms, reactiveVal(target_ids)))
+    live_panels = with_mock_context(ms, reactiveVal(target_ids))
   )
 
   client_views <- with_mock_context(
@@ -597,7 +598,7 @@ test_that("reconcile_views pushes a programmatic membership change", {
   docks <- new.env(parent = emptyenv())
   docks[["V"]] <- list(
     layout = function() NULL,
-    proxy = list(live_panels = live_panels)
+    live_panels = live_panels
   )
 
   client_views <- with_mock_context(
@@ -761,14 +762,14 @@ test_that("a live-only panel add folds into board_layouts (#217)", {
   res <- with_mock_context(ms, board_server_callback(board_rv, update = upd))
   ms$flushReact()
 
-  proxy <- isolate(res$dock$proxy)
-  expect_false(is.null(proxy$live_panels))
+  live_panels <- isolate(res$dock$live_panels)
+  expect_false(is.null(live_panels))
 
   # The add-panel modal / show_panel touch only the live dock; board_layouts
   # must catch up in the same flush (via the fold observer), not the debounced
   # echo, or a later reconcile would restore a layout missing the new panel.
-  cur <- isolate(proxy$live_panels())
-  isolate(proxy$live_panels(c(cur, "block_panel-b")))
+  cur <- isolate(live_panels())
+  isolate(live_panels(c(cur, "block_panel-b")))
   ms$flushReact()
 
   delta <- isolate(upd())

--- a/tests/testthat/test-utils-dock.R
+++ b/tests/testthat/test-utils-dock.R
@@ -1,3 +1,42 @@
+test_that("panel tracking keeps the proxy live_panels membership in step", {
+
+  shiny::isolate({
+
+    proxy <- list(live_panels = shiny::reactiveVal(character()))
+
+    track_panel_added(proxy, "block_panel-a")
+    track_panel_added(proxy, "block_panel-b")
+    track_panel_added(proxy, "block_panel-a")
+
+    expect_setequal(proxy$live_panels(), c("block_panel-a", "block_panel-b"))
+
+    track_panel_removed(proxy, "block_panel-a")
+
+    expect_setequal(proxy$live_panels(), "block_panel-b")
+  })
+})
+
+test_that("panel tracking is a no-op on a proxy without a tracker", {
+  expect_silent(track_panel_added(list(), "block_panel-a"))
+  expect_silent(track_panel_removed(list(), "block_panel-a"))
+})
+
+test_that("add_block_panel records the panel in the proxy tracker", {
+
+  local_mocked_bindings(
+    add_panel = function(...) invisible(),
+    .package = "dockViewR"
+  )
+
+  shiny::isolate({
+
+    proxy <- list(live_panels = shiny::reactiveVal(character()))
+    add_block_panel(c(a = new_dataset_block()), proxy = proxy)
+
+    expect_setequal(proxy$live_panels(), "block_panel-a")
+  })
+})
+
 test_that("parking panels iterates object ids, not panel strings", {
 
   # The footgun: `for` over the classed vector `block_panel_ids()`

--- a/tests/testthat/test-utils-dock.R
+++ b/tests/testthat/test-utils-dock.R
@@ -1,27 +1,27 @@
-test_that("panel tracking keeps the proxy live_panels membership in step", {
+test_that("panel tracking keeps the live_panels membership in step", {
 
   shiny::isolate({
 
-    proxy <- list(live_panels = shiny::reactiveVal(character()))
+    live_panels <- shiny::reactiveVal(character())
 
-    track_panel_added(proxy, "block_panel-a")
-    track_panel_added(proxy, "block_panel-b")
-    track_panel_added(proxy, "block_panel-a")
+    track_panel_added(live_panels, "block_panel-a")
+    track_panel_added(live_panels, "block_panel-b")
+    track_panel_added(live_panels, "block_panel-a")
 
-    expect_setequal(proxy$live_panels(), c("block_panel-a", "block_panel-b"))
+    expect_setequal(live_panels(), c("block_panel-a", "block_panel-b"))
 
-    track_panel_removed(proxy, "block_panel-a")
+    track_panel_removed(live_panels, "block_panel-a")
 
-    expect_setequal(proxy$live_panels(), "block_panel-b")
+    expect_setequal(live_panels(), "block_panel-b")
   })
 })
 
-test_that("panel tracking is a no-op on a proxy without a tracker", {
-  expect_silent(track_panel_added(list(), "block_panel-a"))
-  expect_silent(track_panel_removed(list(), "block_panel-a"))
+test_that("panel tracking is a no-op without a tracker", {
+  expect_silent(track_panel_added(NULL, "block_panel-a"))
+  expect_silent(track_panel_removed(NULL, "block_panel-a"))
 })
 
-test_that("add_block_panel records the panel in the proxy tracker", {
+test_that("add_block_panel records the panel in the dock tracker", {
 
   local_mocked_bindings(
     add_panel = function(...) invisible(),
@@ -30,10 +30,10 @@ test_that("add_block_panel records the panel in the proxy tracker", {
 
   shiny::isolate({
 
-    proxy <- list(live_panels = shiny::reactiveVal(character()))
-    add_block_panel(c(a = new_dataset_block()), proxy = proxy)
+    dock <- list(proxy = NULL, live_panels = shiny::reactiveVal(character()))
+    add_block_panel(c(a = new_dataset_block()), dock = dock)
 
-    expect_setequal(proxy$live_panels(), "block_panel-a")
+    expect_setequal(dock$live_panels(), "block_panel-a")
   })
 })
 

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -204,12 +204,16 @@ test_that("reconcile_views syncs the nav and live state on rename", {
   )
 
   # Pre-populate the registry so reconcile sees the views as already
-  # instantiated (no DOM surgery); their live layout is pending (NULL) so the
-  # layout-mod check is skipped and only the rename fires.
+  # instantiated (no DOM surgery). The proxy's membership matches the board and
+  # the live layout is pending (NULL), so the layout check is a no-op and only
+  # the rename fires.
   docks <- new.env(parent = emptyenv())
-  committed_layouts <- new.env(parent = emptyenv())
   for (id in names(board_layouts(brd))) {
-    docks[[id]] <- list(layout = function() NULL)
+    ids <- as.character(layout_panel_ids(board_layouts(brd)[[id]]))
+    docks[[id]] <- list(
+      layout = function() NULL,
+      proxy = list(live_panels = reactiveVal(ids))
+    )
   }
   active_dock <- reactiveValues()
   client_active <- reactiveVal(active_view(board_layouts(brd)))
@@ -222,7 +226,7 @@ test_that("reconcile_views syncs the nav and live state on rename", {
 
   isolate(
     reconcile_views(board, function(...) NULL, docks, active_dock,
-                    client_active, client_views, committed_layouts, session)
+                    client_active, client_views, session)
   )
 
   expect_true(
@@ -582,6 +586,28 @@ test_that("drop_panels_from_layout resets the active tab when it is dropped", {
   expect_identical(leaf[["activeView"]], "a")
 })
 
+test_that("append_panel_to_layout appends a tab to the last group", {
+
+  out <- append_panel_to_layout(dock_layout("a", "b"), "c")
+
+  expect_setequal(layout_panel_ids(out), c("a", "b", "c"))
+
+  leaves <- grid_leaves(out[["grid"]])
+  last <- leaves[[length(leaves)]]
+
+  expect_true("c" %in% unlist(last[["views"]]))
+  expect_identical(last[["activeView"]], "c")
+})
+
+test_that("append_panel_to_layout seeds an empty view, keeps the name", {
+
+  empty <- append_panel_to_layout(new_dock_layout(), "a")
+  expect_setequal(layout_panel_ids(empty), "a")
+
+  named <- append_panel_to_layout(dock_layout("a", name = "Page 1"), "b")
+  expect_identical(view_name(named), "Page 1")
+})
+
 test_that("empty views payload causes apply to be a no-op", {
 
   brd <- new_dock_board(
@@ -669,11 +695,17 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
       sendCustomMessage = function(type, message) invisible()
     )
 
-    # Registry pre-populated for every view; the DOM helpers are mocked so the
-    # test exercises reconcile's nav-sync, not the live teardown / switch.
+    # Registry pre-populated for every view (proxy membership matching the
+    # board); the DOM helpers are mocked so the test exercises reconcile's
+    # nav-sync, not the live teardown / switch.
     docks <- new.env(parent = emptyenv())
-    committed_layouts <- new.env(parent = emptyenv())
-    for (id in names(state)) docks[[id]] <- list(layout = function() NULL)
+    for (id in names(state)) {
+      ids <- as.character(layout_panel_ids(state[[id]]))
+      docks[[id]] <- list(
+        layout = function() NULL,
+        proxy = list(live_panels = reactiveVal(ids))
+      )
+    }
     active_dock <- reactiveValues()
     client_active <- reactiveVal(name_to_id[[active_label]])
 
@@ -687,8 +719,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
     with_mocked_bindings(
       isolate(
         reconcile_views(board, function(...) NULL, docks, active_dock,
-                        client_active, client_views, committed_layouts,
-                        session)
+                        client_active, client_views, session)
       ),
       remove_view = function(view_id, session, docks) {
         rm(list = view_id, envir = docks)

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -608,6 +608,20 @@ test_that("append_panel_to_layout seeds an empty view, keeps the name", {
   expect_identical(view_name(named), "Page 1")
 })
 
+test_that("fold_live_membership matches the layout to the live panel set", {
+
+  ly <- dock_layout("a", "b")
+
+  added <- fold_live_membership(ly, c("a", "b", "c"))
+  expect_setequal(layout_panel_ids(added), c("a", "b", "c"))
+
+  dropped <- fold_live_membership(ly, "a")
+  expect_setequal(layout_panel_ids(dropped), "a")
+
+  # Already in sync -> NULL, so the caller skips a no-op update.
+  expect_null(fold_live_membership(ly, c("a", "b")))
+})
+
 test_that("empty views payload causes apply to be a no-op", {
 
   brd <- new_dock_board(

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -212,7 +212,7 @@ test_that("reconcile_views syncs the nav and live state on rename", {
     ids <- as.character(layout_panel_ids(board_layouts(brd)[[id]]))
     docks[[id]] <- list(
       layout = function() NULL,
-      proxy = list(live_panels = reactiveVal(ids))
+      live_panels = reactiveVal(ids)
     )
   }
   active_dock <- reactiveValues()
@@ -717,7 +717,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
       ids <- as.character(layout_panel_ids(state[[id]]))
       docks[[id]] <- list(
         layout = function() NULL,
-        proxy = list(live_panels = reactiveVal(ids))
+        live_panels = reactiveVal(ids)
       )
     }
     active_dock <- reactiveValues()


### PR DESCRIPTION
## Summary

A block add reached the live dock through `insert_block_ui()` but only reached `board_layouts()` via the debounced live sync. While it lagged, a board change fired `reconcile_views()`, which restored the dock to the stale `board_layouts` and wiped the just-added panels (#196); #204 papered over this by gating reconcile on a committed-layout snapshot. This makes the membership half of `board_layouts` authoritative server-side so that snapshot can go.

- dockViewR keeps no server-side copy of the dock — `get_dock()` only reflects the browser's last echo — so the server can never read the live panel set synchronously. But it *issues* every membership change (adds are server-side; closes are manual-mode), so it can track them. Each dock proxy now carries a `live_panels` set, kept in lockstep by the add/remove panel helpers (every touchpoint), replacing `committed_layouts`.
- A block add folds its panel into the active view's `board_layouts` in the same update (`apply_board_update.dock_board`), so the panel set never lags the dock.
- `reconcile_views()` compares membership against `live_panels`: a mismatch is a programmatic add/remove to push; when membership agrees it reconciles arrangement against the echo, but only once the echo has caught up — so a just-added panel never reads as an arrangement diff and forces a rebuild.
- Arrangement (sizes, drag reorders) has no server touchpoint and still flows through the debounced sync; it only matters for serialization, which reads the live dock directly. As a side effect, a headless `blockr_ser(board)` no longer drops an added block's panel from a view's layout.

Fixes #217
