### PR TITLE
Pre-render the add/append block browsers; thin action handlers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/ci.yaml@main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
   revdep:
-    uses: cynkra/blockr.ci/.github/workflows/revdep.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/revdep.yaml@main
     with:
       revdep-packages: |
         BristolMyersSquibb/blockr.dag

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -6,7 +6,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    uses: cynkra/blockr.ci/.github/workflows/pkgdown.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/pkgdown.yaml@main
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
     permissions:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     shinyWidgets,
     jsonlite
 Remotes:
-    BristolMyersSquibb/blockr.ui,
+    BristolMyersSquibb/blockr.ui@feat/block-browser-prerender-and-ready-objects,
     BristolMyersSquibb/blockr.core,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     shinyWidgets,
     jsonlite
 Remotes:
-    BristolMyersSquibb/blockr.ui@feat/block-browser-prerender-and-ready-objects,
+    BristolMyersSquibb/blockr.ui,
     BristolMyersSquibb/blockr.core,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* The add-block browser is pre-rendered once into a dedicated
+  `add_block_sidebar` and merely toggled open, instead of being rebuilt
+  on every open. The add / append / prepend handlers are thin adapters
+  over `blockr.ui::block_browser_server()`, which now returns
+  ready-to-apply `blocks` / `links` objects (target port resolved
+  menu-side); the dock-side `build_block_from_spec()`, `valid_block_id()`
+  and `valid_link_id()` helpers are removed. Requires the matching
+  blockr.ui (`block_browser_server()` ready-objects contract).
+
 * Adding a block before the dock view has finished initialising no
   longer throws `argument is of length zero`. While the dock is
   uninitialised its layout is `NULL`; `determine_active_views()` now

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,16 @@
 # blockr.dock (development version)
 
