### PR TITLE
Keep live panel rearrangements on save (#243)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* Live panel rearrangements are no longer lost when a board is saved
+  (#243). `view_data()`, the live dock layout that serialization reads,
+  was stuck at `NULL` for the whole session, so Export fell back to the
+  board's default layout. The live dock registry is now a
+  `reactiveValues` rather than a plain environment, so `view_data()`
+  takes a dependency on each view's entry and re-evaluates when reconcile
+  creates it -- whatever the init flush order -- instead of relying on a
+  reconcile observer priority to win that race.
+
 * The add and append block browsers are each pre-rendered once into a
   dedicated sidebar (`add_block_sidebar` / `append_block_sidebar`) and
   merely toggled open, instead of being rebuilt on every open (the append

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -30,12 +30,14 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   triggers <- action_triggers(actions)
 
   # Per-session dock state, closure-private. `docks` is the live manage_dock()
-  # registry; `client_active` / `client_views` mirror which views the browser
-  # shows, diffed by reconcile_views() — the sole mutator. Per-view panel
-  # membership lives on each dock proxy (`live_panels`), kept authoritative by
-  # the add/remove touchpoints, so reconcile compares against it rather than the
-  # lagging browser echo.
-  docks <- new.env(parent = emptyenv())
+  # registry, keyed by view id; `client_active` / `client_views` mirror which
+  # views the browser shows, diffed by reconcile_views() — the sole mutator.
+  # Per-view panel membership lives on each dock proxy (`live_panels`), kept
+  # authoritative by the add/remove touchpoints, so reconcile compares against
+  # it rather than the lagging browser echo. `docks` is a `reactiveValues`, so
+  # live_view_data() depends on each view's entry and re-evaluates when
+  # reconcile creates it, whatever the init flush order.
+  docks <- reactiveValues()
   active_dock <- reactiveValues()
   client_active <- reactiveVal(NULL)
   client_views <- reactiveVal(seed_view_state(board_layouts(initial_board)))
@@ -161,8 +163,11 @@ switch_view_observer <- function(session, update, client_active) {
 
 # Returns NULL while any view is still pending — its dock not yet created by
 # reconcile, or its dockview layout not yet reported — so downstream observers
-# `req()` past the initial flush instead of racing reconcile. The active view
-# comes from `client_active`, not `client_views`.
+# `req()` past the initial flush. Reading `docks[[v_id]]` (a reactiveValues)
+# takes a dependency on each view's entry, so this re-evaluates when reconcile
+# creates the dock — whatever the init flush order — rather than stranding on
+# the empty-`docks` early return. The active view comes from `client_active`,
+# not `client_views`.
 live_view_data <- function(client_views, docks, client_active) {
   reactive({
     state <- client_views()
@@ -277,11 +282,11 @@ diff_dock_layouts <- function(current, new_layouts) {
 #' not visible while the view is inactive.
 #'
 #' @param view_id View id (string).
-#' @param docks Environment of dock module results, keyed by view id.
+#' @param docks `reactiveValues` of dock module results, keyed by view id.
 #'
 #' @noRd
 hide_view_ui <- function(view_id, docks) {
-  if (is.null(view_id) || !exists(view_id, envir = docks, inherits = FALSE)) {
+  if (is.null(view_id) || !(view_id %in% names(docks))) {
     return()
   }
   dock <- docks[[view_id]]
@@ -300,11 +305,11 @@ hide_view_ui <- function(view_id, docks) {
 #' becomes active.
 #'
 #' @param view_id View id (string).
-#' @param docks Environment of dock module results, keyed by view id.
+#' @param docks `reactiveValues` of dock module results, keyed by view id.
 #'
 #' @noRd
 show_view_ui <- function(view_id, docks) {
-  if (is.null(view_id) || !exists(view_id, envir = docks, inherits = FALSE)) {
+  if (is.null(view_id) || !(view_id %in% names(docks))) {
     return()
   }
   dock <- docks[[view_id]]
@@ -360,7 +365,7 @@ create_view <- function(v_id, layout, board, update, session, docks,
 # surviving in another view keeps its single-instance board-level UI.
 remove_view <- function(v_id, session, docks) {
 
-  if (!exists(v_id, envir = docks, inherits = FALSE)) {
+  if (!(v_id %in% names(docks))) {
     return(invisible())
   }
 
@@ -371,7 +376,7 @@ remove_view <- function(v_id, session, docks) {
     immediate = TRUE,
     session = session
   )
-  rm(list = v_id, envir = docks)
+  trim_rv(docks, v_id)
 
   invisible()
 }
@@ -396,7 +401,7 @@ reconcile_views <- function(board, update, docks, active_dock,
   labels <- view_names(layouts)
   server_active <- active_view(layouts)
   state <- isolate(client_views())
-  have <- ls(docks)
+  have <- names(docks)
   shown <- names(state)
 
   for (v in setdiff(want, have)) {

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -589,7 +589,7 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     return(invisible())
   }
 
-  if (exists(active, envir = docks, inherits = FALSE)) {
+  if (active %in% names(docks)) {
 
     # switch-view must fire before show_view_ui so the target dock carries
     # blockr-view-dock-active; otherwise move-element drops DOM moves into an

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -262,7 +262,7 @@ test_that("live_view_data is NULL while any view layout is uninitialized", {
       dock_layouts(A = new_dock_layout(), B = new_dock_layout())
     )
     ids <- names(client_views())
-    docks <- new.env(parent = emptyenv())
+    docks <- reactiveValues()
     docks[[ids[[1L]]]] <- list(layout = layouts$A)
     docks[[ids[[2L]]]] <- list(layout = layouts$B)
     client_active <- reactiveVal(ids[[1L]])
@@ -280,6 +280,89 @@ test_that("live_view_data is NULL while any view layout is uninitialized", {
   expect_s3_class(lys, "dock_layouts")
   expect_identical(unname(view_names(lys)), c("A", "B"))
   expect_identical(active_name(lys), "A")
+})
+
+test_that("live_view_data re-evaluates once docks are populated (#243)", {
+
+  # Regression: live_view_data first evaluated with `docks` still empty (its
+  # dock module not yet created by reconcile) and hit the empty-dock early
+  # return. When `docks` was a plain environment that read took no reactive
+  # dependency, so reconcile populating `docks` never re-triggered it --
+  # view_data() stayed NULL for the session and serialize fell back to the
+  # default layout. As a `reactiveValues`, reading `docks[[v_id]]` (even for an
+  # absent key) subscribes, so creating the dock re-evaluates this -- with no
+  # separate signal and regardless of flush order.
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  res <- with_mock_context(ms, {
+    client_views <- reactiveVal(dock_layouts(A = new_dock_layout()))
+    docks <- reactiveValues()
+    client_active <- reactiveVal(NULL)
+    list(
+      vd = live_view_data(client_views, docks, client_active),
+      docks = docks,
+      view = names(client_views())[[1L]]
+    )
+  })
+
+  # First read with empty docks: NULL, but the absent-key read has subscribed.
+  expect_null(isolate(res$vd()))
+
+  # Mimic reconcile creating the dock: the reactiveValues write alone
+  # re-triggers live_view_data.
+  layout <- with_mock_context(
+    ms, reactiveVal(list(grid = list(), panels = list()))
+  )
+  with_mock_context(ms, res$docks[[res$view]] <- list(layout = layout))
+
+  lys <- isolate(res$vd())
+
+  expect_s3_class(lys, "dock_layouts")
+  expect_identical(unname(view_names(lys)), "A")
+})
+
+test_that("view_data() tracks a reported layout despite flush order (#243)", {
+
+  # The same regression through the real reconcile + live_view_data composition.
+  # Reading view_data() before the first flush reproduces the init order the
+  # bug needs -- the upsync reads live_view_data while `docks` is still empty,
+  # before reconcile creates the dock modules. The browser then reports a
+  # rearranged layout via the dock `_state` input, which view_data() must pick
+  # up rather than staying frozen at the seed.
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(Page = dock_layout("a", "b"))
+  )
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  res <- with_mock_context(
+    ms, board_server_callback(board_rv, update = reactiveVal())
+  )
+
+  # Force the first read before reconcile runs: docks empty, so NULL.
+  expect_null(isolate(res$view_data()))
+
+  ms$flushReact()
+
+  # The browser reports the live grid through the dock `_state` input, carrying
+  # the real `block_panel-*` ids reversed from the seeded order. It is built
+  # with the public dock_layout() constructor -- which dockview_to_layout()
+  # accepts unclassed -- rather than hand-rolled dockview JSON.
+  reported <- unclass(dock_layout("block_panel-b", "block_panel-a"))
+  do.call(ms$setInputs, set_names(list(reported), "Page-dock_state"))
+  ms$flushReact()
+
+  vd <- isolate(res$view_data())
+
+  # view_data() carries the reported order, not the frozen `[a, b]` default.
+  expect_s3_class(vd, "dock_layouts")
+  expect_identical(
+    layout_panel_ids(vd[["Page"]]),
+    c("block_panel-b", "block_panel-a")
+  )
 })
 
 test_that("layouts_to_board_observer fires update views on divergence", {
@@ -385,17 +468,17 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
   )
 
   # Stand in for create_view: register the dock without the DOM / module
-  # machinery so `ls(docks)` tracks created views. The add decision under test
-  # keys off client_views, not docks.
+  # machinery so `names(docks)` tracks created views. The add decision under
+  # test keys off client_views, not docks.
   stub_create <- function(v_id, layout, board, update, session, docks, ...) {
     dock <- list(
       layout = function() NULL,
       live_panels = reactiveVal(as.character(layout_panel_ids(layout)))
     )
-    assign(v_id, dock, envir = docks)
+    docks[[v_id]] <- dock
   }
 
-  docks <- new.env(parent = emptyenv())
+  docks <- with_mock_context(ms, reactiveValues())
   client_views <- with_mock_context(
     ms,
     reactiveVal(seed_view_state(board_layouts(board)))
@@ -464,10 +547,10 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   forwarded <- NULL
   capture_create <- function(v_id, layout, board, update, session, docks, ...) {
     forwarded <<- board
-    assign(v_id, list(layout = function() NULL), envir = docks)
+    docks[[v_id]] <- list(layout = function() NULL)
   }
 
-  docks <- new.env(parent = emptyenv())
+  docks <- with_mock_context(ms, reactiveValues())
   client_views <- with_mock_context(ms, reactiveVal(list()))
   client_active <- with_mock_context(ms, reactiveVal(NULL))
   active_dock <- with_mock_context(ms, reactiveValues())
@@ -530,7 +613,7 @@ test_that("reconcile_views skips an added panel pending its echo (#196)", {
     )
   )[["V"]]
 
-  docks <- new.env(parent = emptyenv())
+  docks <- with_mock_context(ms, reactiveValues())
   docks[["V"]] <- list(
     layout = function() behind,
     live_panels = with_mock_context(ms, reactiveVal(target_ids))
@@ -595,7 +678,7 @@ test_that("reconcile_views pushes a programmatic membership change", {
 
   live_panels <- with_mock_context(ms, reactiveVal(behind_ids))
 
-  docks <- new.env(parent = emptyenv())
+  docks <- with_mock_context(ms, reactiveValues())
   docks[["V"]] <- list(
     layout = function() NULL,
     live_panels = live_panels

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -207,7 +207,7 @@ test_that("reconcile_views syncs the nav and live state on rename", {
   # instantiated (no DOM surgery). The proxy's membership matches the board and
   # the live layout is pending (NULL), so the layout check is a no-op and only
   # the rename fires.
-  docks <- new.env(parent = emptyenv())
+  docks <- reactiveValues()
   for (id in names(board_layouts(brd))) {
     ids <- as.character(layout_panel_ids(board_layouts(brd)[[id]]))
     docks[[id]] <- list(
@@ -712,7 +712,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
     # Registry pre-populated for every view (proxy membership matching the
     # board); the DOM helpers are mocked so the test exercises reconcile's
     # nav-sync, not the live teardown / switch.
-    docks <- new.env(parent = emptyenv())
+    docks <- reactiveValues()
     for (id in names(state)) {
       ids <- as.character(layout_panel_ids(state[[id]]))
       docks[[id]] <- list(
@@ -736,7 +736,7 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
                         client_active, client_views, session)
       ),
       remove_view = function(view_id, session, docks) {
-        rm(list = view_id, envir = docks)
+        trim_rv(docks, view_id)
         invisible()
       },
       hide_view_ui = function(...) NULL,


### PR DESCRIPTION
## Summary

`view_data()` — the live dock layout that `serialize_board.dock_board()` reads — was frozen at `NULL` for the whole session, so Export fell back to the board's *default* layout and live panel rearrangements were lost on save. Regression from `7a36146`, which removed the `priority = 100` reconcile hack.

Root cause: `live_view_data`'s first read lands before `reconcile_views` has created the dock modules, and the `docks` registry was a plain environment — reading it takes no reactive dependency, so reconcile populating it never re-triggered `view_data()`.

- **Fix: `docks` is now a `reactiveValues`.** Reading `docks[[v_id]]` — even for an absent key — subscribes, so `view_data()` re-evaluates the moment reconcile creates the dock, regardless of init flush order. One reactive source of truth, no separate signal to keep in sync, and the bug can't silently regress.
- View removal goes through blockr.core's `trim_rv()` (BristolMyersSquibb/blockr.core#227), since assigning `NULL` to a `reactiveValues` key leaves it behind.

Two deterministic regression tests, both proven to fail when `docks` is reverted to a plain environment: a unit test on `live_view_data` and an integration test through the full `board_server_callback` composition (reported `_state` → `view_data()`, with the bug's init flush order forced). The view-lifecycle and panel-rearrange e2e tests (#232 / #234) exercise the refactored reconcile / remove / layout paths in CI.

Fixes #243. Supersedes #244 (the rejected `priority` restore).
