### PR TITLE
Fix dock layout save: restore reconcile priority so view_data() isn't stuck NULL

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -49,12 +49,25 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   # Reconcile the live dock session against the committed board (create /
   # destroy / restore / rename / switch views), keeping apply_board_update a
   # pure reducer. No ignoreInit: initial render is the empty-`docks` case.
+  #
+  # priority = 100 so this runs before the layout upsync on the init flush.
+  # The upsync reads live_view_data, which iterates `docks`; until reconcile
+  # has populated `docks`, live_view_data returns NULL early WITHOUT taking a
+  # dependency on any dock's `_state` input. reconcile's later client_views()
+  # write is an identical() no-op, so live_view_data would never re-evaluate
+  # and view_data() would stay NULL for the whole session -- stranding the
+  # upsync (no live layout ever mirrored to board_layouts) and the export
+  # (serialize_board then falls back to the board's default layout). Ordering
+  # dock creation first lets live_view_data's first read see the docks and
+  # bind to `_state`. Do not drop this without making live_view_data
+  # re-evaluate on dock creation by some other means.
   observeEvent(
     board$board,
     reconcile_views(
       board, update, docks, active_dock, client_active, client_views,
       committed_layouts, session
-    )
+    ),
+    priority = 100
   )
 
   # Extensions receive active_dock — a reactiveValues that always mirrors


### PR DESCRIPTION
Fixes #243.

Restores `priority = 100` on the reconcile `observeEvent(board$board, …)` in `board_server_callback` (`R/board-server.R`), lost in `7a36146` *"Remove the priority=100 hack"*.

Without it, the layout-upsync reads `live_view_data` on the init flush **before** `reconcile_views` populates the `docks` registry. The early `return(NULL)` guard then takes a dependency only on `client_views()` (never on the dock `_state` input), and reconcile's later `client_views(state)` write is an `identical()` no-op — so `view_data()` stays NULL for the whole session. `serialize_board.dock_board()` then falls back to the board's default layout, and live rearrangements are lost on Export.

Restoring the priority makes reconcile populate `docks` before the upsync's first read, so `live_view_data` binds to `_state` and tracks live edits.

**Verified live** (Playwright, `blockr.dm/dev/example-value-filter.R`): rearrange panels → Export now captures the live layout (`[dag]{data,flt_df,flt_dm}[adsl]`) instead of the 1-group default.

Note: this branch was originally cut off `feat/block-browser-prerender-and-ready-objects`; that branch has since merged to `main` (#227), so this targets `main` directly. See #243 for the full write-up and the proposed flush-order-independent follow-up.