-* The add-block browser is pre-rendered once into a dedicated
-  `add_block_sidebar` and merely toggled open, instead of being rebuilt
-  on every open. The add / append / prepend handlers are thin adapters
-  over `blockr.ui::block_browser_server()`, which now returns
-  ready-to-apply `blocks` / `links` objects (target port resolved
-  menu-side); the dock-side `build_block_from_spec()`, `valid_block_id()`
-  and `valid_link_id()` helpers are removed. Requires the matching
-  blockr.ui (`block_browser_server()` ready-objects contract).
+* The add and append block browsers are each pre-rendered once into a
+  dedicated sidebar (`add_block_sidebar` / `append_block_sidebar`) and
+  merely toggled open, instead of being rebuilt on every open (the append
+  rebuild was ~500 ms with a large registry, dominated by instantiating
+  every block to compute the linkable filter). The add / append / prepend
+  handlers are thin adapters over `blockr.ui::block_browser_server()`,
+  which now returns ready-to-apply `blocks` / `links` objects (target port
+  resolved menu-side); the dock-side `build_block_from_spec()`,
+  `valid_block_id()` and `valid_link_id()` helpers are removed. Requires
+  the matching blockr.ui (`block_browser_server()` ready-objects
+  contract).
 
 * Adding a block before the dock view has finished initialising no
   longer throws `argument is of length zero`. While the dock is

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -37,31 +37,28 @@ add_block_action <- function(trigger, board, update, ...) {
 append_block_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
-      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
-      # Append is trigger-specific (the source is the right-clicked
-      # block), so the browser is rendered per open. Passing board +
-      # target makes it return `list(blocks, links)` with the link's
-      # port already resolved - this handler just applies both.
+      # The append catalogue (linkable blocks) is registry-based, not
+      # source-specific, so its body is pre-rendered once in `board_ui()`
+      # (the `append_block_sidebar` mount) and opening is a pure toggle.
+      # The source (right-clicked block) is supplied here via the `target`
+      # reactive and resolved into the link at commit; the "Append from X"
+      # context goes in the sidebar title.
+      sidebar_id <- NS(isolate(board$board_id), "append_block_sidebar")
       added <- blockr.ui::block_browser_server(
         "browser",
         board = reactive(board$board),
         target = reactive(blockr.ui::append_to(trigger()))
       )
 
-      browser_ui <- function() {
-        blockr.ui::block_browser_ui(
-          session$ns("browser"), board$board,
-          blockr.ui::append_to(trigger())
-        )
-      }
+      title <- function() paste0("Append from ", trigger())
 
       observeEvent(trigger(), {
-        blockr.ui::show_sidebar(
-          sidebar_id, title = "Append new block", ui = browser_ui()
-        )
+        blockr.ui::show_sidebar(sidebar_id, title = title())
       })
 
       observeEvent(added(), {
+        # `added()` is `list(blocks, links)` with the link's port already
+        # resolved menu-side; apply both.
         res <- added()
         update(list(
           blocks = list(add = res$blocks),
@@ -69,7 +66,7 @@ append_block_action <- function(trigger, board, update, ...) {
         ))
 
         blockr.ui::keep_or_hide_sidebar(
-          sidebar_id, title = "Append new block", ui = browser_ui()
+          sidebar_id, ui = NULL, title = title()
         )
       })
 

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -1,36 +1,30 @@
 add_block_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
-      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
-      added <- blockr.ui::block_browser_server("browser")
-
-      browser_ui <- function() {
-        blockr.ui::block_browser_ui(session$ns("browser"), board$board)
-      }
+      # The add browser's catalogue never varies, so its body is
+      # pre-rendered once in `board_ui()` (the `add_block_sidebar` mount)
+      # under this action's namespace. Opening it is a pure toggle - no
+      # re-render, no server round-trip for the markup.
+      sidebar_id <- NS(isolate(board$board_id), "add_block_sidebar")
+      added <- blockr.ui::block_browser_server(
+        "browser",
+        board = reactive(board$board)
+      )
 
       observeEvent(trigger(), {
-        log_debug("showing add block action sidebar")
-        blockr.ui::show_sidebar(
-          sidebar_id, title = "Add new block", ui = browser_ui()
-        )
+        log_debug("opening pre-rendered add block sidebar")
+        blockr.ui::show_sidebar(sidebar_id, title = "Add new block")
       })
 
       observeEvent(added(), {
-        spec <- added()
+        # `added()` is a ready-to-apply `blocks` object (id-keyed, block
+        # built and named menu-side), so just add it.
+        update(list(blocks = list(add = added())))
 
-        if (!valid_block_id(spec$id, board$board, session)) return()
-
-        new_blk <- build_block_from_spec(spec, board$board, session)
-        if (is.null(new_blk)) return()
-
-        update(list(
-          blocks = list(
-            add = as_blocks(set_names(list(new_blk), spec$id))
-          )
-        ))
-
+        # Re-open without `ui` keeps the pre-rendered body in place (no
+        # re-render) when the user pinned the panel; otherwise it hides.
         blockr.ui::keep_or_hide_sidebar(
-          sidebar_id, title = "Add new block", ui = browser_ui()
+          sidebar_id, ui = NULL, title = "Add new block"
         )
       })
 
@@ -44,7 +38,15 @@ append_block_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
-      added <- blockr.ui::block_browser_server("browser")
+      # Append is trigger-specific (the source is the right-clicked
+      # block), so the browser is rendered per open. Passing board +
+      # target makes it return `list(blocks, links)` with the link's
+      # port already resolved - this handler just applies both.
+      added <- blockr.ui::block_browser_server(
+        "browser",
+        board = reactive(board$board),
+        target = reactive(blockr.ui::append_to(trigger()))
+      )
 
       browser_ui <- function() {
         blockr.ui::block_browser_ui(
@@ -60,41 +62,10 @@ append_block_action <- function(trigger, board, update, ...) {
       })
 
       observeEvent(added(), {
-        spec <- added()
-
-        if (!valid_block_id(spec$id, board$board, session)) return()
-        if (!valid_link_id(spec$link_id, board$board, session)) return()
-
-        new_blk <- build_block_from_spec(spec, board$board, session)
-        if (is.null(new_blk)) return()
-
-        # The browser hides the input-port picker when the new block
-        # has a single named input or is variadic. `block_input_select`
-        # resolves both cases uniformly: it returns the named slot, or
-        # a freshly-generated integer slot for variadic blocks.
-        block_input <- spec$block_input
-        if (is.null(block_input) || !nzchar(block_input)) {
-          block_input <- block_input_select(
-            new_blk,
-            block_id = spec$id,
-            links = board_links(board$board),
-            mode = "inputs"
-          )[1L]
-        }
-
-        new_lnk <- new_link(
-          from = trigger(),
-          to = spec$id,
-          input = block_input
-        )
-
+        res <- added()
         update(list(
-          blocks = list(
-            add = as_blocks(set_names(list(new_blk), spec$id))
-          ),
-          links = list(
-            add = as_links(set_names(list(new_lnk), spec$link_id))
-          )
+          blocks = list(add = res$blocks),
+          links = list(add = res$links)
         ))
 
         blockr.ui::keep_or_hide_sidebar(
@@ -112,7 +83,11 @@ prepend_block_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
-      added <- blockr.ui::block_browser_server("browser")
+      added <- blockr.ui::block_browser_server(
+        "browser",
+        board = reactive(board$board),
+        target = reactive(blockr.ui::prepend_to(trigger()))
+      )
 
       browser_ui <- function() {
         blockr.ui::block_browser_ui(
@@ -128,40 +103,10 @@ prepend_block_action <- function(trigger, board, update, ...) {
       })
 
       observeEvent(added(), {
-        spec <- added()
-
-        if (!valid_block_id(spec$id, board$board, session)) return()
-        if (!valid_link_id(spec$link_id, board$board, session)) return()
-
-        new_blk <- build_block_from_spec(spec, board$board, session)
-        if (is.null(new_blk)) return()
-
-        # Target input port: user pick (arity > 1) or default to the
-        # first available slot, mirroring the previous prepend behaviour.
-        target_input <- spec$target_input
-        if (is.null(target_input) || !nzchar(target_input)) {
-          inps <- block_input_select(
-            board_blocks(board$board)[[trigger()]],
-            trigger(),
-            board_links(board$board),
-            mode = "inputs"
-          )
-          target_input <- inps[1L]
-        }
-
-        new_lnk <- new_link(
-          from = spec$id,
-          to = trigger(),
-          input = target_input
-        )
-
+        res <- added()
         update(list(
-          blocks = list(
-            add = as_blocks(set_names(list(new_blk), spec$id))
-          ),
-          links = list(
-            add = as_links(set_names(list(new_lnk), spec$link_id))
-          )
+          blocks = list(add = res$blocks),
+          links = list(add = res$links)
         ))
 
         blockr.ui::keep_or_hide_sidebar(
@@ -186,62 +131,4 @@ remove_block_action <- function(trigger, board, update, ...) {
     },
     id = "remove_block_action"
   )
-}
-
-# ---- helpers shared by add / append / prepend --------------------------
-
-# The block browser pre-seeds unique ids via `rand_names()` against the
-# current board, so the typical case here is a no-op pass. We still
-# guard against an empty / duplicate id that the user could type into
-# the per-card form.
-valid_block_id <- function(id, board, session) {
-  if (is.null(id) || !nzchar(id) || id %in% board_block_ids(board)) {
-    notify(
-      "Please choose a valid block ID.",
-      type = "warning",
-      session = session
-    )
-    return(FALSE)
-  }
-  TRUE
-}
-
-valid_link_id <- function(id, board, session) {
-  if (is.null(id) || !nzchar(id) || id %in% board_link_ids(board)) {
-    notify(
-      "Please choose a valid link ID.",
-      type = "warning",
-      session = session
-    )
-    return(FALSE)
-  }
-  TRUE
-}
-
-# Instantiate via the registry by uid (spec$type). Apply the user's
-# title if supplied; otherwise keep `create_block_with_name`'s auto-
-# numbered name so "Dataset 1" / "Dataset 2" still works on repeat adds.
-build_block_from_spec <- function(spec, board, session) {
-  blk <- tryCatch(
-    create_block_with_name(
-      spec$type,
-      chr_ply(board_blocks(board), block_name)
-    ),
-    error = function(e) {
-      notify(
-        paste0("Could not create block: ", conditionMessage(e)),
-        type = "error",
-        session = session
-      )
-      NULL
-    }
-  )
-
-  if (is.null(blk)) return(NULL)
-
-  if (!is.null(spec$title) && nzchar(spec$title)) {
-    block_name(blk) <- spec$title
-  }
-
-  blk
 }

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -86,13 +86,18 @@ board_ui.dock_board <- function(
     # DOM ids. Action handlers reach the matching mount by reading
     # `board$board_id` (set by blockr.core in the board's reactiveValues)
     # and composing `NS(board$board_id, "actions_sidebar")` at server time.
-    # Contract: one sidebar = one concern. We mount two on the right
+    # Contract: one sidebar = one concern. We mount three on the right
     # (matching their navbar triggers) but with different modes so they
     # coexist cleanly when both are open:
-    #   * "actions_sidebar":  the six action handlers (add/append/prepend
-    #     block, add link, add/edit stack). `push` mode: shifts page
-    #     content aside while open. Body is populated server-side via
-    #     `show_sidebar()` because each action ships a freshly-built form.
+    #   * "actions_sidebar":  the trigger-specific action handlers
+    #     (append/prepend block, add link, add/edit stack). `push` mode:
+    #     shifts page content aside while open. Body is populated
+    #     server-side via `show_sidebar()` because each ships a
+    #     freshly-built, trigger-dependent form.
+    #   * "add_block_sidebar": the add-block browser. `push` mode. Body
+    #     is pre-rendered here at UI-build time (its catalogue is the
+    #     registry, board-independent) and the add action just toggles
+    #     it, so opening never re-renders.
     #   * "settings_sidebar": the navbar gear's board-options panel.
     #     `overlay` mode: layers above the page (and above the action
     #     panel when both are pinned) without reflowing content. Body is
@@ -104,7 +109,23 @@ board_ui.dock_board <- function(
     # pin semantics intuitive without multi-pin machinery on the JS side.
     blockr.ui::sidebar_ui(
       NS(id, "actions_sidebar"),
-      mode = "push",
+      mode = "overlay",
+      side = "right"
+    ),
+    # "add_block_sidebar": the add-block browser. Its catalogue is the
+    # registry and never varies, so the body is pre-rendered here once
+    # rather than rebuilt on every open (the dynamic actions_sidebar
+    # path). The id is composed so the markup lands under the
+    # `add_block_action` server's namespace - that handler mounts
+    # `block_browser_server("browser")` and just toggles this panel
+    # (`show_sidebar()` with no `ui`), so opening it never re-renders.
+    blockr.ui::sidebar_ui(
+      NS(id, "add_block_sidebar"),
+      ui = blockr.ui::block_browser_ui(
+        NS(NS(id, "add_block_action"), "browser")
+      ),
+      title = "Add new block",
+      mode = "overlay",
       side = "right"
     ),
     blockr.ui::sidebar_ui(

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -86,18 +86,19 @@ board_ui.dock_board <- function(
     # DOM ids. Action handlers reach the matching mount by reading
     # `board$board_id` (set by blockr.core in the board's reactiveValues)
     # and composing `NS(board$board_id, "actions_sidebar")` at server time.
-    # Contract: one sidebar = one concern. We mount three on the right
+    # Contract: one sidebar = one concern. We mount four on the right
     # (matching their navbar triggers) but with different modes so they
     # coexist cleanly when both are open:
-    #   * "actions_sidebar":  the trigger-specific action handlers
-    #     (append/prepend block, add link, add/edit stack). `push` mode:
-    #     shifts page content aside while open. Body is populated
-    #     server-side via `show_sidebar()` because each ships a
-    #     freshly-built, trigger-dependent form.
-    #   * "add_block_sidebar": the add-block browser. `push` mode. Body
-    #     is pre-rendered here at UI-build time (its catalogue is the
-    #     registry, board-independent) and the add action just toggles
-    #     it, so opening never re-renders.
+    #   * "actions_sidebar":  the remaining trigger-specific handlers
+    #     (add link, add/edit stack, and the dormant prepend block).
+    #     Body is populated server-side via `show_sidebar()` because each
+    #     ships a freshly-built, trigger-dependent form.
+    #   * "add_block_sidebar" / "append_block_sidebar": the block browser
+    #     for the add and append flows. Both catalogues are registry-based
+    #     (board- / source-independent), so their bodies are pre-rendered
+    #     here at UI-build time and the handlers just toggle them open, so
+    #     opening never re-renders. The source for append is supplied
+    #     server-side at commit.
     #   * "settings_sidebar": the navbar gear's board-options panel.
     #     `overlay` mode: layers above the page (and above the action
     #     panel when both are pinned) without reflowing content. Body is
@@ -125,6 +126,23 @@ board_ui.dock_board <- function(
         NS(NS(id, "add_block_action"), "browser")
       ),
       title = "Add new block",
+      mode = "overlay",
+      side = "right"
+    ),
+    # "append_block_sidebar": the append browser. Its linkable-block
+    # catalogue is registry-based, not source-specific, so it too is
+    # pre-rendered once (via the source-less `append_to()` descriptor).
+    # The right-clicked source is supplied server-side by the append
+    # action at commit; the "Append from X" context goes in the sidebar
+    # title. Composed id so the markup lands under the
+    # `append_block_action` server's namespace.
+    blockr.ui::sidebar_ui(
+      NS(id, "append_block_sidebar"),
+      ui = blockr.ui::block_browser_ui(
+        NS(NS(id, "append_block_action"), "browser"),
+        target = blockr.ui::append_to()
+      ),
+      title = "Append new block",
       mode = "overlay",
       side = "right"
     ),

--- a/tests/testthat/test-action-block.R
+++ b/tests/testthat/test-action-block.R
@@ -356,6 +356,53 @@ test_that("add block action toggles its pre-rendered sidebar on confirm", {
   )
 })
 
+test_that("append block action toggles its pre-rendered sidebar on confirm", {
+  keep_calls <- list()
+
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(id, ...) {
+      keep_calls[[length(keep_calls) + 1L]] <<-
+        list(id = id, args = list(...))
+      invisible(NULL)
+    },
+    hide_sidebar = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(a = new_dataset_block())),
+    board_id = "my_board"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        append_block_action(
+          trigger = reactive("a"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "head_block", id = "h1", title = NULL,
+        link_id = "lnk1", block_input = "data", nonce = 1
+      ))
+
+      expect_named(r_update(), c("blocks", "links"))
+      expect_length(keep_calls, 1L)
+      # Append also targets its dedicated, pre-rendered sidebar and
+      # re-opens without `ui` (no re-render); the source goes in the title.
+      expect_identical(keep_calls[[1L]]$id, "my_board-append_block_sidebar")
+      expect_identical(keep_calls[[1L]]$args$title, "Append from a")
+      expect_null(keep_calls[[1L]]$args$ui)
+    }
+  )
+})
+
 test_that("remove block action", {
   r_board <- reactiveValues(
     board = new_board(blocks = c(a = new_dataset_block()))

--- a/tests/testthat/test-action-block.R
+++ b/tests/testthat/test-action-block.R
@@ -1,17 +1,22 @@
-# The browser publishes its committed-block spec into the parent
-# session's namespace as `<sub>-commit`, where <sub> is the module id
-# the handler mounts (`block_browser_server("browser")`). Drive that
-# input directly to simulate the user adding a block.
+# `block_browser_server("browser")` publishes its committed value into the
+# parent session's namespace as `browser-commit`. The module now builds
+# the block (and, for append / prepend, the link with its port resolved)
+# and returns a ready-to-apply value: a `blocks` object for add, or
+# `list(blocks, links)` for append / prepend. The handlers just apply it,
+# so these tests drive `browser-commit` and assert the `update()` payload.
+#
+# Id semantics: an empty id field means "assign me one" - the module
+# resolves a unique, board-avoiding id at commit. Only a *non-empty*
+# duplicate id is rejected (no commit fires).
 commit_spec <- function(...) list(...)
 
-test_that("add block action: valid commit creates one block", {
+test_that("add block action: commit creates one ready block", {
   r_board <- reactiveValues(board = new_board(), board_id = "b")
   r_update <- reactiveVal(list())
-
   local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
     .package = "blockr.ui"
   )
 
@@ -20,28 +25,15 @@ test_that("add block action: valid commit creates one block", {
       moduleServer(
         id,
         add_block_action(
-          trigger = reactive(TRUE),
-          board   = r_board,
-          update  = r_update
+          trigger = reactive(TRUE), board = r_board, update = r_update
         )
       )
     },
     {
       session$flushReact()
 
-      # Invalid: empty id -> no update.
       session$setInputs(`browser-commit` = commit_spec(
-        type = "dataset_block", id = "", title = NULL,
-        link_id = NULL, block_input = NULL, target_input = NULL,
-        nonce = 1
-      ))
-      expect_length(r_update(), 0L)
-
-      # Valid commit -> one block under spec$id.
-      session$setInputs(`browser-commit` = commit_spec(
-        type = "dataset_block", id = "ds1", title = "My data",
-        link_id = NULL, block_input = NULL, target_input = NULL,
-        nonce = 2
+        type = "dataset_block", id = "ds1", title = "My data", nonce = 1
       ))
 
       upd <- r_update()
@@ -54,20 +46,84 @@ test_that("add block action: valid commit creates one block", {
   )
 })
 
+test_that("add block action: an empty id is auto-assigned", {
+  r_board <- reactiveValues(board = new_board(), board_id = "b")
+  r_update <- reactiveVal(list())
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_block_action(
+          trigger = reactive(TRUE), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "dataset_block", id = "", title = NULL, nonce = 1
+      ))
+
+      upd <- r_update()
+      expect_named(upd, "blocks")
+      expect_s3_class(upd$blocks$add, "blocks")
+      # Auto-generated, non-empty id.
+      expect_true(nzchar(names(upd$blocks$add)))
+    }
+  )
+})
+
+test_that("add block action: a non-empty duplicate id is rejected", {
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(ds1 = new_dataset_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_block_action(
+          trigger = reactive(TRUE), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "dataset_block", id = "ds1", title = NULL, nonce = 1
+      ))
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
 test_that("append block action: NULL block_input falls back to the only slot", {
-  # head_block has a single input ("data"); the browser hides the
-  # input-port picker so spec$block_input arrives as NULL. The handler
-  # must fall back to that sole slot.
   r_board <- reactiveValues(
     board = new_board(blocks = c(a = new_dataset_block())),
     board_id = "b"
   )
   r_update <- reactiveVal(list())
-
   local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
     .package = "blockr.ui"
   )
 
@@ -76,18 +132,15 @@ test_that("append block action: NULL block_input falls back to the only slot", {
       moduleServer(
         id,
         append_block_action(
-          trigger = reactive("a"),
-          board   = r_board,
-          update  = r_update
+          trigger = reactive("a"), board = r_board, update = r_update
         )
       )
     },
     {
       session$flushReact()
-      session$setInputs(`browser-commit` = list(
+      session$setInputs(`browser-commit` = commit_spec(
         type = "head_block", id = "h1", title = NULL,
-        link_id = "lnk1", block_input = NULL, target_input = NULL,
-        nonce = 1
+        link_id = "lnk1", block_input = NULL, nonce = 1
       ))
 
       upd <- r_update()
@@ -104,11 +157,10 @@ test_that("append block action: valid commit creates one block + one link", {
     board_id = "b"
   )
   r_update <- reactiveVal(list())
-
   local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
     .package = "blockr.ui"
   )
 
@@ -117,28 +169,16 @@ test_that("append block action: valid commit creates one block + one link", {
       moduleServer(
         id,
         append_block_action(
-          trigger = reactive("a"),
-          board   = r_board,
-          update  = r_update
+          trigger = reactive("a"), board = r_board, update = r_update
         )
       )
     },
     {
       session$flushReact()
 
-      # Missing link_id -> no update.
-      session$setInputs(`browser-commit` = commit_spec(
-        type = "head_block", id = "h1", title = NULL,
-        link_id = "", block_input = "data", target_input = NULL,
-        nonce = 1
-      ))
-      expect_length(r_update(), 0L)
-
-      # Valid commit -> blocks add + links add.
       session$setInputs(`browser-commit` = commit_spec(
         type = "head_block", id = "h1", title = "First rows",
-        link_id = "lnk1", block_input = "data", target_input = NULL,
-        nonce = 2
+        link_id = "lnk1", block_input = "data", nonce = 1
       ))
 
       upd <- r_update()
@@ -147,6 +187,46 @@ test_that("append block action: valid commit creates one block + one link", {
       expect_named(upd$links$add, "lnk1")
       expect_s3_class(upd$blocks$add, "blocks")
       expect_s3_class(upd$links$add, "links")
+      # Link wires source -> new block.
+      df <- as.data.frame(upd$links$add)
+      expect_identical(df$from, "a")
+      expect_identical(df$to, "h1")
+    }
+  )
+})
+
+test_that("append block action: an empty link_id is auto-assigned", {
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(a = new_dataset_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        append_block_action(
+          trigger = reactive("a"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "head_block", id = "h1", title = NULL,
+        link_id = "", block_input = "data", nonce = 1
+      ))
+
+      upd <- r_update()
+      expect_named(upd, c("blocks", "links"))
+      expect_true(nzchar(names(upd$links$add)))
     }
   )
 })
@@ -157,11 +237,10 @@ test_that("prepend block action: target_input picks the link slot", {
     board_id = "b"
   )
   r_update <- reactiveVal(list())
-
   local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
     .package = "blockr.ui"
   )
 
@@ -170,9 +249,7 @@ test_that("prepend block action: target_input picks the link slot", {
       moduleServer(
         id,
         prepend_block_action(
-          trigger = reactive("m"),
-          board   = r_board,
-          update  = r_update
+          trigger = reactive("m"), board = r_board, update = r_update
         )
       )
     },
@@ -181,19 +258,62 @@ test_that("prepend block action: target_input picks the link slot", {
 
       session$setInputs(`browser-commit` = commit_spec(
         type = "dataset_block", id = "ds1", title = NULL,
-        link_id = "lnk1", block_input = NULL, target_input = "y",
-        nonce = 1
+        link_id = "lnk1", block_input = NULL, target_input = "y", nonce = 1
       ))
 
       upd <- r_update()
       expect_named(upd, c("blocks", "links"))
       expect_named(upd$blocks$add, "ds1")
       expect_named(upd$links$add, "lnk1")
+      df <- as.data.frame(upd$links$add)
+      # Prepend wires new block -> target on the chosen slot.
+      expect_identical(df$from, "ds1")
+      expect_identical(df$to, "m")
+      expect_identical(df$input, "y")
     }
   )
 })
 
-test_that("add block action chains via keep_or_hide_sidebar on confirm", {
+test_that("prepend: NULL target_input falls back to only slot", {
+  # head_block has arity 1 (input "data"); the browser hides the
+  # target_input picker, so spec$target_input arrives as NULL. The
+  # module resolves the target's only free slot.
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(h = new_head_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL),
+    .package = "blockr.ui"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        prepend_block_action(
+          trigger = reactive("h"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "dataset_block", id = "ds1", title = NULL,
+        link_id = "lnk1", block_input = NULL, target_input = NULL, nonce = 1
+      ))
+
+      upd <- r_update()
+      expect_length(upd$links$add, 1L)
+      expect_identical(as.data.frame(upd$links$add)$input, "data")
+    }
+  )
+})
+
+test_that("add block action toggles its pre-rendered sidebar on confirm", {
   keep_calls <- list()
 
   local_mocked_bindings(
@@ -215,251 +335,23 @@ test_that("add block action chains via keep_or_hide_sidebar on confirm", {
       moduleServer(
         id,
         add_block_action(
-          trigger = reactive(TRUE),
-          board   = r_board,
-          update  = r_update
+          trigger = reactive(TRUE), board = r_board, update = r_update
         )
       )
     },
     {
       session$flushReact()
       session$setInputs(`browser-commit` = commit_spec(
-        type = "dataset_block", id = "x", title = "X block",
-        link_id = NULL, block_input = NULL, target_input = NULL,
-        nonce = 1
+        type = "dataset_block", id = "x", title = "X block", nonce = 1
       ))
 
       expect_length(r_update(), 1L)
       expect_length(keep_calls, 1L)
-      expect_identical(keep_calls[[1L]]$id, "my_board-actions_sidebar")
+      # Add now targets its dedicated, pre-rendered sidebar and re-opens
+      # without `ui` (no re-render).
+      expect_identical(keep_calls[[1L]]$id, "my_board-add_block_sidebar")
       expect_identical(keep_calls[[1L]]$args$title, "Add new block")
-    }
-  )
-})
-
-test_that("append block action: invalid block_id does not update", {
-  r_board <- reactiveValues(
-    board = new_board(blocks = c(a = new_dataset_block())),
-    board_id = "b"
-  )
-  r_update <- reactiveVal(list())
-
-  local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
-    .package = "blockr.ui"
-  )
-
-  testServer(
-    function(id, ...) {
-      moduleServer(
-        id,
-        append_block_action(
-          trigger = reactive("a"),
-          board   = r_board,
-          update  = r_update
-        )
-      )
-    },
-    {
-      session$flushReact()
-      session$setInputs(`browser-commit` = list(
-        type = "head_block", id = "", title = NULL,
-        link_id = "lnk1", block_input = "data", target_input = NULL,
-        nonce = 1
-      ))
-      expect_length(r_update(), 0L)
-    }
-  )
-})
-
-test_that("prepend block action: invalid block_id / link_id do not update", {
-  r_board <- reactiveValues(
-    board = new_board(blocks = c(m = new_merge_block())),
-    board_id = "b"
-  )
-  r_update <- reactiveVal(list())
-
-  local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
-    .package = "blockr.ui"
-  )
-
-  testServer(
-    function(id, ...) {
-      moduleServer(
-        id,
-        prepend_block_action(
-          trigger = reactive("m"),
-          board   = r_board,
-          update  = r_update
-        )
-      )
-    },
-    {
-      session$flushReact()
-
-      # Empty block_id -> bail.
-      session$setInputs(`browser-commit` = list(
-        type = "dataset_block", id = "", title = NULL,
-        link_id = "lnk1", block_input = NULL, target_input = "x",
-        nonce = 1
-      ))
-      expect_length(r_update(), 0L)
-
-      # Empty link_id -> bail.
-      session$setInputs(`browser-commit` = list(
-        type = "dataset_block", id = "ds1", title = NULL,
-        link_id = "", block_input = NULL, target_input = "x",
-        nonce = 2
-      ))
-      expect_length(r_update(), 0L)
-    }
-  )
-})
-
-test_that("prepend: NULL target_input falls back to only slot", {
-  # head_block has arity 1 (input "data"); the browser hides the
-  # target_input picker, so spec$target_input arrives as NULL. The
-  # handler must fall back to `block_input_select(..., mode = "inputs")[1L]`.
-  r_board <- reactiveValues(
-    board = new_board(blocks = c(h = new_head_block())),
-    board_id = "b"
-  )
-  r_update <- reactiveVal(list())
-
-  local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
-    .package = "blockr.ui"
-  )
-
-  testServer(
-    function(id, ...) {
-      moduleServer(
-        id,
-        prepend_block_action(
-          trigger = reactive("h"),
-          board   = r_board,
-          update  = r_update
-        )
-      )
-    },
-    {
-      session$flushReact()
-      session$setInputs(`browser-commit` = list(
-        type = "dataset_block", id = "ds1", title = NULL,
-        link_id = "lnk1", block_input = NULL, target_input = NULL,
-        nonce = 1
-      ))
-
-      upd <- r_update()
-      expect_length(upd$links$add, 1L)
-      expect_identical(as.data.frame(upd$links$add)$input, "data")
-    }
-  )
-})
-
-test_that("append / prepend: unknown type bails after NULL block", {
-  # Both handlers must short-circuit on a build failure (the
-  # `if (is.null(new_blk)) return()` guard after build_block_from_spec).
-  r_board <- reactiveValues(
-    board = new_board(blocks = c(a = new_dataset_block(),
-                                 m = new_merge_block())),
-    board_id = "b"
-  )
-  r_update_app <- reactiveVal(list())
-  r_update_pre <- reactiveVal(list())
-
-  local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
-    .package = "blockr.ui"
-  )
-
-  bogus <- function(update_rv) {
-    list(
-      type = "no_such_block_xyz", id = "x", title = NULL,
-      link_id = "l", block_input = "x", target_input = "x",
-      nonce = 1
-    )
-  }
-
-  testServer(
-    function(id, ...) {
-      moduleServer(
-        id,
-        append_block_action(
-          trigger = reactive("a"),
-          board   = r_board,
-          update  = r_update_app
-        )
-      )
-    },
-    {
-      session$flushReact()
-      session$setInputs(`browser-commit` = bogus(r_update_app))
-      expect_length(r_update_app(), 0L)
-    }
-  )
-
-  testServer(
-    function(id, ...) {
-      moduleServer(
-        id,
-        prepend_block_action(
-          trigger = reactive("m"),
-          board   = r_board,
-          update  = r_update_pre
-        )
-      )
-    },
-    {
-      session$flushReact()
-      session$setInputs(`browser-commit` = bogus(r_update_pre))
-      expect_length(r_update_pre(), 0L)
-    }
-  )
-})
-
-test_that("build_block_from_spec: unknown type bails with notify", {
-  # An unknown registry uid in spec$type makes create_block_with_name
-  # throw; `build_block_from_spec` catches it, notifies, returns NULL,
-  # and the handlers bail without calling update().
-  r_board <- reactiveValues(board = new_board(), board_id = "b")
-  r_update <- reactiveVal(list())
-
-  local_mocked_bindings(
-    show_sidebar       = function(...) invisible(list(...)),
-    keep_or_hide_sidebar = function(...) invisible(list(...)),
-    hide_sidebar       = function(...) invisible(list(...)),
-    .package = "blockr.ui"
-  )
-
-  testServer(
-    function(id, ...) {
-      moduleServer(
-        id,
-        add_block_action(
-          trigger = reactive(TRUE),
-          board   = r_board,
-          update  = r_update
-        )
-      )
-    },
-    {
-      session$flushReact()
-      session$setInputs(`browser-commit` = list(
-        type = "no_such_block_xyz", id = "x", title = NULL,
-        link_id = NULL, block_input = NULL, target_input = NULL,
-        nonce = 1
-      ))
-      expect_length(r_update(), 0L)
+      expect_null(keep_calls[[1L]]$args$ui)
     }
   )
 })
@@ -475,9 +367,7 @@ test_that("remove block action", {
       moduleServer(
         id,
         remove_block_action(
-          trigger = reactive("a"),
-          board   = r_board,
-          update  = r_update
+          trigger = reactive("a"), board = r_board, update = r_update
         )
       )
     },

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -6,7 +6,9 @@ test_that("dummy board ui test", {
   )
 
   expect_s3_class(ui, "shiny.tag.list")
-  expect_length(ui, 8L)
+  # 8 base elements + the two pre-rendered block-browser sidebars
+  # (add_block_sidebar, append_block_sidebar).
+  expect_length(ui, 10L)
 })
 
 # Settings sidebar is mounted with pre-rendered content + a JS-trigger gear


### PR DESCRIPTION
## Summary

Pre-render the add and append block browsers and make the block action
handlers thin adapters over `blockr.ui::block_browser_server()`, which now
returns ready-to-apply `blocks` / `links` objects.

- The add and append catalogues are registry-based (board- /
  source-independent), so each is pre-rendered once into a dedicated
  sidebar (`add_block_sidebar` / `append_block_sidebar`, mounted at the
  matching action's composed namespace) and the handler just toggles it
  open — no rebuild on every open.
- `add` / `append` / `prepend` handlers apply the ready objects directly;
  removed the dock-side `build_block_from_spec()`, `valid_block_id()` and
  `valid_link_id()` (validation + port resolution now live menu-side).
- Prepend stays dynamic: its target-input picker is target/board-specific,
  and it has no UI trigger today.

Fixes the per-open append rebuild (blockr.dock#224).

## Why (profiling)

On a live deployment (54-block registry) append open was ~500 ms and
reopen was just as slow (no caching). The client render of the 50 cards was
~4 ms, so the cost was entirely the server rebuild — dominated by
instantiating every registered block to compute the linkable filter — now
moved to a one-time startup cost.

## Depends on

blockr.ui PR (ready-objects contract). `Remotes` points at
`blockr.ui@feat/block-browser-prerender-and-ready-objects`; revert to
`BristolMyersSquibb/blockr.ui` once that PR merges.

## Verification

`R CMD check` 0/0/0; `lintr` clean; `test-action-block.R` rewritten to the
new contract; verified on deployment (append now opens instantly).
