### PR TITLE
Harden e2e wait_bound against slow-runner DataTables rebind

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -208,15 +208,21 @@ set_in <- function(app, id, value) {
 click <- function(app, id) app$click(nsid(id))
 
 # A DataTables redraw (e.g. after adding a row) re-renders the cell inputs,
-# which Shiny re-binds client-side after the server goes idle; wait for the
-# binding before driving the new row's inputs.
-wait_bound <- function(app, id) {
+# which the table's `drawCallback` re-binds via `Shiny.bindAll` -- but only
+# once the async redraw completes, which can land *after* the server reports
+# idle. So idle alone does not mean the new inputs are drivable: wait for idle,
+# then poll for the `.shiny-bound-input` marker the rebind adds, both under one
+# generous budget. A fixed 15s window let a slow CI runner's redraw outlast it
+# and eject green PRs from the merge queue.
+wait_bound <- function(app, id, timeout = 30 * 1000) {
+
+  app$wait_for_idle(timeout = timeout)
+
   app$wait_for_js(
     paste0(
-      "document.querySelector('#", nsid(id),
-      ".shiny-bound-input') !== null"
+      "document.querySelector('#", nsid(id), ".shiny-bound-input') !== null"
     ),
-    timeout = 15 * 1000
+    timeout = timeout
   )
 }
 

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -76,7 +76,6 @@ test_that("edit board extension links blocks (e2e)", {
 
   set_in(app, "new_link_id", "ab")
   click(app, "add_link")
-  app$wait_for_idle()
   wait_bound(app, "ab_from")
 
   set_in(app, "ab_from", "a")
@@ -145,7 +144,6 @@ test_that("edit board extension stacks (e2e)", {
 
   set_in(app, "new_stack_id", "grp")
   click(app, "add_stack")
-  app$wait_for_idle()
   wait_bound(app, "grp_name")
 
   set_in(app, "grp_name", "Group A")


### PR DESCRIPTION
## Summary

- The e2e helper `wait_bound()` polled a fixed 15s window for the `.shiny-bound-input` marker after an `add_link` / `add_stack` DataTables redraw. Those cell inputs are re-bound client-side by the table's `drawCallback` (`Shiny.bindAll`), which can complete *after* the server reports idle — so on a loaded macOS CI runner the rebind lagged past the window, timed out, and ejected otherwise-green PRs from the merge queue (the #245 ejection that prompted this).
- `wait_bound()` now waits for idle, then polls the same marker, both under one generous, overridable 30s budget — folding in the `wait_for_idle()` the two call sites previously did separately (the issue's "couple the budget to `wait_for_idle()`" direction). The readiness signal is unchanged; only the brittle fixed window is gone.

Fixes #247
