### PR TITLE
Migrate block-condition display off removed server$cond

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,8 @@ Imports:
     shinyWidgets,
     jsonlite
 Remotes:
-    BristolMyersSquibb/blockr.ui,
-    BristolMyersSquibb/blockr.core,
+    BristolMyersSquibb/blockr.ui@225-block-conditions,
+    BristolMyersSquibb/blockr.core@217-board-conditions,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,8 @@ Imports:
     shinyWidgets,
     jsonlite
 Remotes:
-    BristolMyersSquibb/blockr.ui@225-block-conditions,
-    BristolMyersSquibb/blockr.core@217-board-conditions,
+    BristolMyersSquibb/blockr.ui,
+    BristolMyersSquibb/blockr.core,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:
     testthat (>= 3.0.0),

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -529,10 +529,10 @@ edit_block_server <- function(callbacks = list()) {
         conds <- reactive(
           {
             req(block_id %in% names(board$blocks))
+            df <- board$blocks[[block_id]]$server$conditions()
             lapply(
               set_names(nm = c("error", "warning", "message")),
-              function(cnd, cnds) coal(unlst(lst_xtr(cnds, cnd)), list()),
-              reactiveValuesToList(board$blocks[[block_id]]$server$cond)
+              function(sev) df$message[df$severity == sev]
             )
           }
         )


### PR DESCRIPTION
## Summary

- blockr.core#217 (PR BristolMyersSquibb/blockr.core#218) removed the block server's raw `cond` reactiveValues. Each block server now exposes `server$conditions()`, a reactive data frame with one row per active condition (columns `block`, `phase`, `severity`, `message`, `id`).
- `R/plugin-block.R` built its per-block condition display by walking `reactiveValuesToList(board$blocks[[id]]$server$cond)`. It now reads that frame and groups `message` by `severity`, producing the same per-severity message lists. `update_blk_cond_observer()` is unchanged — it already operates on the resulting character vectors (empty severities give `character(0)`, so its `length()` guard still skips them).

This is the dock half of a coordinated breaking change. CI on this branch installs core@main, which has no `server$conditions()` yet, so it will stay red until core #218 lands; that PR pins this branch into its revdep so the two are validated against each other and land together. Verified locally against core@217-board-conditions: the full dock suite passes, and the `testServer` block-condition tests drive the migrated path (they error against the old `server$cond` read, pass against the frame).

Fixes #225
