### PR TITLE
Add e2e test for serialization round-trip through a live app

### DIFF
--- a/tests/testthat/apps/serdes/app.R
+++ b/tests/testthat/apps/serdes/app.R
@@ -1,0 +1,32 @@
+library(blockr.core)
+library(blockr.dock)
+
+# Fixture for the serialization round-trip e2e: a board carrying every kind of
+# dock-owned state -- two views with distinct layouts (a rich multi-panel view
+# with custom sizes, an active panel and the extension panel; a single-panel
+# view), a non-default active view, plus blocks, a link and a stack. The test
+# exports this through the live Export/Import plugin and asserts the board
+# rebuilds and re-renders identically after the restore reload.
+serve(
+  new_dock_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_head_block(),
+      c = new_head_block()
+    ),
+    links = links(ab = new_link("a", "b", "data")),
+    stacks = stacks(grp = c("a", "b")),
+    extensions = new_edit_board_extension(),
+    layouts = list(
+      overview = dock_layout("c", name = "Overview"),
+      analysis = dock_layout(
+        "edit_board_extension",
+        panels("a", "b", active = "b"),
+        sizes = c(0.3, 0.7),
+        name = "Analysis"
+      )
+    ),
+    active = "analysis"
+  ),
+  "my_board"
+)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -85,6 +85,70 @@ read_view_nav <- function(app, board_id = "my_board") {
   )
 }
 
+# Wait until the server-rendered dock shell is in place: the view nav, every
+# block card and the active view's handle. These render independently of the
+# dockview client, so the serialization e2e can read them without racing the
+# (client-side) panel layout.
+wait_dock_loaded <- function(app, n_blocks, board_id = "my_board") {
+  app$wait_for_js(
+    sprintf("document.querySelector('#%s-view_nav') !== null", board_id),
+    timeout = 30 * 1000
+  )
+  app$wait_for_js(
+    sprintf(
+      "document.querySelectorAll('[id^=\"%s-block_handle-\"]').length === %d",
+      board_id, n_blocks
+    ),
+    timeout = 30 * 1000
+  )
+  app$wait_for_js(
+    "document.querySelector('.blockr-view-dock-active') !== null",
+    timeout = 30 * 1000
+  )
+}
+
+# The dock-owned board state observable in server-rendered DOM: the view nav
+# (one row per view), the active view's id (the `blockr-view-dock-active`
+# handle), and every block's card id. The serialization e2e captures this
+# before and after a save / restore reload to assert the round-trip rebuilds it
+# identically. Block cards live in a pool the dockview client teleports into
+# panels, so query their ids globally rather than from a fixed container.
+read_dock_state <- function(app, board_id = "my_board") {
+  container <- xml2::read_html(
+    app$get_html(paste0("#", board_id, "-view_container"))
+  )
+  active_node <- xml2::xml_find_all(
+    container,
+    paste0(
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ",
+      "' blockr-view-dock-active ')]"
+    )
+  )
+  active_view <- sub(
+    paste0("^", board_id, "-view_handle-"), "",
+    xml2::xml_attr(active_node, "id")
+  )
+
+  handles <- unlist(
+    app$get_js(
+      sprintf(
+        paste0(
+          "Array.from(document.querySelectorAll(",
+          "'[id^=\"%s-block_handle-\"]')).map(e => e.id)"
+        ),
+        board_id
+      )
+    )
+  )
+  block_ids <- sort(sub(paste0("^", board_id, "-block_handle-"), "", handles))
+
+  list(
+    nav = read_view_nav(app, board_id),
+    active_view = active_view,
+    blocks = block_ids
+  )
+}
+
 # Shared helpers for the edit-board extension e2e tests (links, stacks). The
 # extension namespaces its inputs under `my_board-edit_board_extension-`. The
 # extension panel stays active in those tests (pre-seeded fixtures, no block

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -236,3 +236,68 @@ test_that("multi-view nav renders one labelled entry per view (#189)", {
   expect_true("Third" %in% nav$label)
   expect_false(any(nav$label == ""))
 })
+
+test_that("a board survives the live Export/Import round-trip (#233)", {
+
+  skip_on_cran()
+
+  app <- shinytest2::AppDriver$new(
+    test_path("apps", "serdes"),
+    name = "serdes",
+    seed = 42,
+    load_timeout = 40 * 1000,
+    timeout = 30 * 1000
+  )
+  withr::defer(app$stop())
+
+  wait_dock_loaded(app, n_blocks = 3)
+  before <- read_dock_state(app)
+
+  # The fixture seeds the dock-owned state the round-trip must preserve: two
+  # named views with a non-default active view, plus three blocks.
+  expect_setequal(before$nav$label, c("Overview", "Analysis"))
+  expect_identical(before$nav$label[before$nav$active], "Analysis")
+  expect_identical(before$active_view, "analysis")
+  expect_identical(before$blocks, c("a", "b", "c"))
+
+  # Export through the live download handler, then assert the server-produced
+  # artifact carries the dock-owned state the DOM does not surface without the
+  # dockview client -- the extension, the panel-level layout, the producer
+  # version that routes deserialization -- alongside blocks, links and stacks.
+  path <- app$get_download("my_board-preserve_board-serialize")
+  expect_gt(file.size(path), 0)
+
+  ser <- jsonlite::fromJSON(path, simplifyDataFrame = FALSE,
+                            simplifyMatrix = FALSE)
+  expect_identical(
+    ser$constructor$version,
+    as.character(utils::packageVersion("blockr.dock"))
+  )
+
+  restored <- blockr_deser(ser)
+  expect_setequal(board_block_ids(restored), c("a", "b", "c"))
+  expect_identical(board_link_ids(restored), "ab")
+  expect_setequal(names(board_stacks(restored)), "grp")
+  expect_length(dock_extensions(restored), 1L)
+
+  ly <- board_layouts(restored)
+  expect_identical(unname(view_names(ly)), c("Overview", "Analysis"))
+  expect_identical(active_view(ly), "analysis")
+  expect_setequal(
+    layout_panel_ids(ly[["analysis"]]),
+    c("ext_panel-edit_board_extension", "block_panel-a", "block_panel-b")
+  )
+
+  # Import the saved file. Restoring reloads the session: the probe, wiped by
+  # the reload, both waits for and proves the reload fired.
+  app$run_js("window.__serdes_probe = true;")
+  app$upload_file(`my_board-preserve_board-restore` = path, wait_ = FALSE)
+  app$wait_for_js("typeof window.__serdes_probe === 'undefined'",
+                  timeout = 30 * 1000)
+
+  wait_dock_loaded(app, n_blocks = 3)
+
+  # The deserialize + reconcile + re-render rebuilds the dock-owned view
+  # structure and the blocks identically.
+  expect_identical(read_dock_state(app), before)
+})


### PR DESCRIPTION
## Summary

- Serialization is otherwise covered only by pure-function unit tests; this adds the live-server e2e the round-trip lacked (part of #228), exercising the dock serde, reconcile and `session$reload()` path through a running app.
- The fixture board carries every kind of dock-owned state: two named views with a non-default active view, a multi-panel layout with custom sizes and an active panel, the edit-board extension panel, plus blocks, a link and a stack.
- The test drives the live Export download and asserts the server-produced artifact (producer version, views, active view, extension panel, blocks / links / stacks), then drives the Import upload and asserts the post-reload DOM rebuilds the view structure and blocks identically.
- DOM facts are read with xml2 (view nav, the active-view handle, block cards) — no UI snapshots; the restore reload is proven by a JS probe the reload wipes.

Fixes #233
