### PR TITLE
Adopt core's server-side lock and freeze hidden block inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,19 @@
   `active_dock` alongside the visibility channel, so the deferred build --
   the view switch and the add-panel path -- sees the served `ctrl_block`.
 
+* Locked mode is now a server-side trust boundary, not just UI hiding (#127,
+  #135, #136). `is_dock_locked()` reads blockr.core's `blockr.locked` option
+  (renamed from `blockr.dock_is_locked`), so one flag drives both core's update
+  / option gate and dock's UI hides; a deployment setting the old option must
+  switch to `blockr.locked`. Hiding a block's input section -- and every block
+  on a locked board -- now drives core's per-block `frozen` channel: the
+  block's expression is pinned and its inputs are no longer consumed, so a
+  forged `Shiny.setInputValue` behind the hidden or read-only controls reaches
+  nothing (upstream data still flows, and showing the section again thaws it).
+  View switching on a locked board is driven client-side, as core's gate
+  rejects the active-view update; the board-options accordion (#135) and the
+  empty view's "Add panel" prompt (#136) are dropped when locked.
+
 * At startup the board now builds only the active view's dockView;
   off-screen views' docks are created on first visit rather than all up
   front (#304), mirroring the card deferral below. Building every view's

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -8,8 +8,9 @@
 #' @param board Reactive board state (list with `$board`).
 #' @param update Reactive update signal from blockr.core.
 #' @param visibility Per-block visibility channel from blockr.core: a list of
-#'   two reactiveVal environments (`required`, `visible`) the dock writes to
-#'   gate off-screen blocks.
+#'   three reactiveVal environments (`required`, `visible`, `frozen`) the dock
+#'   writes to gate off-screen blocks and to freeze the inputs of blocks whose
+#'   controls are hidden.
 #' @param ... Extension server arguments.
 #' @param plugins Served board plugins. Core threads these to its own block
 #'   server but not to callbacks, so `blockr_app_server.dock_board()` captures
@@ -55,11 +56,12 @@ board_server_callback <- function(board, update, visibility, ...,
   client_active <- reactiveVal(NULL)
   client_views <- reactiveVal(seed_view_state(board_views(initial_board)))
 
-  # The `visibility` channel core hands us (per-block `required` / `visible`
-  # reactiveVal slots) is the single store: its `required` axis doubles as the
-  # dock's build ledger, read back via built_cards(). Stash it on active_dock --
-  # the dock handle every card-touching path receives (view switch, panel-op
-  # apply, core insert / remove) -- so they read and write the one channel.
+  # The `visibility` channel core hands us (per-block `required` / `visible` /
+  # `frozen` reactiveVal slots) is the single store: its `required` axis doubles
+  # as the dock's build ledger, read back via built_cards(). Stash it on
+  # active_dock -- the dock handle every card-touching path receives (view
+  # switch, panel-op apply, core insert / remove) -- so they read and write the
+  # one channel.
   active_dock$visibility <- visibility
 
   # The served plugin set rides the same handle so those deferred card-build
@@ -67,10 +69,17 @@ board_server_callback <- function(board, update, visibility, ...,
   # default (which carries no served ctrl_block).
   active_dock$plugins <- plugins
 
-  switch_view_observer(session, update, client_active)
+  switch_view_observer(
+    session, update, client_active, board, docks, active_dock
+  )
   add_view_observer(client_views, session, board, update)
   remove_view_observer(client_views, session, update)
   rename_view_observer(client_views, session, update)
+
+  # Freeze the inputs of every block whose controls are hidden -- and every
+  # block on a locked board -- so a forged input behind the hidden / read-only
+  # controls reaches nothing server-side (#127).
+  freeze_hidden_inputs(board, visibility)
 
   # Reconcile the live dock session against the committed board (create /
   # destroy / restore / rename / switch views), keeping apply_board_update a
@@ -202,20 +211,38 @@ bare_view <- function(x) {
 #' A tab click (`input$view_nav` carries the target view id) requests an
 #' active-view change through the update lifecycle; the reconcile pass does
 #' the DOM switch. Guarded so a no-op (e.g. the nav echoing a programmatic
-#' `value` set back) does not re-enter the lifecycle.
+#' `value` set back) does not re-enter the lifecycle. On a locked board core's
+#' update gate rejects the active-view update, so the switch is driven directly
+#' against the DOM instead, keeping navigation live on a read-only board.
 #'
 #' @param session Shiny session.
 #' @param update Board update signal.
 #' @param client_active Reactive holding the client-shown active view id.
+#' @param board Reactive board state, read to detect the locked case.
+#' @param docks,active_dock Live dock registry and active-dock handle, driving
+#'   the client-side switch when locked.
 #'
 #' @noRd
-switch_view_observer <- function(session, update, client_active) {
+switch_view_observer <- function(session, update, client_active, board, docks,
+                                 active_dock) {
   observeEvent(
     session$input$view_nav,
     {
       target <- session$input$view_nav
 
-      if (!identical(target, isolate(client_active()))) {
+      if (identical(target, isolate(client_active()))) {
+        return()
+      }
+
+      # On a locked board the active view is ephemeral client state, not a
+      # board mutation: core's update gate rejects every board_update while
+      # locked, so drive the DOM switch directly instead of via the lifecycle.
+      if (is_board_locked(isolate(board$board))) {
+        switch_active_view(
+          target, docks, active_dock, client_active, isolate(board$board),
+          session
+        )
+      } else {
         update(list(views = list(active = target)))
       }
     },
@@ -253,6 +280,46 @@ report_visible_observer <- function(visibility, client_active, docks) {
       mark_cards_rendered(visibility, on_screen(), view)
     }
   )
+}
+
+# Drive blockr.core's per-block `frozen` channel off the block-card section
+# toggles. A block whose "inputs" section is hidden -- and every block on a
+# locked board, whose controls are read-only -- is frozen: core pins its
+# expression and stops consuming its inputs, so a forged `Shiny.setInputValue`
+# behind the hidden controls reaches nothing. Upstream data still flows, and
+# showing the section again (or unlocking) thaws it.
+#
+# Freeze only once a block has reported its section state (`visible()` non-NULL,
+# which the client sends only after the card paints). A block must evaluate
+# while still editable, so core's expression pin captures its published value;
+# freezing one from birth would hold a blank. A block without the edit-block
+# plugin (no `visible`) never reports, hence is never frozen.
+freeze_hidden_inputs <- function(board, visibility) {
+
+  observe({
+
+    brd <- board$board
+    locked <- is_board_locked(brd)
+
+    for (id in board_block_ids(brd)) {
+
+      slot <- visibility$frozen[[id]]
+
+      if (is.null(slot)) {
+        next
+      }
+
+      vis <- board$blocks[[id]]$server$visible
+      sections <- if (not_null(vis)) vis()
+      reported <- not_null(sections)
+
+      frozen <- reported && (locked || !("inputs" %in% sections))
+
+      if (!identical(isolate(slot()), frozen)) {
+        slot(frozen)
+      }
+    }
+  })
 }
 
 # The grid mirror's observer, split from manage_dock for testability. It reacts

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -205,6 +205,18 @@ settings_body <- function(
     if (plg %in% names(plgs)) board_ui(id, plgs[[plg]], x)
   }
 
+  generate_code <- div(
+    id = "generate_code",
+    opt_ui_or_null("generate_code", plugins, x)
+  )
+
+  # Locked board: the options accordion writes board state via
+  # set_board_option_value(), which core's gate rejects while locked. Drop it
+  # so the settings sidebar offers only the read-only generated-code export.
+  if (is_dock_locked()) {
+    return(generate_code)
+  }
+
   # Caller-supplied `options` (threaded from `serve()` through
   # `blockr_app_server.dock_board()` / `settings_observer()`) wins; fall
   # back to the recomputed default only when the caller has nothing to say.
@@ -215,10 +227,7 @@ settings_body <- function(
   opts <- split(options, chr_ply(options, attr, "category"))
 
   tagList(
-    div(
-      id = "generate_code",
-      opt_ui_or_null("generate_code", plugins, x)
-    ),
+    generate_code,
     hr(),
     do.call(
       accordion,

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -240,7 +240,11 @@ set_dock_view_output <- function(..., session = get_session()) {
 }
 
 is_dock_locked <- function() {
-  isTRUE(blockr_option("dock_is_locked", FALSE))
+
+  # Read blockr.core's `blockr.locked`, the same flag the server-side gate
+  # consults via is_board_locked(), so one deployment option drives both core's
+  # update / option gate and dock's UI hides.
+  isTRUE(blockr_option("locked", FALSE))
 }
 
 dock_panel_groups <- function(session = get_session()) {

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -139,6 +139,17 @@ group_front_panel <- function(dock, group_id) {
 
 #' @noRd
 empty_dock_prompt <- function(ns) {
+
+  if (is_dock_locked()) {
+    return(
+      div(
+        class = "blockr-empty-dock-prompt",
+        bsicons::bs_icon("lock-fill", size = "2em"),
+        tags$p("This view is empty")
+      )
+    )
+  }
+
   div(
     class = "blockr-empty-dock-prompt",
     bsicons::bs_icon("plus-circle", size = "2em"),

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ extensions. Drag-and-drop and panel resizing are also disabled.
 library(blockr.dock)
 library(blockr.core)
 
-options(blockr.dock_is_locked = TRUE)
+options(blockr.locked = TRUE)
 
 serve(
   new_dock_board(

--- a/inst/examples/locked-dock/app.R
+++ b/inst/examples/locked-dock/app.R
@@ -1,7 +1,7 @@
 library(blockr.dock)
 library(blockr.core)
 
-options(blockr.dock_is_locked = TRUE)
+options(blockr.locked = TRUE)
 
 serve(
   new_dock_board(

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -21,21 +21,23 @@ board_args <- function(...) {
 }
 
 # Stand-in for the `visibility` channel blockr.core hands the board callback:
-# two environments of per-block reactiveVals (`required`, `visible`), one slot
-# per block, mirroring core's add_vis_slots at construction (which seeds every
-# board block before the callback runs). The dock writes values into these
-# slots; core owns their lifecycle in the real thing. Pass the block ids to
-# seed, or a board handle to seed from its blocks.
+# three environments of per-block reactiveVals (`required`, `visible`,
+# `frozen`), one slot per block, mirroring core's add_vis_slots at construction
+# (which seeds every board block before the callback runs). The dock writes
+# values into these slots; core owns their lifecycle in the real thing. Pass the
+# block ids to seed, or a board handle to seed from its blocks.
 fake_visibility <- function(x = character()) {
   ids <- if (is.character(x)) x else board_block_ids(shiny::isolate(x$board))
 
   vis <- list(
     required = new.env(parent = emptyenv()),
-    visible = new.env(parent = emptyenv())
+    visible = new.env(parent = emptyenv()),
+    frozen = new.env(parent = emptyenv())
   )
   for (id in ids) {
     vis$required[[id]] <- shiny::reactiveVal(NA)
     vis$visible[[id]] <- shiny::reactiveVal(NA_character_)
+    vis$frozen[[id]] <- shiny::reactiveVal(FALSE)
   }
   vis
 }

--- a/tests/testthat/test-board-plugins.R
+++ b/tests/testthat/test-board-plugins.R
@@ -13,7 +13,7 @@ test_that("board plugins", {
 
 test_that("preserve_board stays available in locked mode (#123)", {
 
-  withr::local_options(blockr.dock_is_locked = TRUE)
+  withr::local_options(blockr.locked = TRUE)
   expect_true(is_dock_locked())
 
   plugins <- board_plugins(new_dock_board())

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1419,3 +1419,188 @@ test_that("switch_active_view first-visit card uses served ctrl (#331)", {
     paste(unlist(card), collapse = ""), "ctrl-sentinel", fixed = TRUE
   )
 })
+
+test_that("locked board switches views client-side, no board update (#127)", {
+
+  withr::local_options(blockr.locked = TRUE)
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = "a", B = "b")
+  )
+
+  client_active <- reactiveVal("A")
+  captured <- NULL
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          switch_view_observer(
+            session,
+            update = function(x) captured <<- x,
+            client_active = client_active,
+            board = reactiveValues(board = brd),
+            docks = reactiveValues(),
+            active_dock = reactiveValues()
+          )
+        }
+      )
+    },
+    {
+      session$setInputs(view_nav = "A")
+      session$setInputs(view_nav = "B")
+      session$flushReact()
+
+      # The active view advances in session state, but nothing travels the
+      # update channel: on a locked board core's gate rejects every board
+      # update, so navigation switches the DOM directly.
+      expect_identical(client_active(), "B")
+      expect_null(captured)
+    }
+  )
+})
+
+test_that("unlocked board switches views through the update channel", {
+
+  withr::local_options(blockr.locked = FALSE)
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = "a", B = "b")
+  )
+
+  client_active <- reactiveVal("A")
+  captured <- NULL
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          switch_view_observer(
+            session,
+            update = function(x) captured <<- x,
+            client_active = client_active,
+            board = reactiveValues(board = brd),
+            docks = reactiveValues(),
+            active_dock = reactiveValues()
+          )
+        }
+      )
+    },
+    {
+      session$setInputs(view_nav = "A")
+      session$setInputs(view_nav = "B")
+      session$flushReact()
+
+      # The switch rides the update lifecycle; flipping client_active is the
+      # reconcile pass's job, so the observer leaves it untouched.
+      expect_identical(captured, list(views = list(active = "B")))
+      expect_identical(client_active(), "A")
+    }
+  )
+})
+
+test_that("hiding a block's input section freezes it on the channel (#127)", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_dataset_block())
+  )
+
+  vis_a <- reactiveVal(c("inputs", "outputs"))
+  vis_b <- reactiveVal(c("inputs", "outputs"))
+
+  board <- reactiveValues(
+    board = brd,
+    blocks = list(
+      a = list(server = list(visible = vis_a)),
+      b = list(server = list(visible = vis_b))
+    )
+  )
+
+  visibility <- fake_visibility(c("a", "b"))
+
+  is_frozen <- function(id) isolate(visibility$frozen[[id]]())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          freeze_hidden_inputs(board, visibility)
+        }
+      )
+    },
+    {
+      session$flushReact()
+
+      # Both sections shown on an unlocked board: nothing frozen.
+      expect_false(is_frozen("a"))
+      expect_false(is_frozen("b"))
+
+      # Hide b's input section -> only b freezes.
+      vis_b("outputs")
+      session$flushReact()
+      expect_false(is_frozen("a"))
+      expect_true(is_frozen("b"))
+
+      # Show it again -> thaw.
+      vis_b(c("inputs", "outputs"))
+      session$flushReact()
+      expect_false(is_frozen("b"))
+    }
+  )
+})
+
+test_that("a locked board freezes every block once it reports (#127)", {
+
+  withr::local_options(blockr.locked = TRUE)
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_dataset_block())
+  )
+
+  # `a` has reported its sections (its card painted); `b` has not yet.
+  vis_a <- reactiveVal(c("inputs", "outputs"))
+  vis_b <- reactiveVal(NULL)
+
+  board <- reactiveValues(
+    board = brd,
+    blocks = list(
+      a = list(server = list(visible = vis_a)),
+      b = list(server = list(visible = vis_b))
+    )
+  )
+
+  visibility <- fake_visibility(c("a", "b"))
+
+  is_frozen <- function(id) isolate(visibility$frozen[[id]]())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          freeze_hidden_inputs(board, visibility)
+        }
+      )
+    },
+    {
+      session$flushReact()
+
+      # `a` shows its inputs, yet the locked board freezes it anyway -- a forged
+      # input can no longer steer it. `b` has not painted (no reported
+      # sections), so it stays editable, letting its expression evaluate and pin
+      # before the freeze lands.
+      expect_true(is_frozen("a"))
+      expect_false(is_frozen("b"))
+
+      # `b` paints -> it freezes too.
+      vis_b(c("inputs", "outputs"))
+      session$flushReact()
+      expect_true(is_frozen("b"))
+    }
+  )
+})

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -121,13 +121,13 @@ test_that("locked mode renders a navbar lock indicator", {
   brd <- new_dock_board(blocks = c(a = new_dataset_block()))
 
   unlocked_html <- withr::with_options(
-    list(blockr.dock_is_locked = NULL),
+    list(blockr.locked = NULL),
     as.character(board_ui("test", brd))
   )
   expect_false(grepl("blockr-lock-indicator", unlocked_html, fixed = TRUE))
 
   locked_html <- withr::with_options(
-    list(blockr.dock_is_locked = TRUE),
+    list(blockr.locked = TRUE),
     as.character(board_ui("test", brd))
   )
   expect_match(locked_html, "blockr-lock-indicator", fixed = TRUE)
@@ -135,4 +135,22 @@ test_that("locked mode renders a navbar lock indicator", {
   expect_match(locked_html, "blockr-lock-indicator-label", fixed = TRUE)
   # Visible label, not just the aria-label / tooltip.
   expect_match(locked_html, ">Read-only<", fixed = TRUE)
+})
+
+test_that("locked mode drops the board-options accordion (#135)", {
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+
+  html <- withr::with_options(
+    list(blockr.locked = TRUE),
+    as.character(board_ui("test", brd))
+  )
+
+  # The editable board_name input and the options accordion are gone -- both
+  # write board state, which core's gate refuses while locked.
+  expect_false(grepl('id="test-board_name"', html, fixed = TRUE))
+  expect_false(grepl('id="test-board_options"', html, fixed = TRUE))
+
+  # The read-only generated-code export stays available.
+  expect_match(html, 'id="generate_code"', fixed = TRUE)
 })

--- a/tests/testthat/test-layout-class.R
+++ b/tests/testthat/test-layout-class.R
@@ -236,7 +236,7 @@ test_that("lock_panels flips tabComponent both ways (#124)", {
   # time. lock_panels is the explicit re-coercion applied at restore time
   # to bring saved panels in line with the *current* lock state.
   unlocked_payload <- withr::with_options(
-    list(blockr.dock_is_locked = NULL),
+    list(blockr.locked = NULL),
     as_dock_layout(dock_grid("a"), blocks = blks)
   )
 
@@ -279,7 +279,7 @@ test_that("lock_panels restores callback on save-locked -> restore-unlocked", {
   blks <- c(a = new_dataset_block())
 
   locked_payload <- withr::with_options(
-    list(blockr.dock_is_locked = TRUE),
+    list(blockr.locked = TRUE),
     as_dock_layout(dock_grid("a"), blocks = blks)
   )
 

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -218,7 +218,7 @@ test_that("locked dock keeps block_card_toggles hidden (#122)", {
 
   # Unlocked: widget renders visible, with `selected` matching saved attr
   unlocked <- withr::with_options(
-    list(blockr.dock_is_locked = NULL),
+    list(blockr.locked = NULL),
     block_card_toggles(blk, NS("x"))
   )
   expect_s3_class(unlocked, "shiny.tag.list")
@@ -229,7 +229,7 @@ test_that("locked dock keeps block_card_toggles hidden (#122)", {
   # Locked: widget still renders (so input$collapse_blk_sections seeds
   # accordion_panel_set) but is hidden and the tooltip script is dropped
   locked <- withr::with_options(
-    list(blockr.dock_is_locked = TRUE),
+    list(blockr.locked = TRUE),
     block_card_toggles(blk, NS("x"))
   )
   expect_s3_class(locked, "shiny.tag")

--- a/tests/testthat/test-utils-ui.R
+++ b/tests/testthat/test-utils-ui.R
@@ -49,3 +49,19 @@ test_that("group_front_panel resolves a group to its front panel, else NULL", {
   expect_identical(group_front_panel(dock, "grp2"), "block_panel-b")
   expect_null(group_front_panel(dock, "absent"))
 })
+
+test_that("empty_dock_prompt offers no add control when locked (#136)", {
+
+  unlocked <- withr::with_options(
+    list(blockr.locked = NULL),
+    as.character(empty_dock_prompt(NS("x")))
+  )
+  expect_match(unlocked, 'id="x-empty_dock_add"', fixed = TRUE)
+
+  locked <- withr::with_options(
+    list(blockr.locked = TRUE),
+    as.character(empty_dock_prompt(NS("x")))
+  )
+  expect_false(grepl("empty_dock_add", locked, fixed = TRUE))
+  expect_match(locked, "lock-fill", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

- Locked mode is now a server-side trust boundary, not just UI hiding. `is_dock_locked()` reads blockr.core's `blockr.locked`, so blockr.core's update gate refuses every structural mutation while locked; dock keeps its UI hides and switches the active view **client-side** (the gate would otherwise reject the active-view update, freezing navigation on a locked multi-page board). The board-options accordion (#135) and the empty-view "Add panel" prompt (#136) are dropped when locked.
- Hiding a block's input section now drives blockr.core's per-block `frozen` channel: those inputs are suspended server-side — the block's expression is pinned and its inputs are no longer consumed — instead of merely `display: none`. A forged `Shiny.setInputValue` behind the hidden controls reaches nothing, closing the unlock vector that an arbitrary-code block would otherwise have (a hidden-but-live input is the same forge vector as the lock itself). The block still re-evaluates on upstream data changes, and showing the section again thaws it.

This pins `core@231-freeze-inputs`, which carries both the lock gate (#230) and the `frozen` channel (#232) and is a superset of `core@main`. It depends on the blockr.core freeze stack (#206 → #211 → #232); CI is blocked on the pak lockfile (blockr.ui pins `core@main`) until that stack reaches `main`, at which point the pin drops.

Fixes #127
Fixes #135
Fixes #136
