### PR TITLE
WIP: Panel navigator — the "Blocks" sidebar (self-contained in blockr.dock)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,6 +60,7 @@ Collate:
     'board-plugins.R'
     'board-server.R'
     'board-ui.R'
+    'panel-navigator.R'
     'dock-board.R'
     'dock-stack.R'
     'ext-class.R'

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -181,6 +181,23 @@ live_view_data <- function(client_views, docks, client_active) {
         return(NULL)
       }
       out <- dockview_to_layout(ly)
+
+      # FIX #3: do not fold a mid-flight echo into the board. The browser's
+      # `_state` echo can fire while `apply_layout_diff` is tearing the dock
+      # down and rebuilding it, reporting a *partial* panel set. `live_panels`
+      # is the authoritative server-side membership; if the echo disagrees, it
+      # is mid-relayout -- folding it would corrupt `target` and make reconcile
+      # do another full teardown (the membership-diff loop). Hold this view
+      # (-> whole sync holds) until its echo membership catches up. Legitimate
+      # membership changes update `live_panels` via the add/remove touchpoints
+      # *first*, so they are not lost here.
+      if (!setequal(as.character(layout_panel_ids(out)),
+                    as.character(isolate(dk$live_panels())))) {
+        message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
+                "] sync-guard ", v_id, " echo-membership != live_panels -> HOLD")
+        return(NULL)
+      }
+
       nm <- view_name(state[[v_id]])
       if (!is.null(nm)) {
         view_name(out) <- nm
@@ -223,6 +240,10 @@ layouts_to_board_observer <- function(view_data, update, board) {
     delta <- diff_dock_layouts(current, new_layouts)
 
     if (length(delta)) {
+      message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] sync echo->board: mod=[",
+              paste(names(delta$mod), collapse = ","), "] add=",
+              length(delta$add), " rm=", length(delta$rm),
+              if (!is.null(delta$active)) paste0(" active=", delta$active) else "")
       update(list(views = delta))
     }
   })
@@ -489,6 +510,7 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
 
   if (!setequal(live_ids, target_ids)) {
 
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " membership-diff -> PUSH")
     apply_layout_diff(
       view = view,
       target = target,
@@ -498,6 +520,7 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
     )
 
     dock$live_panels(target_ids)
+    dock$last_applied(target)
 
     return(invisible())
   }
@@ -505,17 +528,35 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
   live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
 
   if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " echo-membership-lag -> skip")
     return(invisible())
   }
 
   if (!layouts_match(live, target)) {
-    apply_layout_diff(
-      view = view,
-      target = target,
-      dock = dock,
-      blocks = blocks,
-      extensions = extensions
-    )
+
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " arr-mismatch; target-changed-vs-last=",
+            !layouts_match(isolate(dock$last_applied()), target))
+
+    # The browser's echoed arrangement (`live`) differs from `target`. Only
+    # re-push when `target` itself changed since we last applied it -- a genuine
+    # server-side rearrange (block add, views$mod, restore). If `target` is
+    # unchanged, the mismatch is just the debounced `_state` echo lagging while
+    # the layout settles; re-pushing here tears the dock down and restores it,
+    # which makes the browser echo again -> reconcile -> re-push ... an infinite
+    # teardown/restore loop that never converges on a slow / CPU-contended
+    # client (the "loads forever" symptom). Wait for the echo to catch up.
+    if (!layouts_match(isolate(dock$last_applied()), target)) {
+
+      apply_layout_diff(
+        view = view,
+        target = target,
+        dock = dock,
+        blocks = blocks,
+        extensions = extensions
+      )
+
+      dock$last_applied(target)
+    }
   }
 
   invisible()
@@ -566,6 +607,12 @@ manage_dock <- function(
     prev_active_group <- reactiveVal()
     active_group_trail <- reactiveVal()
     n_panels <- reactive(length(live_panels()))
+    # The target layout we last pushed to this dock. Used by
+    # reconcile_view_layout() to tell a genuine server-side arrangement change
+    # from the browser's debounced `_state` echo merely lagging behind a stable
+    # target -- the latter must NOT trigger a re-push (else infinite loop on
+    # slow clients).
+    last_applied <- reactiveVal(init_layout)
 
     dock <- list(
       proxy = proxy,
@@ -574,7 +621,8 @@ manage_dock <- function(
       layout = reactive(dockViewR::get_dock(proxy)),
       n_panels = n_panels,
       prev_active_group = prev_active_group,
-      active_group_trail = active_group_trail
+      active_group_trail = active_group_trail,
+      last_applied = last_applied
     )
 
     # Fold live-only membership changes — the add-panel modal, a closed tab, an

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -193,8 +193,6 @@ live_view_data <- function(client_views, docks, client_active) {
       # *first*, so they are not lost here.
       if (!setequal(as.character(layout_panel_ids(out)),
                     as.character(isolate(dk$live_panels())))) {
-        message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
-                "] sync-guard ", v_id, " echo-membership != live_panels -> HOLD")
         return(NULL)
       }
 
@@ -240,10 +238,6 @@ layouts_to_board_observer <- function(view_data, update, board) {
     delta <- diff_dock_layouts(current, new_layouts)
 
     if (length(delta)) {
-      message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] sync echo->board: mod=[",
-              paste(names(delta$mod), collapse = ","), "] add=",
-              length(delta$add), " rm=", length(delta$rm),
-              if (!is.null(delta$active)) paste0(" active=", delta$active) else "")
       update(list(views = delta))
     }
   })
@@ -510,7 +504,6 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
 
   if (!setequal(live_ids, target_ids)) {
 
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " membership-diff -> PUSH")
     apply_layout_diff(
       view = view,
       target = target,
@@ -528,14 +521,10 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
   live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
 
   if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " echo-membership-lag -> skip")
     return(invisible())
   }
 
   if (!layouts_match(live, target)) {
-
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " arr-mismatch; target-changed-vs-last=",
-            !layouts_match(isolate(dock$last_applied()), target))
 
     # The browser's echoed arrangement (`live`) differs from `target`. Only
     # re-push when `target` itself changed since we last applied it -- a genuine

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -104,6 +104,11 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
 
   register_actions(actions, triggers, board, update, ext_res)
 
+  # The Blocks navigator: a dock-side sidebar over the live board. Reads the
+  # block list / stacks from core and toggles per-view panel visibility on
+  # the active dock; needs no blockr.ui changes (builds on its primitives).
+  panel_navigator_observer(board, update, dock, session = session)
+
   c(
     list(
       dock = dock,

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -55,6 +55,17 @@ board_ui.dock_board <- function(
             )
           )
         },
+        # Panel navigator trigger. Unlike the gear, its body is dynamic
+        # (the live board + view state), so it is a real action button:
+        # the server observer renders it on click via `show_sidebar()`.
+        tags$button(
+          type = "button",
+          class = "btn action-button blockr-navbar-icon-btn",
+          id = NS(id, "open_panel_navigator"),
+          `aria-label` = "Blocks",
+          title = "Blocks",
+          bsicons::bs_icon("grid-1x2")
+        ),
         # Pure-JS open trigger via `data-blockr-sidebar-target`. The
         # settings sidebar's body is pre-rendered into its mount below, so
         # no server observer is needed: clicking the gear toggles the
@@ -150,6 +161,15 @@ board_ui.dock_board <- function(
       NS(id, "settings_sidebar"),
       ui = settings_body(id, x, options = options),
       title = "Board options",
+      mode = "overlay",
+      side = "right"
+    ),
+    # "panel_navigator_sidebar": the Blocks navigator. Its body lists the
+    # live board grouped by stack with per-row view-visibility toggles, so
+    # it is rendered server-side on open (via `show_sidebar()` from
+    # `panel_navigator_observer()`), not pre-rendered here.
+    blockr.ui::sidebar_ui(
+      NS(id, "panel_navigator_sidebar"),
       mode = "overlay",
       side = "right"
     )

--- a/R/panel-navigator.R
+++ b/R/panel-navigator.R
@@ -1,37 +1,31 @@
 #' Panel navigator
 #'
-#' A right-side sidebar that lists *every* block on the board, grouped by
-#' its blockr.core stack (or "Ungrouped"), with a per-row eye toggle
-#' reflecting whether the block's panel is on the current view. It turns
-#' the add-panel picker inside-out: instead of "what can I add", it shows
-#' "here is everything you have, and where it is".
+#' A right-side sidebar listing *every* block on the board grouped by its
+#' blockr.core stack (or "Ungrouped"), each block a row with a visibility
+#' switch reflecting whether its panel is on the current view. It turns the
+#' add-panel picker inside-out: instead of "what can I add", it shows "here
+#' is everything you have, and where it is".
 #'
-#' The navigator lives entirely in blockr.dock and is built on the
-#' `blockr.ui` sidebar + card primitives (it reuses the block-browser card
-#' chrome via `blockr.ui::block_browser_dep()` but renders its own markup,
-#' so blockr.ui needs no changes). It is wired by
-#' `panel_navigator_observer()` from `board_server_callback()`:
+#' This is the "Visible blocks" design (variant B) ported verbatim from the
+#' blockr.ui `feat/panel-navigator-stacks` prototype: collapsible accent-
+#' coloured stack bars, a per-row toggle switch, grip-drag to move / reorder
+#' blocks between stacks, inline rename (double-click), and a "+ New stack"
+#' control. The CSS / JS are self-contained (no block-browser dependency),
+#' so the navigator lives entirely in blockr.dock and needs nothing from
+#' blockr.ui beyond the sidebar shell.
 #'
-#' * the navbar "Blocks" button (`open_panel_navigator`) opens the sidebar,
-#'   rendering the current board / view state server-side;
-#' * the card eye toggles a block's panel on the active view via
-#'   `show_block_panel()` / `hide_block_panel()`;
-#' * clicking a shown row reveals (selects) its panel via
-#'   `select_block_panel()`.
-#'
-#' Visibility is a *view* concern (it lives in the dock layout, not the
-#' core board), which is exactly why the navigator is a dock feature: the
-#' eye toggles per-view panel membership, while the block list and stack
-#' grouping it reads come straight from blockr.core.
-#'
-#' This first cut covers the read / eye / reveal path; rename, drag-to-stack
-#' and "+ new stack" are layered on top later (they route through the core
-#' board `update()` channel, not the dock).
+#' Wired by `panel_navigator_observer()` from `board_server_callback()`:
+#' the navbar "Blocks" button opens the sidebar (rendered server-side from
+#' live board / view state); the switch toggles a panel on the active view
+#' (`show/hide_block_panel`); a row click reveals (`select_block_panel`);
+#' grip-drag / rename / new-stack go through the core board `update()`
+#' channel. Visibility is a view concern (the dock layout, not the core
+#' board), which is exactly why the navigator is a dock feature.
 #'
 #' @param board Reactive board state (list with `$board`).
-#' @param update Board update signal (reserved for the later core-event
-#'   path; unused in this cut).
-#' @param dock The active dock handle (`active_dock`): carries `proxy`,
+#' @param update Board update signal (for the core events: assign / rename /
+#'   add-stack).
+#' @param dock The active dock handle (`active_dock`): `proxy`,
 #'   `live_panels`, `board_ns`.
 #' @param session Shiny session (the board session).
 #'
@@ -52,8 +46,8 @@ panel_navigator_observer <- function(board, update, dock,
 
   # Re-render on the next flush (after `update()` has mutated the board) but
   # only while the sidebar is open — used after grouping changes that move
-  # cards between sections or add a section. Rename / toggle update the DOM
-  # client-side, so they skip this to keep scroll / search state.
+  # cards between sections or add a section. Toggle / rename update the DOM
+  # client-side, so they skip this to keep scroll / collapse / search state.
   refresh_nav <- function() {
     session$onFlushed(
       function() {
@@ -69,6 +63,7 @@ panel_navigator_observer <- function(board, update, dock,
 
   observeEvent(input$open_panel_navigator, render_nav())
 
+  # One multiplexed input, keyed by `kind` (the navigator's InputBinding).
   observeEvent(input$panel_nav_event, {
     ev <- input$panel_nav_event
     req(ev$kind)
@@ -82,14 +77,17 @@ panel_navigator_observer <- function(board, update, dock,
         select_block_panel(ev$id, dock$proxy)
       },
       # Core events — applied through the board `update()` channel.
-      rename = nav_rename_block(brd, update, ev$id, ev$value),
-      rename_stack = nav_rename_stack(brd, update, ev$id, ev$value),
+      rename = nav_rename_block(brd, update, ev$id, ev$name),
+      rename_stack = nav_rename_stack(brd, update, ev$stack, ev$name),
       assign = {
-        nav_reassign_stack(brd, update, ev$id, ev$to, ev$order)
+        payload <- nav_reassign_payload(brd, ev$id, coal(ev$stack, ""), ev$before)
+        if (!is.null(payload)) {
+          update(payload)
+        }
         refresh_nav()
       },
       add_stack = {
-        nav_add_stack(brd, update)
+        nav_add_stack(brd, update, ev$name)
         refresh_nav()
       },
       invisible(NULL)
@@ -132,93 +130,93 @@ nav_rename_stack <- function(board, update, sid, value) {
   }
 }
 
-# Move a block to stack `to` ("" / NA -> Ungrouped), or reorder within a
-# stack. One block lives in at most one stack, so a cross-stack move is a
-# remove-from-source + add-to-target pair sent as one delta (blockr.core
-# validates the consistent end state). `order` is the client's full ordered
-# block-id list for the target stack (drag-insert position); when supplied it
-# sets the target's membership order, which serialises as stack block order.
-# Dropping on Ungrouped has no per-stack order to keep, so it just clears the
-# block's stack.
-nav_reassign_stack <- function(board, update, bid, to, order = NULL) {
-  if (!bid %in% board_block_ids(board)) {
-    return(invisible())
+# Build the board-update payload for a grip drag: move `block_id` into stack
+# `target` ("" = ungrouped) before block `before` (or append), or reorder
+# within a stack. Pure blockr.core; the deltas carry only `blocks`, so stack
+# name / colour are preserved, and stack block order serialises. Returns
+# `NULL` for a no-op.
+nav_reassign_payload <- function(board, block_id, target, before = NULL) {
+  if (!block_id %in% board_block_ids(board)) {
+    return(NULL)
   }
 
-  stacks <- board_stacks(board)
-  to <- if (is.null(to) || !nzchar(to)) NA_character_ else to
+  all_stacks <- board_stacks(board)
 
-  if (!is.na(to) && !to %in% names(stacks)) {
-    return(invisible())
-  }
-
-  src <- NA_character_
-  for (sid in names(stacks)) {
-    if (bid %in% stack_blocks(stacks[[sid]])) {
-      src <- sid
+  cur <- NULL
+  for (sid in names(all_stacks)) {
+    if (block_id %in% stack_blocks(all_stacks[[sid]])) {
+      cur <- sid
       break
     }
   }
 
-  # Target Ungrouped: drop out of any stack (no order to persist there).
-  if (is.na(to)) {
-    if (is.na(src)) {
-      return(invisible())
+  target <- if (identical(target, "") || is.na(target)) NULL else target
+  before <- if (length(before) && nzchar(before)) before else NULL
+
+  if (!is.null(target) && !target %in% names(all_stacks)) {
+    return(NULL)
+  }
+
+  insert_before <- function(vec, id, before) {
+    vec <- setdiff(vec, id)
+    if (is.null(before) || !before %in% vec) {
+      c(vec, id)
+    } else {
+      append(vec, id, after = match(before, vec) - 1L)
     }
-    update(list(stacks = list(mod = set_names(
-      list(list(blocks = setdiff(stack_blocks(stacks[[src]]), bid))), src
-    ))))
-    return(invisible())
   }
 
-  # Target is a real stack: build its new ordered membership. Trust the
-  # client order but fence it to ids that legitimately belong here (the
-  # target's current members plus the incoming block).
-  cur <- stack_blocks(stacks[[to]])
-  allowed <- c(cur, bid)
-  new_order <- if (length(order)) {
-    o <- intersect(as.character(order), board_block_ids(board))
-    o <- unique(o[o %in% allowed])
-    if (!bid %in% o) o <- c(o, bid)
-    o
-  } else {
-    union(cur, bid)
+  if (identical(cur, target)) {
+    if (is.null(target)) {
+      return(NULL)
+    }
+    blks <- stack_blocks(all_stacks[[target]])
+    new_blks <- insert_before(blks, block_id, before)
+    if (identical(new_blks, blks)) {
+      return(NULL)
+    }
+    return(list(
+      stacks = list(mod = set_names(list(list(blocks = new_blks)), target))
+    ))
   }
 
-  if (identical(src, to) && identical(new_order, cur)) {
-    return(invisible())
+  mod <- list()
+  if (!is.null(cur)) {
+    mod[[cur]] <- list(blocks = setdiff(stack_blocks(all_stacks[[cur]]), block_id))
+  }
+  if (!is.null(target)) {
+    mod[[target]] <- list(
+      blocks = insert_before(stack_blocks(all_stacks[[target]]), block_id, before)
+    )
   }
 
-  mods <- set_names(list(list(blocks = new_order)), to)
-  if (!is.na(src) && !identical(src, to)) {
-    mods[[src]] <- list(blocks = setdiff(stack_blocks(stacks[[src]]), bid))
-  }
-
-  update(list(stacks = list(mod = mods)))
+  list(stacks = list(mod = mod))
 }
 
-# Create an empty stack with a fresh id and a default "Stack N" name (the
-# user renames it inline afterwards). It renders immediately as a drop zone.
-nav_add_stack <- function(board, update) {
-  existing <- chr_ply(board_stacks(board), stack_name)
-  n <- length(existing) + 1L
-  while (paste("Stack", n) %in% existing) {
-    n <- n + 1L
+# Create an empty stack with the user-supplied name and a fresh id; it
+# renders immediately as a drop target.
+nav_add_stack <- function(board, update, name) {
+  name <- trimws(coal(name, ""))
+  if (!nzchar(name)) {
+    return(invisible())
   }
 
   new_id <- rand_names(old_names = board_stack_ids(board))
   stk <- as_dock_stacks(
-    set_names(list(new_dock_stack(character(), name = paste("Stack", n))), new_id)
+    set_names(list(new_dock_stack(character(), name = name)), new_id)
   )
 
   update(list(stacks = list(add = stk)))
 }
 
-# Build the sidebar body: a search box + stack-grouped block cards. Pure
-# function of the current board + the active dock's live panel set, so it
-# is re-rendered on each open (and, later, on board-structure change).
-panel_navigator_body <- function(board, dock, ns) {
+# ---- model -------------------------------------------------------------
 
+# Shape the grouped model the renderer consumes: a list of groups, each
+# `list(id, name, color, kind, entries)`, where an entry is
+# `list(id, type, title, subtitle, icon, package, color, on_view, tags)`.
+# Pure function of the current board + the active dock's live panel set.
+nav_build_model <- function(board, dock) {
+  blocks <- board_blocks(board)
   layouts <- board_layouts(board)
   active <- active_view(layouts)
   labels <- view_names(layouts)
@@ -226,174 +224,55 @@ panel_navigator_body <- function(board, dock, ns) {
   shown <- shown_block_ids(dock)
   others <- other_view_tags(layouts, active, labels)
 
-  blocks <- board_blocks(board)
-  groups <- nav_groups(board, blocks)
-
-  htmltools::attachDependencies(
-    div(
-      id = ns("panel_nav"),
-      class = "blockr-stack-menu blockr-panel-nav",
-      # JS reads this to address the multiplexed Shiny input it fires
-      # (toggle / focus events). `.blockr-stack-menu` only resolves the
-      # shared card design tokens; the block-browser InputBinding scopes to
-      # `.blockr-block-browser`, so it never binds here.
-      `data-input-id` = ns("panel_nav_event"),
-      tags$input(
-        type = "search",
-        class = "blockr-block-browser-search blockr-panel-nav-search",
-        placeholder = "Search...",
-        `aria-label` = "Search blocks"
-      ),
-      div(
-        class = "blockr-block-browser-categories blockr-panel-nav-groups",
-        lapply(groups, nav_group, shown = shown, others = others,
-               blocks = blocks)
-      ),
-      tags$button(
-        type = "button",
-        class = "blockr-panel-nav-add-stack",
-        bsicons::bs_icon("plus-lg"),
-        "New stack"
-      ),
-      div(
-        class = "blockr-block-browser-empty",
-        "No blocks match your search."
-      )
-    ),
-    list(blockr.ui::block_browser_dep(), panel_navigator_dep())
-  )
-}
-
-# Group block ids by stack, in board order, with an "Ungrouped" bucket
-# (block ids in no stack) last. Each group carries its display name and
-# colour (NA when none / plain white).
-nav_groups <- function(board, blocks) {
   stacks <- board_stacks(board)
-
   grouped <- unlist(lapply(stacks, stack_blocks), use.names = FALSE)
   ungrouped <- setdiff(board_block_ids(board), grouped)
 
+  entry <- function(bid) {
+    meta <- blks_metadata(blocks[bid])
+    list(
+      id = bid,
+      type = "block",
+      title = coal(safe_block_name(blocks[[bid]]), as.character(meta$name[1L])),
+      subtitle = as.character(meta$category[1L]),
+      icon = as.character(meta$icon[1L]),
+      package = as.character(meta$package[1L]),
+      color = as.character(meta$color[1L]),
+      on_view = bid %in% shown,
+      tags = unique(others[[bid]])
+    )
+  }
+
   groups <- lapply(seq_along(stacks), function(i) {
     s <- stacks[[i]]
+    ids <- intersect(stack_blocks(s), names(blocks))
     list(
       id = names(stacks)[[i]],
       name = coal(stack_name(s), names(stacks)[[i]]),
-      color = nav_stack_color(s),
-      ids = stack_blocks(s)
+      color = nav_stack_accent(s),
+      kind = "stack",
+      entries = lapply(ids, entry)
     )
   })
 
-  # The Ungrouped bucket carries no stack id (`""`); dropping a card on it
-  # removes the block from its stack.
-  groups <- c(
+  # Ungrouped carries no stack id (`""`) and stays a drop target so a block
+  # can be dragged out of a stack.
+  c(
     groups,
-    list(list(id = "", name = "Ungrouped", color = NA_character_,
-              ids = ungrouped))
+    list(list(id = "", name = "Ungrouped", color = "", kind = "ungrouped",
+              entries = lapply(ungrouped, entry)))
   )
-
-  groups
 }
 
-# Stack colour, or NA when it carries none (a plain core stack reports
-# white) — used to decide whether to draw the heading colour dot.
-nav_stack_color <- function(s) {
-  col <- tryCatch(stack_color(s), error = function(e) NA_character_)
-  if (!is_string(col) || !nzchar(col) || toupper(col) == "#FFFFFF") {
-    return(NA_character_)
+# Stack accent colour, or "" when it carries none (a plain core stack
+# reports white) so the renderer falls back to neutral grey.
+nav_stack_accent <- function(s) {
+  col <- tryCatch(stack_color(s), error = function(e) "")
+  if (!is_string(col) || !grepl("^#[0-9a-fA-F]{6}$", col) ||
+        toupper(col) == "#FFFFFF") {
+    return("")
   }
   col
-}
-
-nav_group <- function(g, shown, others, blocks) {
-  ids <- intersect(g$ids, names(blocks))
-  n_shown <- sum(ids %in% shown)
-
-  div(
-    class = "blockr-block-browser-category blockr-panel-nav-group",
-    `data-category` = g$name,
-    # The stack id (`""` for Ungrouped) is the drop target: dropping a card
-    # here reassigns the block to this stack (or out of any stack).
-    `data-stack-id` = g$id,
-    div(
-      class = "blockr-panel-nav-group-head",
-      if (!is.na(g$color)) {
-        tags$span(
-          class = "blockr-panel-nav-dot",
-          style = paste0("background:", g$color, ";")
-        )
-      },
-      tags$h3(g$name),
-      tags$span(
-        class = "blockr-panel-nav-count",
-        paste0(n_shown, "/", length(ids), " shown")
-      )
-    ),
-    div(
-      class = "blockr-block-browser-cards",
-      lapply(ids, function(bid) {
-        nav_card(bid, blocks[[bid]], blocks[bid], bid %in% shown, others[[bid]])
-      })
-    )
-  )
-}
-
-# One card row, reusing the block-browser card classes for the icon tile /
-# name chrome, plus the navigator's own eye toggle and view tags. `blk` is
-# the single block (for its instance name); `blk1` the length-1 blocks
-# subset (for registry metadata via blks_metadata()).
-nav_card <- function(bid, blk, blk1, is_shown, tags_for) {
-
-  meta <- blks_metadata(blk1)
-  name <- coal(safe_block_name(blk), as.character(meta$name[1L]))
-  icon <- as.character(meta$icon[1L])
-  category <- as.character(meta$category[1L])
-  package <- as.character(meta$package[1L])
-
-  div(
-    class = paste(
-      "blockr-block-browser-card blockr-panel-nav-card",
-      if (is_shown) "pn-shown" else "pn-hidden"
-    ),
-    `data-block-id` = bid,
-    draggable = "true",
-    `data-name` = name,
-    `data-package` = package,
-    `data-category` = category,
-    div(
-      class = "blockr-block-browser-card-header",
-      tags$span(
-        class = "blockr-block-browser-card-icon",
-        if (nzchar(icon)) htmltools::HTML(icon)
-      ),
-      div(
-        class = "blockr-block-browser-card-body",
-        div(
-          class = "blockr-block-browser-card-titles",
-          tags$span(class = "blockr-block-browser-card-name", name),
-          if (length(tags_for)) {
-            tags$span(
-              class = "blockr-panel-nav-tags",
-              lapply(unique(tags_for), function(t) {
-                tags$span(class = "blockr-panel-nav-tag", t)
-              })
-            )
-          },
-          tags$button(
-            type = "button",
-            class = "blockr-panel-nav-eye",
-            `aria-label` = "Toggle on this view",
-            title = "Show / hide on this view",
-            bsicons::bs_icon("eye-fill")
-          )
-        )
-      )
-    )
-  )
-}
-
-safe_block_name <- function(blk) {
-  nm <- tryCatch(block_name(blk), error = function(e) NULL)
-  if (is.null(nm) || !nzchar(nm)) NULL else nm
 }
 
 # Block ids whose panel is currently shown on the ACTIVE view. Read from
@@ -426,11 +305,269 @@ other_view_tags <- function(layouts, active, labels) {
   res
 }
 
-# Block-panel id strings -> block ids. The panel id format is
-# "block_panel-<id>" (see maybe_block_panel_id()).
+# Block-panel id strings -> block ids ("block_panel-<id>").
 block_ids_from_panels <- function(pids) {
   pids <- as.character(pids)
   sub("^block_panel-", "", grep("^block_panel-", pids, value = TRUE))
+}
+
+safe_block_name <- function(blk) {
+  nm <- tryCatch(block_name(blk), error = function(e) NULL)
+  if (is.null(nm) || !nzchar(nm)) NULL else nm
+}
+
+# ---- rendering (the "Visible blocks" design, variant B) ----------------
+
+# Build the sidebar body: search + stack-grouped block rows + add-stack.
+panel_navigator_body <- function(board, dock, ns) {
+  model <- nav_build_model(board, dock)
+
+  htmltools::attachDependencies(
+    div(
+      # Root id = the InputBinding's reported input ("panel_nav_event").
+      id = ns("panel_nav_event"),
+      class = "blockr-panel-navigator",
+      tags$input(
+        type = "search",
+        class = "blockr-panel-nav-search",
+        placeholder = "Search blocks...",
+        `aria-label` = "Search blocks",
+        autocomplete = "off",
+        autocorrect = "off",
+        autocapitalize = "off",
+        spellcheck = "false"
+      ),
+      div(
+        class = "blockr-panel-nav-body",
+        lapply(model, nav_group_section)
+      ),
+      div(
+        class = "blockr-panel-nav-empty",
+        "No blocks match your search."
+      ),
+      nav_add_stack_control()
+    ),
+    list(panel_navigator_dep())
+  )
+}
+
+# One group = one coloured stack bar (`ghd`) you click to collapse, listing
+# block rows. Accent = the stack colour (via `--accent*` vars); Ungrouped
+# uses a neutral grey. The "N shown" count is how many of the group's blocks
+# are currently visible (on the active view).
+nav_group_section <- function(group) {
+  accent <- if (identical(group$kind, "stack") && nzchar(coal(group$color, ""))) {
+    group$color
+  } else {
+    "#6b7280"
+  }
+  style <- sprintf(
+    "--accent:%s;--accent-bg:%s;--accent-ink:%s;",
+    accent, hex_alpha(accent, 0.13), darken_hex(accent, 0.72)
+  )
+
+  droppable <- group$kind %in% c("stack", "ungrouped")
+  shown <- sum(vapply(group$entries, function(e) isTRUE(e$on_view), logical(1L)))
+
+  label <- if (identical(group$kind, "stack")) {
+    nav_rename("stack", group$name, "blockr-panel-nav-glab")
+  } else {
+    tags$span(class = "blockr-panel-nav-glab", group$name)
+  }
+
+  empty_ungrouped <- identical(group$kind, "ungrouped") &&
+    length(group$entries) == 0L
+
+  div(
+    class = paste(
+      "blockr-panel-nav-grp open",
+      if (droppable) "blockr-panel-nav-dropzone" else "",
+      if (empty_ungrouped) "blockr-panel-nav-grp-empty" else ""
+    ),
+    style = style,
+    `data-stack-id` = if (droppable) group$id else NULL,
+    `data-kind` = group$kind,
+    div(
+      class = "blockr-panel-nav-ghd",
+      role = "button",
+      tabindex = "0",
+      `aria-expanded` = "true",
+      nav_caret_icon(),
+      label,
+      tags$span(
+        class = "blockr-panel-nav-gvis",
+        sprintf("%d shown", shown)
+      )
+    ),
+    div(
+      class = "blockr-panel-nav-gbody",
+      div(
+        class = "blockr-panel-nav-rows",
+        lapply(group$entries, nav_entry_card)
+      )
+    )
+  )
+}
+
+# One block row: grip (hover) + category-tinted icon tile + renamable name
+# (+ other-view tags) + the visibility switch. `.on`/`.off` reflects
+# current-view membership.
+nav_entry_card <- function(entry) {
+  on_view <- isTRUE(entry$on_view)
+  cat_color <- if (nzchar(coal(entry$color, ""))) entry$color else "#999999"
+
+  div(
+    class = paste("blockr-panel-nav-row", if (on_view) "on" else "off"),
+    draggable = "true",
+    `data-panel-id` = entry$id,
+    `data-panel-type` = entry$type,
+    `data-on-view` = if (on_view) "true" else "false",
+    `data-search` = tolower(paste(entry$title, entry$subtitle, entry$package)),
+    tags$span(
+      class = "blockr-panel-nav-grip",
+      title = "Drag to move between stacks / reorder",
+      `aria-hidden` = "true",
+      nav_grip_icon()
+    ),
+    tags$span(
+      class = "blockr-panel-nav-tile",
+      style = sprintf(
+        "background:%s;color:%s", hex_alpha(cat_color, 0.13), cat_color
+      ),
+      if (nzchar(entry$icon)) htmltools::HTML(entry$icon)
+    ),
+    tags$span(
+      class = "blockr-panel-nav-namewrap",
+      nav_rename("block", entry$title, "blockr-panel-nav-name"),
+      nav_tags_row(entry$tags)
+    ),
+    nav_switch(on_view)
+  )
+}
+
+nav_tags_row <- function(tags) {
+  if (!length(tags)) {
+    return(NULL)
+  }
+  shiny::tags$span(
+    class = "blockr-panel-nav-tags",
+    lapply(tags, function(t) {
+      shiny::tags$span(class = "blockr-panel-nav-tag", t)
+    })
+  )
+}
+
+# Canonical inline-rename widget: double-click the name / label to rename;
+# a subtle hover highlight hints it is editable (no pencil); Enter / blur
+# commit, Esc reverts; F2 is the keyboard path. `kind` is "block" or
+# "stack" (the navigator commits the matching rename event).
+nav_rename <- function(kind, text, extra_class = NULL) {
+  tags$span(
+    class = "blockr-panel-nav-rename",
+    `data-rename-kind` = kind,
+    tags$span(
+      class = paste("blockr-panel-nav-rename-text", extra_class),
+      title = "Double-click to rename",
+      text
+    ),
+    tags$input(
+      class = "blockr-panel-nav-rename-input",
+      type = "text",
+      value = text,
+      tabindex = "-1",
+      `aria-label` = "Rename",
+      autocomplete = "off",
+      autocorrect = "off",
+      autocapitalize = "off",
+      spellcheck = "false"
+    )
+  )
+}
+
+# The switch is the ONLY visibility toggle: a row's pill switch. role=switch
+# + aria-checked; the JS toggles on click / Enter / Space.
+nav_switch <- function(on) {
+  tags$span(
+    class = "blockr-panel-nav-switch",
+    role = "switch",
+    tabindex = "0",
+    `aria-checked` = if (on) "true" else "false",
+    `aria-label` = "Show / hide on this view"
+  )
+}
+
+# A compact footer to create a new (empty) stack: a button that reveals an
+# inline name input. Submitting fires an "add_stack" event.
+nav_add_stack_control <- function() {
+  div(
+    class = "blockr-panel-nav-addstack",
+    tags$button(
+      type = "button",
+      class = "blockr-panel-nav-addstack-btn",
+      "+ New stack"
+    ),
+    div(
+      class = "blockr-panel-nav-addstack-form",
+      tags$input(
+        type = "text",
+        class = "blockr-panel-nav-addstack-input",
+        placeholder = "Stack name, then Enter",
+        autocomplete = "off",
+        autocorrect = "off",
+        autocapitalize = "off",
+        spellcheck = "false"
+      )
+    )
+  )
+}
+
+# ---- icons + colour helpers --------------------------------------------
+
+nav_caret_icon <- function() {
+  htmltools::HTML(paste0(
+    '<svg class="blockr-panel-nav-caret" viewBox="0 0 24 24" width="15" ',
+    'height="15" fill="none" stroke="currentColor" stroke-width="2" ',
+    'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">',
+    '<path d="m9 18 6-6-6-6"/></svg>'
+  ))
+}
+
+nav_grip_icon <- function() {
+  htmltools::HTML(paste0(
+    '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" ',
+    'aria-hidden="true"><circle cx="9" cy="6" r="1.4"/>',
+    '<circle cx="15" cy="6" r="1.4"/><circle cx="9" cy="12" r="1.4"/>',
+    '<circle cx="15" cy="12" r="1.4"/><circle cx="9" cy="18" r="1.4"/>',
+    '<circle cx="15" cy="18" r="1.4"/></svg>'
+  ))
+}
+
+# rgba()/darkened helpers for the per-stack / per-category accent. Colours
+# are 6-digit hex; anything else falls back unchanged.
+hex_alpha <- function(hex, alpha) {
+  rgb <- hex_rgb(hex)
+  if (is.null(rgb)) {
+    return(hex)
+  }
+  sprintf("rgba(%d,%d,%d,%.2f)", rgb[1], rgb[2], rgb[3], alpha)
+}
+
+darken_hex <- function(hex, factor) {
+  rgb <- hex_rgb(hex)
+  if (is.null(rgb)) {
+    return(hex)
+  }
+  sprintf("#%02x%02x%02x", round(rgb[1] * factor), round(rgb[2] * factor),
+          round(rgb[3] * factor))
+}
+
+hex_rgb <- function(hex) {
+  hex <- sub("^#", "", hex)
+  if (!grepl("^[0-9a-fA-F]{6}$", hex)) {
+    return(NULL)
+  }
+  c(strtoi(substr(hex, 1, 2), 16L), strtoi(substr(hex, 3, 4), 16L),
+    strtoi(substr(hex, 5, 6), 16L))
 }
 
 panel_navigator_dep <- function() {

--- a/R/panel-navigator.R
+++ b/R/panel-navigator.R
@@ -63,6 +63,21 @@ panel_navigator_observer <- function(board, update, dock,
 
   observeEvent(input$open_panel_navigator, render_nav())
 
+  # Follow view switches: the switches / counts / tags are all relative to
+  # the ACTIVE view, so a pinned navigator must re-render when the active
+  # view changes. Keyed on the active view id (not every board change) so
+  # block edits and visibility toggles keep scroll / collapse / search
+  # state. The render is deferred (refresh_nav -> onFlushed), so it runs
+  # after reconcile has swapped `active_dock` to the now-active view.
+  last_view <- reactiveVal(active_view(board_layouts(isolate(board$board))))
+  observeEvent(board$board, {
+    av <- active_view(board_layouts(board$board))
+    if (!identical(av, isolate(last_view()))) {
+      last_view(av)
+      refresh_nav()
+    }
+  }, ignoreInit = TRUE)
+
   # One multiplexed input, keyed by `kind` (the navigator's InputBinding).
   observeEvent(input$panel_nav_event, {
     ev <- input$panel_nav_event

--- a/R/panel-navigator.R
+++ b/R/panel-navigator.R
@@ -40,41 +40,152 @@ panel_navigator_observer <- function(board, update, dock,
                                      session = get_session()) {
   input <- session$input
   ns <- session$ns
+  sidebar_id <- ns("panel_navigator_sidebar")
 
-  observeEvent(input$open_panel_navigator, {
+  render_nav <- function() {
     blockr.ui::show_sidebar(
-      ns("panel_navigator_sidebar"),
+      sidebar_id,
       title = "Blocks",
       ui = panel_navigator_body(board$board, dock, ns)
     )
-  })
+  }
+
+  # Re-render on the next flush (after `update()` has mutated the board) but
+  # only while the sidebar is open — used after grouping changes that move
+  # cards between sections or add a section. Rename / toggle update the DOM
+  # client-side, so they skip this to keep scroll / search state.
+  refresh_nav <- function() {
+    session$onFlushed(
+      function() {
+        isolate(
+          if (isTRUE(blockr.ui::sidebar_state(sidebar_id)$open)) {
+            render_nav()
+          }
+        )
+      },
+      once = TRUE
+    )
+  }
+
+  observeEvent(input$open_panel_navigator, render_nav())
 
   observeEvent(input$panel_nav_event, {
     ev <- input$panel_nav_event
-    req(ev$kind, ev$id)
-
+    req(ev$kind)
     brd <- board$board
-    bid <- ev$id
-
-    if (!bid %in% board_block_ids(brd)) {
-      return()
-    }
 
     switch(
       ev$kind,
-      toggle = {
-        if (identical(ev$to, "add")) {
-          show_block_panel(board_blocks(brd)[bid], add_panel = TRUE, dock = dock)
-        } else {
-          hide_block_panel(bid, rm_panel = TRUE, dock = dock)
-        }
+      # Dock (view-membership) events — applied on the active dock.
+      toggle = nav_toggle(brd, dock, ev$id, ev$to),
+      focus = if (ev$id %in% board_block_ids(brd)) {
+        select_block_panel(ev$id, dock$proxy)
       },
-      focus = select_block_panel(bid, dock$proxy),
+      # Core events — applied through the board `update()` channel.
+      rename = nav_rename_block(brd, update, ev$id, ev$value),
+      rename_stack = nav_rename_stack(brd, update, ev$id, ev$value),
+      assign = {
+        nav_reassign_stack(brd, update, ev$id, ev$to)
+        refresh_nav()
+      },
+      add_stack = {
+        nav_add_stack(brd, update)
+        refresh_nav()
+      },
       invisible(NULL)
     )
   })
 
   invisible(NULL)
+}
+
+# ---- event handlers ----------------------------------------------------
+
+nav_toggle <- function(board, dock, bid, to) {
+  if (!bid %in% board_block_ids(board)) {
+    return(invisible())
+  }
+  if (identical(to, "add")) {
+    show_block_panel(board_blocks(board)[bid], add_panel = TRUE, dock = dock)
+  } else {
+    hide_block_panel(bid, rm_panel = TRUE, dock = dock)
+  }
+}
+
+nav_rename_block <- function(board, update, bid, value) {
+  value <- trimws(coal(value, ""))
+  if (nzchar(value) && bid %in% board_block_ids(board)) {
+    update(list(
+      blocks = list(mod = set_names(list(list(block_name = value)), bid))
+    ))
+  }
+}
+
+nav_rename_stack <- function(board, update, sid, value) {
+  value <- trimws(coal(value, ""))
+  if (nzchar(value) && sid %in% board_stack_ids(board)) {
+    # Partial-arg delta: `update_stack()` merges it onto the live stack, so
+    # sending only `name` preserves the blocks and colour.
+    update(list(
+      stacks = list(mod = set_names(list(list(name = value)), sid))
+    ))
+  }
+}
+
+# Move a block to stack `to` ("" / NA -> Ungrouped). One block lives in at
+# most one stack, so this is a remove-from-source + add-to-target pair, sent
+# as a single delta so blockr.core validates the consistent end state.
+nav_reassign_stack <- function(board, update, bid, to) {
+  if (!bid %in% board_block_ids(board)) {
+    return(invisible())
+  }
+
+  stacks <- board_stacks(board)
+  to <- if (is.null(to) || !nzchar(to)) NA_character_ else to
+
+  src <- NA_character_
+  for (sid in names(stacks)) {
+    if (bid %in% stack_blocks(stacks[[sid]])) {
+      src <- sid
+      break
+    }
+  }
+
+  if (identical(src, to)) {
+    return(invisible())
+  }
+  if (!is.na(to) && !to %in% names(stacks)) {
+    return(invisible())
+  }
+
+  mods <- list()
+  if (!is.na(src)) {
+    mods[[src]] <- list(blocks = setdiff(stack_blocks(stacks[[src]]), bid))
+  }
+  if (!is.na(to)) {
+    mods[[to]] <- list(blocks = union(stack_blocks(stacks[[to]]), bid))
+  }
+
+  if (length(mods)) {
+    update(list(stacks = list(mod = mods)))
+  }
+}
+
+# Create an empty stack with a fresh id and a default "Stack N" name (the
+# user renames it inline afterwards). It renders immediately as a drop zone.
+nav_add_stack <- function(board, update) {
+  existing <- chr_ply(board_stacks(board), stack_name)
+  n <- length(existing) + 1L
+  while (paste("Stack", n) %in% existing) {
+    n <- n + 1L
+  }
+
+  new_id <- rand_names(old_names = board_stack_ids(board))
+  stk <- as_dock_stacks(
+    set_names(list(new_dock_stack(character(), name = paste("Stack", n))), new_id)
+  )
+
+  update(list(stacks = list(add = stk)))
 }
 
 # Build the sidebar body: a search box + stack-grouped block cards. Pure
@@ -112,6 +223,12 @@ panel_navigator_body <- function(board, dock, ns) {
         lapply(groups, nav_group, shown = shown, others = others,
                blocks = blocks)
       ),
+      tags$button(
+        type = "button",
+        class = "blockr-panel-nav-add-stack",
+        bsicons::bs_icon("plus-lg"),
+        "New stack"
+      ),
       div(
         class = "blockr-block-browser-empty",
         "No blocks match your search."
@@ -133,18 +250,20 @@ nav_groups <- function(board, blocks) {
   groups <- lapply(seq_along(stacks), function(i) {
     s <- stacks[[i]]
     list(
+      id = names(stacks)[[i]],
       name = coal(stack_name(s), names(stacks)[[i]]),
       color = nav_stack_color(s),
       ids = stack_blocks(s)
     )
   })
 
-  if (length(ungrouped)) {
-    groups <- c(
-      groups,
-      list(list(name = "Ungrouped", color = NA_character_, ids = ungrouped))
-    )
-  }
+  # The Ungrouped bucket carries no stack id (`""`); dropping a card on it
+  # removes the block from its stack.
+  groups <- c(
+    groups,
+    list(list(id = "", name = "Ungrouped", color = NA_character_,
+              ids = ungrouped))
+  )
 
   groups
 }
@@ -166,6 +285,9 @@ nav_group <- function(g, shown, others, blocks) {
   div(
     class = "blockr-block-browser-category blockr-panel-nav-group",
     `data-category` = g$name,
+    # The stack id (`""` for Ungrouped) is the drop target: dropping a card
+    # here reassigns the block to this stack (or out of any stack).
+    `data-stack-id` = g$id,
     div(
       class = "blockr-panel-nav-group-head",
       if (!is.na(g$color)) {
@@ -207,6 +329,7 @@ nav_card <- function(bid, blk, blk1, is_shown, tags_for) {
       if (is_shown) "pn-shown" else "pn-hidden"
     ),
     `data-block-id` = bid,
+    draggable = "true",
     `data-name` = name,
     `data-package` = package,
     `data-category` = category,

--- a/R/panel-navigator.R
+++ b/R/panel-navigator.R
@@ -85,7 +85,7 @@ panel_navigator_observer <- function(board, update, dock,
       rename = nav_rename_block(brd, update, ev$id, ev$value),
       rename_stack = nav_rename_stack(brd, update, ev$id, ev$value),
       assign = {
-        nav_reassign_stack(brd, update, ev$id, ev$to)
+        nav_reassign_stack(brd, update, ev$id, ev$to, ev$order)
         refresh_nav()
       },
       add_stack = {
@@ -132,16 +132,25 @@ nav_rename_stack <- function(board, update, sid, value) {
   }
 }
 
-# Move a block to stack `to` ("" / NA -> Ungrouped). One block lives in at
-# most one stack, so this is a remove-from-source + add-to-target pair, sent
-# as a single delta so blockr.core validates the consistent end state.
-nav_reassign_stack <- function(board, update, bid, to) {
+# Move a block to stack `to` ("" / NA -> Ungrouped), or reorder within a
+# stack. One block lives in at most one stack, so a cross-stack move is a
+# remove-from-source + add-to-target pair sent as one delta (blockr.core
+# validates the consistent end state). `order` is the client's full ordered
+# block-id list for the target stack (drag-insert position); when supplied it
+# sets the target's membership order, which serialises as stack block order.
+# Dropping on Ungrouped has no per-stack order to keep, so it just clears the
+# block's stack.
+nav_reassign_stack <- function(board, update, bid, to, order = NULL) {
   if (!bid %in% board_block_ids(board)) {
     return(invisible())
   }
 
   stacks <- board_stacks(board)
   to <- if (is.null(to) || !nzchar(to)) NA_character_ else to
+
+  if (!is.na(to) && !to %in% names(stacks)) {
+    return(invisible())
+  }
 
   src <- NA_character_
   for (sid in names(stacks)) {
@@ -151,24 +160,41 @@ nav_reassign_stack <- function(board, update, bid, to) {
     }
   }
 
-  if (identical(src, to)) {
-    return(invisible())
-  }
-  if (!is.na(to) && !to %in% names(stacks)) {
+  # Target Ungrouped: drop out of any stack (no order to persist there).
+  if (is.na(to)) {
+    if (is.na(src)) {
+      return(invisible())
+    }
+    update(list(stacks = list(mod = set_names(
+      list(list(blocks = setdiff(stack_blocks(stacks[[src]]), bid))), src
+    ))))
     return(invisible())
   }
 
-  mods <- list()
-  if (!is.na(src)) {
+  # Target is a real stack: build its new ordered membership. Trust the
+  # client order but fence it to ids that legitimately belong here (the
+  # target's current members plus the incoming block).
+  cur <- stack_blocks(stacks[[to]])
+  allowed <- c(cur, bid)
+  new_order <- if (length(order)) {
+    o <- intersect(as.character(order), board_block_ids(board))
+    o <- unique(o[o %in% allowed])
+    if (!bid %in% o) o <- c(o, bid)
+    o
+  } else {
+    union(cur, bid)
+  }
+
+  if (identical(src, to) && identical(new_order, cur)) {
+    return(invisible())
+  }
+
+  mods <- set_names(list(list(blocks = new_order)), to)
+  if (!is.na(src) && !identical(src, to)) {
     mods[[src]] <- list(blocks = setdiff(stack_blocks(stacks[[src]]), bid))
   }
-  if (!is.na(to)) {
-    mods[[to]] <- list(blocks = union(stack_blocks(stacks[[to]]), bid))
-  }
 
-  if (length(mods)) {
-    update(list(stacks = list(mod = mods)))
-  }
+  update(list(stacks = list(mod = mods)))
 }
 
 # Create an empty stack with a fresh id and a default "Stack N" name (the

--- a/R/panel-navigator.R
+++ b/R/panel-navigator.R
@@ -1,0 +1,295 @@
+#' Panel navigator
+#'
+#' A right-side sidebar that lists *every* block on the board, grouped by
+#' its blockr.core stack (or "Ungrouped"), with a per-row eye toggle
+#' reflecting whether the block's panel is on the current view. It turns
+#' the add-panel picker inside-out: instead of "what can I add", it shows
+#' "here is everything you have, and where it is".
+#'
+#' The navigator lives entirely in blockr.dock and is built on the
+#' `blockr.ui` sidebar + card primitives (it reuses the block-browser card
+#' chrome via `blockr.ui::block_browser_dep()` but renders its own markup,
+#' so blockr.ui needs no changes). It is wired by
+#' `panel_navigator_observer()` from `board_server_callback()`:
+#'
+#' * the navbar "Blocks" button (`open_panel_navigator`) opens the sidebar,
+#'   rendering the current board / view state server-side;
+#' * the card eye toggles a block's panel on the active view via
+#'   `show_block_panel()` / `hide_block_panel()`;
+#' * clicking a shown row reveals (selects) its panel via
+#'   `select_block_panel()`.
+#'
+#' Visibility is a *view* concern (it lives in the dock layout, not the
+#' core board), which is exactly why the navigator is a dock feature: the
+#' eye toggles per-view panel membership, while the block list and stack
+#' grouping it reads come straight from blockr.core.
+#'
+#' This first cut covers the read / eye / reveal path; rename, drag-to-stack
+#' and "+ new stack" are layered on top later (they route through the core
+#' board `update()` channel, not the dock).
+#'
+#' @param board Reactive board state (list with `$board`).
+#' @param update Board update signal (reserved for the later core-event
+#'   path; unused in this cut).
+#' @param dock The active dock handle (`active_dock`): carries `proxy`,
+#'   `live_panels`, `board_ns`.
+#' @param session Shiny session (the board session).
+#'
+#' @noRd
+panel_navigator_observer <- function(board, update, dock,
+                                     session = get_session()) {
+  input <- session$input
+  ns <- session$ns
+
+  observeEvent(input$open_panel_navigator, {
+    blockr.ui::show_sidebar(
+      ns("panel_navigator_sidebar"),
+      title = "Blocks",
+      ui = panel_navigator_body(board$board, dock, ns)
+    )
+  })
+
+  observeEvent(input$panel_nav_event, {
+    ev <- input$panel_nav_event
+    req(ev$kind, ev$id)
+
+    brd <- board$board
+    bid <- ev$id
+
+    if (!bid %in% board_block_ids(brd)) {
+      return()
+    }
+
+    switch(
+      ev$kind,
+      toggle = {
+        if (identical(ev$to, "add")) {
+          show_block_panel(board_blocks(brd)[bid], add_panel = TRUE, dock = dock)
+        } else {
+          hide_block_panel(bid, rm_panel = TRUE, dock = dock)
+        }
+      },
+      focus = select_block_panel(bid, dock$proxy),
+      invisible(NULL)
+    )
+  })
+
+  invisible(NULL)
+}
+
+# Build the sidebar body: a search box + stack-grouped block cards. Pure
+# function of the current board + the active dock's live panel set, so it
+# is re-rendered on each open (and, later, on board-structure change).
+panel_navigator_body <- function(board, dock, ns) {
+
+  layouts <- board_layouts(board)
+  active <- active_view(layouts)
+  labels <- view_names(layouts)
+
+  shown <- shown_block_ids(dock)
+  others <- other_view_tags(layouts, active, labels)
+
+  blocks <- board_blocks(board)
+  groups <- nav_groups(board, blocks)
+
+  htmltools::attachDependencies(
+    div(
+      id = ns("panel_nav"),
+      class = "blockr-stack-menu blockr-panel-nav",
+      # JS reads this to address the multiplexed Shiny input it fires
+      # (toggle / focus events). `.blockr-stack-menu` only resolves the
+      # shared card design tokens; the block-browser InputBinding scopes to
+      # `.blockr-block-browser`, so it never binds here.
+      `data-input-id` = ns("panel_nav_event"),
+      tags$input(
+        type = "search",
+        class = "blockr-block-browser-search blockr-panel-nav-search",
+        placeholder = "Search...",
+        `aria-label` = "Search blocks"
+      ),
+      div(
+        class = "blockr-block-browser-categories blockr-panel-nav-groups",
+        lapply(groups, nav_group, shown = shown, others = others,
+               blocks = blocks)
+      ),
+      div(
+        class = "blockr-block-browser-empty",
+        "No blocks match your search."
+      )
+    ),
+    list(blockr.ui::block_browser_dep(), panel_navigator_dep())
+  )
+}
+
+# Group block ids by stack, in board order, with an "Ungrouped" bucket
+# (block ids in no stack) last. Each group carries its display name and
+# colour (NA when none / plain white).
+nav_groups <- function(board, blocks) {
+  stacks <- board_stacks(board)
+
+  grouped <- unlist(lapply(stacks, stack_blocks), use.names = FALSE)
+  ungrouped <- setdiff(board_block_ids(board), grouped)
+
+  groups <- lapply(seq_along(stacks), function(i) {
+    s <- stacks[[i]]
+    list(
+      name = coal(stack_name(s), names(stacks)[[i]]),
+      color = nav_stack_color(s),
+      ids = stack_blocks(s)
+    )
+  })
+
+  if (length(ungrouped)) {
+    groups <- c(
+      groups,
+      list(list(name = "Ungrouped", color = NA_character_, ids = ungrouped))
+    )
+  }
+
+  groups
+}
+
+# Stack colour, or NA when it carries none (a plain core stack reports
+# white) — used to decide whether to draw the heading colour dot.
+nav_stack_color <- function(s) {
+  col <- tryCatch(stack_color(s), error = function(e) NA_character_)
+  if (!is_string(col) || !nzchar(col) || toupper(col) == "#FFFFFF") {
+    return(NA_character_)
+  }
+  col
+}
+
+nav_group <- function(g, shown, others, blocks) {
+  ids <- intersect(g$ids, names(blocks))
+  n_shown <- sum(ids %in% shown)
+
+  div(
+    class = "blockr-block-browser-category blockr-panel-nav-group",
+    `data-category` = g$name,
+    div(
+      class = "blockr-panel-nav-group-head",
+      if (!is.na(g$color)) {
+        tags$span(
+          class = "blockr-panel-nav-dot",
+          style = paste0("background:", g$color, ";")
+        )
+      },
+      tags$h3(g$name),
+      tags$span(
+        class = "blockr-panel-nav-count",
+        paste0(n_shown, "/", length(ids), " shown")
+      )
+    ),
+    div(
+      class = "blockr-block-browser-cards",
+      lapply(ids, function(bid) {
+        nav_card(bid, blocks[[bid]], blocks[bid], bid %in% shown, others[[bid]])
+      })
+    )
+  )
+}
+
+# One card row, reusing the block-browser card classes for the icon tile /
+# name chrome, plus the navigator's own eye toggle and view tags. `blk` is
+# the single block (for its instance name); `blk1` the length-1 blocks
+# subset (for registry metadata via blks_metadata()).
+nav_card <- function(bid, blk, blk1, is_shown, tags_for) {
+
+  meta <- blks_metadata(blk1)
+  name <- coal(safe_block_name(blk), as.character(meta$name[1L]))
+  icon <- as.character(meta$icon[1L])
+  category <- as.character(meta$category[1L])
+  package <- as.character(meta$package[1L])
+
+  div(
+    class = paste(
+      "blockr-block-browser-card blockr-panel-nav-card",
+      if (is_shown) "pn-shown" else "pn-hidden"
+    ),
+    `data-block-id` = bid,
+    `data-name` = name,
+    `data-package` = package,
+    `data-category` = category,
+    div(
+      class = "blockr-block-browser-card-header",
+      tags$span(
+        class = "blockr-block-browser-card-icon",
+        if (nzchar(icon)) htmltools::HTML(icon)
+      ),
+      div(
+        class = "blockr-block-browser-card-body",
+        div(
+          class = "blockr-block-browser-card-titles",
+          tags$span(class = "blockr-block-browser-card-name", name),
+          if (length(tags_for)) {
+            tags$span(
+              class = "blockr-panel-nav-tags",
+              lapply(unique(tags_for), function(t) {
+                tags$span(class = "blockr-panel-nav-tag", t)
+              })
+            )
+          },
+          tags$button(
+            type = "button",
+            class = "blockr-panel-nav-eye",
+            `aria-label` = "Toggle on this view",
+            title = "Show / hide on this view",
+            bsicons::bs_icon("eye-fill")
+          )
+        )
+      )
+    )
+  )
+}
+
+safe_block_name <- function(blk) {
+  nm <- tryCatch(block_name(blk), error = function(e) NULL)
+  if (is.null(nm) || !nzchar(nm)) NULL else nm
+}
+
+# Block ids whose panel is currently shown on the ACTIVE view. Read from
+# the live dock's authoritative membership set (ahead of the browser echo).
+shown_block_ids <- function(dock) {
+  lp <- dock$live_panels
+  if (is.null(lp)) {
+    return(character())
+  }
+  live <- tryCatch(isolate(lp()), error = function(e) character())
+  block_ids_from_panels(live)
+}
+
+# For every OTHER view, the block ids it shows -> the view labels each
+# block appears on. Drives the "also on X" tags.
+other_view_tags <- function(layouts, active, labels) {
+  res <- list()
+  for (vid in names(layouts)) {
+    if (identical(vid, active)) {
+      next
+    }
+    pids <- tryCatch(
+      as.character(layout_panel_ids(layouts[[vid]])),
+      error = function(e) character()
+    )
+    for (b in block_ids_from_panels(pids)) {
+      res[[b]] <- c(res[[b]], unname(labels[[vid]]))
+    }
+  }
+  res
+}
+
+# Block-panel id strings -> block ids. The panel id format is
+# "block_panel-<id>" (see maybe_block_panel_id()).
+block_ids_from_panels <- function(pids) {
+  pids <- as.character(pids)
+  sub("^block_panel-", "", grep("^block_panel-", pids, value = TRUE))
+}
+
+panel_navigator_dep <- function() {
+  htmltools::htmlDependency(
+    "blockr-panel-navigator",
+    pkg_version(),
+    src = pkg_file("assets"),
+    stylesheet = "css/panel-navigator.css",
+    script = "js/panel-navigator.js"
+  )
+}

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -589,6 +589,10 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     return(invisible())
   }
 
+  message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
+          "] view-switch ", old, " -> ", active, " START")
+  .t0 <- Sys.time()
+
   if (active %in% names(docks)) {
 
     # switch-view must fire before show_view_ui so the target dock carries
@@ -600,8 +604,15 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     )
 
     hide_view_ui(old, docks)
+    .t_hide <- Sys.time()
     show_view_ui(active, docks)
+    .t_show <- Sys.time()
     update_active_dock(active_dock, docks[[active]])
+
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
+            "] view-switch ", active, " ui-done hide=",
+            round(as.numeric(.t_hide - .t0), 3), "s show=",
+            round(as.numeric(.t_show - .t_hide), 3), "s")
   }
 
   client_active(active)

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -589,10 +589,6 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     return(invisible())
   }
 
-  message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
-          "] view-switch ", old, " -> ", active, " START")
-  .t0 <- Sys.time()
-
   if (active %in% names(docks)) {
 
     # switch-view must fire before show_view_ui so the target dock carries
@@ -604,15 +600,8 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     )
 
     hide_view_ui(old, docks)
-    .t_hide <- Sys.time()
     show_view_ui(active, docks)
-    .t_show <- Sys.time()
     update_active_dock(active_dock, docks[[active]])
-
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
-            "] view-switch ", active, " ui-done hide=",
-            round(as.numeric(.t_hide - .t0), 3), "s show=",
-            round(as.numeric(.t_show - .t_hide), 3), "s")
   }
 
   client_active(active)

--- a/dev/panel-navigator-demo.R
+++ b/dev/panel-navigator-demo.R
@@ -1,0 +1,40 @@
+# Panel navigator demo (feat/panel-navigator-dock).
+#
+# A dock board with several blocks, two stacks, and two views so the
+# navigator shows: stack grouping, an Ungrouped bucket, per-row eye state
+# reflecting the active view, and "also on <view>" tags.
+#
+#   Rscript dev/panel-navigator-demo.R   # serves on 3838
+pkgload::load_all("../blockr.core", quiet = TRUE)
+pkgload::load_all("../blockr.ui", quiet = TRUE)
+pkgload::load_all(".", quiet = TRUE)
+
+library(blockr.dplyr)
+
+board <- new_dock_board(
+  blocks = c(
+    data = new_dataset_block("iris"),
+    sel  = new_select_block(),
+    flt  = new_filter_block(),
+    summ = new_select_block(),
+    data2 = new_dataset_block("mtcars")
+  ),
+  links = list(
+    new_link("data", "sel"),
+    new_link("sel", "flt")
+  ),
+  stacks = list(
+    pipeline = new_dock_stack(c("data", "sel", "flt"), name = "Pipeline"),
+    summaries = new_dock_stack(c("summ"), name = "Summaries")
+  ),
+  layouts = list(
+    main = dock_layout("data", "sel", "flt", name = "Main"),
+    review = dock_layout("summ", "data2", name = "Review")
+  ),
+  active = "main"
+)
+
+shiny::runApp(
+  serve(board),
+  port = 3838, host = "0.0.0.0", launch.browser = FALSE
+)

--- a/inst/assets/css/panel-navigator.css
+++ b/inst/assets/css/panel-navigator.css
@@ -1,0 +1,111 @@
+/* Panel navigator: dock-side styling for the "Blocks" sidebar.
+
+   The card chrome (icon tile, name, search, category/cards layout) comes
+   from blockr.ui's block_browser_dep(), reused as-is via the shared
+   `.blockr-block-browser-*` classes. The navigator root carries
+   `.blockr-stack-menu` purely to resolve that bundle's `--bb-*` design
+   tokens; it deliberately is NOT `.blockr-block-browser` (whose input
+   binding would otherwise treat these rows as add-a-block cards).
+
+   Only the navigator-specific bits live here: the root container (the
+   block-browser root layout is scoped to its own class, so we re-state a
+   minimal version), the stack heading dot + "N shown" count, the view
+   tags, the eye toggle, and the dimmed look of a hidden row. */
+
+.blockr-panel-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+  margin: -16px;
+  padding: 16px;
+  color: var(--bb-grey-900);
+}
+
+/* Stack heading: colour dot + label + right-aligned shown count. */
+.blockr-panel-nav-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.blockr-panel-nav-group-head h3 {
+  margin: 0;
+}
+
+.blockr-panel-nav-dot {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+
+.blockr-panel-nav-count {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--bb-grey-400);
+  white-space: nowrap;
+}
+
+/* View tags ("also on <view>"). */
+.blockr-panel-nav-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: 8px;
+}
+
+.blockr-panel-nav-tag {
+  font-size: 10px;
+  line-height: 1.4;
+  padding: 0 6px;
+  border-radius: 9999px;
+  background: var(--bb-grey-100);
+  color: var(--bb-grey-500);
+  white-space: nowrap;
+}
+
+/* Eye toggle, pushed to the row's right edge. */
+.blockr-panel-nav-eye {
+  margin-left: auto;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--bb-blue-600);
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.blockr-panel-nav-eye:hover {
+  background: var(--bb-grey-100);
+}
+
+.blockr-panel-nav-card.pn-hidden .blockr-panel-nav-eye {
+  color: var(--bb-grey-400);
+}
+
+/* A hidden row is greyed out (its block is not on the current view). */
+.blockr-panel-nav-card.pn-hidden {
+  opacity: 0.55;
+}
+
+.blockr-panel-nav-card.pn-hidden:hover,
+.blockr-panel-nav-card.pn-hidden:focus-within {
+  opacity: 1;
+}
+
+/* A shown row's body invites a reveal-on-click. */
+.blockr-panel-nav-card.pn-shown {
+  cursor: pointer;
+}

--- a/inst/assets/css/panel-navigator.css
+++ b/inst/assets/css/panel-navigator.css
@@ -1,196 +1,450 @@
-/* Panel navigator: dock-side styling for the "Blocks" sidebar.
+/* Panel navigator — the "Visible blocks" design (variant B).
+   See _blockr.design/open/panel-navigator/6-visibility-sidebar-variantB.md.
+   Self-contained: no dependency on the block-browser tokens. */
 
-   The card chrome (icon tile, name, search, category/cards layout) comes
-   from blockr.ui's block_browser_dep(), reused as-is via the shared
-   `.blockr-block-browser-*` classes. The navigator root carries
-   `.blockr-stack-menu` purely to resolve that bundle's `--bb-*` design
-   tokens; it deliberately is NOT `.blockr-block-browser` (whose input
-   binding would otherwise treat these rows as add-a-block cards).
+.blockr-panel-navigator {
+  --g50: #f9fafb;
+  --g100: #f3f4f6;
+  --g200: #e5e7eb;
+  --g300: #d1d5db;
+  --g400: #9ca3af;
+  --g500: #6b7280;
+  --g700: #374151;
+  --g900: #111827;
+  --blue: #2162b7;
 
-   Only the navigator-specific bits live here: the root container (the
-   block-browser root layout is scoped to its own class, so we re-state a
-   minimal version), the stack heading dot + "N shown" count, the view
-   tags, the eye toggle, and the dimmed look of a hidden row. */
-
-.blockr-panel-nav {
   display: flex;
   flex-direction: column;
   gap: 12px;
   height: 100%;
   min-height: 0;
-  margin: -16px;
-  padding: 16px;
-  color: var(--bb-grey-900);
+  color: var(--g900);
 }
 
-/* Stack heading: colour dot + label + right-aligned shown count. */
-.blockr-panel-nav-group-head {
+/* ---- search ---- */
+.blockr-panel-nav-search {
+  flex: 0 0 auto;
+  width: 100%;
+  padding: 9px 12px 9px 36px;
+  border: 1px solid var(--g200);
+  border-radius: 9px;
+  background: var(--g50)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%239ca3af'><path d='M11.74 10.34a6.5 6.5 0 1 0-1.4 1.4l3.85 3.85a1 1 0 0 0 1.42-1.42l-3.85-3.85zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'/></svg>")
+    no-repeat 12px center / 14px 14px;
+  font-size: 13.5px;
+  color: var(--g900);
+}
+
+.blockr-panel-nav-search::placeholder {
+  color: var(--g400);
+}
+
+.blockr-panel-nav-search:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(33, 98, 183, 0.15);
+}
+
+/* ---- body / groups ---- */
+.blockr-panel-nav-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.blockr-panel-nav-grp {
+  margin-bottom: 8px;
+  border: 1px solid var(--g200);
+  border-radius: 11px;
+  overflow: hidden;
+}
+
+.blockr-panel-nav-grp.blockr-panel-nav-dropover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-bg);
+}
+
+.blockr-panel-nav-grp.hidden {
+  display: none;
+}
+
+/* An empty Ungrouped is hidden, but reappears while a drag is in progress
+   so it can still receive a block dragged out of a stack. */
+.blockr-panel-nav-grp-empty {
+  display: none;
+}
+
+.blockr-panel-navigator.is-dragging .blockr-panel-nav-grp-empty {
+  display: block;
+}
+
+.blockr-panel-navigator.is-dragging .blockr-panel-nav-grp-empty
+  .blockr-panel-nav-rows {
+  min-height: 22px;
+}
+
+.blockr-panel-navigator.is-dragging .blockr-panel-nav-grp-empty
+  .blockr-panel-nav-rows::after {
+  content: "Drop here to ungroup";
+  display: block;
+  padding: 3px 6px;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--g400);
+}
+
+/* ---- the stack bar ---- */
+.blockr-panel-nav-ghd {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 11px 13px;
+  border: none;
+  background: var(--accent-bg);
+  font: inherit;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+}
+
+.blockr-panel-nav-ghd:hover {
+  filter: brightness(0.97);
+}
+
+.blockr-panel-nav-caret {
+  flex: 0 0 auto;
+  color: var(--accent);
+  transition: transform 0.18s ease;
+}
+
+.blockr-panel-nav-grp.open .blockr-panel-nav-caret {
+  transform: rotate(90deg);
+}
+
+.blockr-panel-nav-glab {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  color: var(--accent-ink);
+}
+
+.blockr-panel-nav-gvis {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--accent-ink);
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 99px;
+  white-space: nowrap;
+}
+
+/* ---- collapse animation ---- */
+.blockr-panel-nav-gbody {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.2s ease;
+}
+
+.blockr-panel-nav-grp.open .blockr-panel-nav-gbody {
+  grid-template-rows: 1fr;
+}
+
+.blockr-panel-nav-rows {
+  overflow: hidden;
+  min-height: 0;
+  background: #fff;
+  padding: 6px;
+}
+
+/* ---- block row ---- */
+.blockr-panel-nav-row {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 4px;
+  padding: 7px 8px;
+  border-radius: 8px;
+  position: relative;
+  background: #fff;
 }
 
-.blockr-panel-nav-group-head h3 {
-  margin: 0;
+.blockr-panel-nav-row:hover {
+  background: var(--g50);
 }
 
-.blockr-panel-nav-dot {
-  flex: 0 0 auto;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+.blockr-panel-nav-row.hidden {
+  display: none;
 }
 
-.blockr-panel-nav-count {
-  margin-left: auto;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--bb-grey-400);
-  white-space: nowrap;
-}
-
-/* View tags ("also on <view>"). */
-.blockr-panel-nav-tags {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-left: 8px;
-}
-
-.blockr-panel-nav-tag {
-  font-size: 10px;
-  line-height: 1.4;
-  padding: 0 6px;
-  border-radius: 9999px;
-  background: var(--bb-grey-100);
-  color: var(--bb-grey-500);
-  white-space: nowrap;
-}
-
-/* Eye toggle, pushed to the row's right edge. */
-.blockr-panel-nav-eye {
-  margin-left: auto;
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  cursor: pointer;
-  color: var(--bb-blue-600);
-  transition: background 0.12s ease, color 0.12s ease;
-}
-
-.blockr-panel-nav-eye:hover {
-  background: var(--bb-grey-100);
-}
-
-.blockr-panel-nav-card.pn-hidden .blockr-panel-nav-eye {
-  color: var(--bb-grey-400);
-}
-
-/* A hidden row is greyed out (its block is not on the current view). */
-.blockr-panel-nav-card.pn-hidden {
-  opacity: 0.55;
-}
-
-.blockr-panel-nav-card.pn-hidden:hover,
-.blockr-panel-nav-card.pn-hidden:focus-within {
-  opacity: 1;
-}
-
-/* A shown row's body invites a reveal-on-click. */
-.blockr-panel-nav-card.pn-shown {
-  cursor: pointer;
-}
-
-/* ---- drag to reassign ------------------------------------------------ */
-
-.blockr-panel-nav-card[draggable="true"] {
-  cursor: grab;
-}
-
-.blockr-panel-nav-card.pn-dragging {
+.blockr-panel-nav-row.dragging {
   opacity: 0.4;
 }
 
-.blockr-panel-nav-group.pn-drop-target {
-  outline: 2px dashed var(--bb-blue-500);
-  outline-offset: 2px;
-  border-radius: 8px;
-  background: var(--bb-blue-100);
+/* drop-position indicator while reordering */
+.blockr-panel-nav-row.dropline::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: -1px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--accent);
 }
 
-/* Insertion indicator while reordering: a line before the target card, or
-   at the end of the list when appending. */
-.blockr-panel-nav-card.pn-drop-before {
-  box-shadow: 0 -2px 0 0 var(--bb-blue-500);
+.blockr-panel-nav-grip {
+  flex: 0 0 auto;
+  width: 16px;
+  display: grid;
+  place-items: center;
+  color: var(--g300);
+  cursor: grab;
+  opacity: 0;
+  transition: opacity 0.12s ease;
 }
 
-.blockr-block-browser-cards.pn-drop-end {
-  box-shadow: 0 2px 0 0 var(--bb-blue-500);
+.blockr-panel-nav-row:hover .blockr-panel-nav-grip {
+  opacity: 1;
 }
 
-/* Keep an empty stack (no cards) visible as a drop zone — the block-browser
-   CSS would otherwise hide any category with no non-hidden card, which also
-   matches a genuinely empty group. Search-filtered groups (cards present
-   but all hidden) still collapse via that rule. */
-.blockr-panel-nav-group:not(:has(.blockr-block-browser-card)) {
-  display: flex !important;
+.blockr-panel-nav-grip:active {
+  cursor: grabbing;
+}
+
+.blockr-panel-nav-tile {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+}
+
+.blockr-panel-nav-tile svg,
+.blockr-panel-nav-tile img {
+  width: 15px;
+  height: 15px;
+}
+
+.blockr-panel-nav-namewrap {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
   flex-direction: column;
+  gap: 2px;
 }
 
-.blockr-panel-nav-group:not(:has(.blockr-block-browser-card))
-  .blockr-block-browser-cards::after {
-  content: "Drop a block here";
+.blockr-panel-nav-name {
   display: block;
-  padding: 10px 8px;
-  font-size: 12px;
-  color: var(--bb-grey-400);
-  border: 1px dashed var(--bb-grey-300);
-  border-radius: 6px;
-  text-align: center;
+  min-width: 0;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--g900);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-/* ---- inline rename --------------------------------------------------- */
-
-.blockr-panel-nav-group-head h3 {
-  cursor: text;
+.blockr-panel-nav-row.off .blockr-panel-nav-name {
+  color: var(--g400);
 }
 
-.pn-editing {
-  outline: 2px solid var(--bb-blue-500);
-  outline-offset: 1px;
-  border-radius: 3px;
+.blockr-panel-nav-row.off .blockr-panel-nav-tile {
+  filter: grayscale(1);
+  opacity: 0.5;
+}
+
+/* ---- the switch: the ONLY visibility toggle ---- */
+.blockr-panel-nav-switch {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 20px;
+  border-radius: 99px;
+  background: var(--g300);
+  position: relative;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.blockr-panel-nav-switch::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
   background: #fff;
-  cursor: text;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform 0.15s ease;
 }
 
-/* ---- "+ New stack" --------------------------------------------------- */
+.blockr-panel-nav-row.on .blockr-panel-nav-switch {
+  background: var(--accent);
+}
 
-.blockr-panel-nav-add-stack {
+.blockr-panel-nav-row.on .blockr-panel-nav-switch::after {
+  transform: translateX(14px);
+}
+
+.blockr-panel-nav-switch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ---- other-view tags ---- */
+.blockr-panel-nav-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.blockr-panel-nav-tag {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  align-self: flex-start;
-  padding: 4px 10px;
-  font-size: 12px;
-  color: var(--bb-grey-600);
-  background: transparent;
-  border: 1px dashed var(--bb-grey-300);
-  border-radius: 6px;
-  cursor: pointer;
+  padding: 0 6px;
+  font-size: 9.5px;
+  line-height: 1.5;
+  color: var(--g500);
+  background: var(--g100);
+  border-radius: 99px;
+  white-space: nowrap;
+}
+
+.blockr-panel-nav-tag::before {
+  content: "";
+  width: 4px;
+  height: 4px;
+  margin-right: 3px;
+  border-radius: 50%;
+  background: var(--g400);
+}
+
+/* ---- inline rename (canonical pattern; see nav_rename() in R) ---- */
+/* The name (block) or label (stack) is a dedicated rename zone: a subtle
+   hover chip hints it is editable (no pencil); double-click to edit. */
+.blockr-panel-nav-rename {
+  position: relative;
+  display: block;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.blockr-panel-nav-rename-text {
+  display: block;
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  padding: 1px 4px;
+  margin: -1px -4px;
+  cursor: text;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: background 0.12s ease, border-color 0.12s ease;
 }
 
-.blockr-panel-nav-add-stack:hover {
-  background: var(--bb-grey-50);
-  border-color: var(--bb-grey-400);
-  color: var(--bb-grey-900);
+.blockr-panel-nav-rename-text:hover {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: var(--g200);
+}
+
+.blockr-panel-nav-rename-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  margin: 0;
+  padding: 1px 4px;
+  font: inherit;
+  color: var(--g900);
+  background: #fff;
+  border: 1px solid var(--blue);
+  border-radius: 5px;
+  box-sizing: border-box;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.blockr-panel-nav-rename-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(33, 98, 183, 0.15);
+}
+
+.blockr-panel-nav-rename.editing .blockr-panel-nav-rename-text {
+  opacity: 0;
+}
+
+.blockr-panel-nav-rename.editing .blockr-panel-nav-rename-input {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ---- empty state ---- */
+.blockr-panel-nav-empty {
+  display: none;
+  padding: 18px 8px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--g400);
+}
+
+.blockr-panel-navigator.is-empty .blockr-panel-nav-empty {
+  display: block;
+}
+
+.blockr-panel-navigator.is-empty .blockr-panel-nav-body {
+  display: none;
+}
+
+/* ---- add-stack control ---- */
+.blockr-panel-nav-addstack {
+  flex: 0 0 auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--g100);
+}
+
+.blockr-panel-nav-addstack-btn {
+  border: none;
+  background: transparent;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--blue);
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.blockr-panel-nav-addstack-btn:hover {
+  background: rgba(33, 98, 183, 0.08);
+}
+
+.blockr-panel-nav-addstack-form {
+  display: none;
+  padding: 6px 0 0;
+}
+
+.blockr-panel-nav-addstack.is-open .blockr-panel-nav-addstack-form {
+  display: block;
+}
+
+.blockr-panel-nav-addstack.is-open .blockr-panel-nav-addstack-btn {
+  display: none;
+}
+
+.blockr-panel-nav-addstack-input {
+  width: 100%;
+  height: 32px;
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--g300);
+  border-radius: 6px;
+}
+
+.blockr-panel-nav-addstack-input:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(33, 98, 183, 0.15);
 }

--- a/inst/assets/css/panel-navigator.css
+++ b/inst/assets/css/panel-navigator.css
@@ -127,6 +127,16 @@
   background: var(--bb-blue-100);
 }
 
+/* Insertion indicator while reordering: a line before the target card, or
+   at the end of the list when appending. */
+.blockr-panel-nav-card.pn-drop-before {
+  box-shadow: 0 -2px 0 0 var(--bb-blue-500);
+}
+
+.blockr-block-browser-cards.pn-drop-end {
+  box-shadow: 0 2px 0 0 var(--bb-blue-500);
+}
+
 /* Keep an empty stack (no cards) visible as a drop zone — the block-browser
    CSS would otherwise hide any category with no non-hidden card, which also
    matches a genuinely empty group. Search-filtered groups (cards present

--- a/inst/assets/css/panel-navigator.css
+++ b/inst/assets/css/panel-navigator.css
@@ -109,3 +109,78 @@
 .blockr-panel-nav-card.pn-shown {
   cursor: pointer;
 }
+
+/* ---- drag to reassign ------------------------------------------------ */
+
+.blockr-panel-nav-card[draggable="true"] {
+  cursor: grab;
+}
+
+.blockr-panel-nav-card.pn-dragging {
+  opacity: 0.4;
+}
+
+.blockr-panel-nav-group.pn-drop-target {
+  outline: 2px dashed var(--bb-blue-500);
+  outline-offset: 2px;
+  border-radius: 8px;
+  background: var(--bb-blue-100);
+}
+
+/* Keep an empty stack (no cards) visible as a drop zone — the block-browser
+   CSS would otherwise hide any category with no non-hidden card, which also
+   matches a genuinely empty group. Search-filtered groups (cards present
+   but all hidden) still collapse via that rule. */
+.blockr-panel-nav-group:not(:has(.blockr-block-browser-card)) {
+  display: flex !important;
+  flex-direction: column;
+}
+
+.blockr-panel-nav-group:not(:has(.blockr-block-browser-card))
+  .blockr-block-browser-cards::after {
+  content: "Drop a block here";
+  display: block;
+  padding: 10px 8px;
+  font-size: 12px;
+  color: var(--bb-grey-400);
+  border: 1px dashed var(--bb-grey-300);
+  border-radius: 6px;
+  text-align: center;
+}
+
+/* ---- inline rename --------------------------------------------------- */
+
+.blockr-panel-nav-group-head h3 {
+  cursor: text;
+}
+
+.pn-editing {
+  outline: 2px solid var(--bb-blue-500);
+  outline-offset: 1px;
+  border-radius: 3px;
+  background: #fff;
+  cursor: text;
+}
+
+/* ---- "+ New stack" --------------------------------------------------- */
+
+.blockr-panel-nav-add-stack {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--bb-grey-600);
+  background: transparent;
+  border: 1px dashed var(--bb-grey-300);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.blockr-panel-nav-add-stack:hover {
+  background: var(--bb-grey-50);
+  border-color: var(--bb-grey-400);
+  color: var(--bb-grey-900);
+}

--- a/inst/assets/js/panel-navigator.js
+++ b/inst/assets/js/panel-navigator.js
@@ -81,10 +81,49 @@
     }
   });
 
-  // ---- drag a card onto a stack heading to reassign --------------------
+  // ---- drag a card to reassign (onto a stack) or reorder (between cards)-
 
   function dropGroup(el) {
     return el && el.closest ? el.closest(".blockr-panel-nav-group") : null;
+  }
+
+  // The would-be target ordering for `group` if `draggedId` were dropped at
+  // vertical position `clientY`: the group's cards (minus the dragged one)
+  // with the dragged id spliced in before the first card whose midpoint is
+  // below the cursor (else appended). `beforeCard` is that card, for the
+  // insertion indicator.
+  function reorderState(group, draggedId, clientY) {
+    var cards = Array.prototype.filter.call(
+      group.querySelectorAll(".blockr-panel-nav-card"),
+      function (c) {
+        return c.getAttribute("data-block-id") !== draggedId;
+      }
+    );
+    var beforeCard = null;
+    for (var i = 0; i < cards.length; i++) {
+      var r = cards[i].getBoundingClientRect();
+      if (clientY < r.top + r.height / 2) {
+        beforeCard = cards[i];
+        break;
+      }
+    }
+    var ids = cards.map(function (c) {
+      return c.getAttribute("data-block-id");
+    });
+    var idx = beforeCard
+      ? ids.indexOf(beforeCard.getAttribute("data-block-id"))
+      : ids.length;
+    ids.splice(idx, 0, draggedId);
+    return { order: ids, beforeCard: beforeCard };
+  }
+
+  function clearIndicators(root) {
+    Array.prototype.forEach.call(
+      root.querySelectorAll(".pn-drop-before, .pn-drop-end"),
+      function (el) {
+        el.classList.remove("pn-drop-before", "pn-drop-end");
+      }
+    );
   }
 
   document.addEventListener("dragstart", function (event) {
@@ -106,17 +145,35 @@
   document.addEventListener("dragend", function (event) {
     var card = event.target.closest(".blockr-panel-nav-card");
     if (card) card.classList.remove("pn-dragging");
-    var roots = document.querySelectorAll(".pn-drop-target");
-    Array.prototype.forEach.call(roots, function (el) {
-      el.classList.remove("pn-drop-target");
-    });
+    Array.prototype.forEach.call(
+      document.querySelectorAll(".pn-drop-target"),
+      function (el) {
+        el.classList.remove("pn-drop-target");
+      }
+    );
+    var root = navRoot(card);
+    if (root) clearIndicators(root);
   });
 
   document.addEventListener("dragover", function (event) {
     var grp = dropGroup(event.target);
-    if (!grp || !navRoot(grp)) return;
+    var root = grp && navRoot(grp);
+    if (!root) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = "move";
+
+    // Insertion indicator: the dragged card is known via `.pn-dragging`
+    // (dataTransfer is unreadable during dragover).
+    clearIndicators(root);
+    var dragged = root.querySelector(".pn-dragging");
+    if (!dragged) return;
+    var st = reorderState(grp, dragged.getAttribute("data-block-id"), event.clientY);
+    if (st.beforeCard) {
+      st.beforeCard.classList.add("pn-drop-before");
+    } else {
+      var cards = grp.querySelector(".blockr-block-browser-cards");
+      if (cards) cards.classList.add("pn-drop-end");
+    }
   });
 
   document.addEventListener("dragenter", function (event) {
@@ -128,21 +185,30 @@
     var grp = dropGroup(event.target);
     if (grp && !grp.contains(event.relatedTarget)) {
       grp.classList.remove("pn-drop-target");
+      clearIndicators(navRoot(grp));
     }
   });
 
   document.addEventListener("drop", function (event) {
     var grp = dropGroup(event.target);
-    if (!grp || !navRoot(grp)) return;
+    var root = grp && navRoot(grp);
+    if (!root) return;
     event.preventDefault();
     grp.classList.remove("pn-drop-target");
+    clearIndicators(root);
+
     var bid = event.dataTransfer.getData("text/plain");
     if (!bid) return;
-    // `data-stack-id` is the target stack ("" = Ungrouped / out of stack).
-    send(navRoot(grp), {
+
+    // `data-stack-id` is the target stack ("" = Ungrouped / out of stack);
+    // `order` is the full target ordering, so the same event handles a
+    // cross-stack move, a reorder within a stack, and an append-on-heading.
+    var st = reorderState(grp, bid, event.clientY);
+    send(root, {
       kind: "assign",
       id: bid,
-      to: grp.getAttribute("data-stack-id") || ""
+      to: grp.getAttribute("data-stack-id") || "",
+      order: st.order
     });
   });
 

--- a/inst/assets/js/panel-navigator.js
+++ b/inst/assets/js/panel-navigator.js
@@ -1,292 +1,356 @@
-/* Panel navigator: client behaviour for the dock's "Blocks" sidebar.
- *
- * The body is injected dynamically (via blockr.ui::show_sidebar), so all
- * handlers are delegated on `document` and scoped to the navigator root
- * (`.blockr-panel-nav`). The root's `data-input-id` is the Shiny input the
- * navigator's server observer reads (a multiplexed {kind, id, to, nonce}).
- *
- * Eye toggles are optimistic: the row's shown/hidden class is flipped (and
- * the group count updated) immediately, then the event is sent for the
- * server to apply via show/hide_block_panel(). Search reuses the shared
- * card filter shipped by block_browser_dep() (window.BlockrUI.cardSearch).
- */
 (function () {
   "use strict";
 
+  // The panel navigator (variant B). A single Shiny input whose value is
+  // multiplexed by `kind`:
+  //   - "toggle":       the switch shows / hides a block on the view
+  //   - "assign":       grip-drag a block to another stack, or reorder
+  //   - "add_stack":    create a new (empty) stack
+  //   - "rename":       rename a block
+  //   - "rename_stack": rename a stack
+  // The value carries a monotonically increasing `nonce` so Shiny re-fires.
+  var EVT = "blockr-panel-navigator:event";
   var seq = 0;
 
-  function navRoot(el) {
-    return el && el.closest ? el.closest(".blockr-panel-nav") : null;
+  function commit(root, value) {
+    value.nonce = ++seq;
+    root._navValue = value;
+    root.dispatchEvent(new CustomEvent(EVT));
   }
 
-  function send(root, payload) {
-    var id = root.getAttribute("data-input-id");
-    if (!id || !window.Shiny) return;
-    payload.nonce = ++seq;
-    Shiny.setInputValue(id, payload, { priority: "event" });
-  }
-
-  function updateCount(card) {
-    var group = card.closest(".blockr-panel-nav-group");
-    if (!group) return;
-    var total = group.querySelectorAll(".blockr-panel-nav-card").length;
-    var shown = group.querySelectorAll(
-      ".blockr-panel-nav-card.pn-shown"
-    ).length;
-    var count = group.querySelector(".blockr-panel-nav-count");
-    if (count) count.textContent = shown + "/" + total + " shown";
-  }
-
-  document.addEventListener("click", function (event) {
-    var root = navRoot(event.target);
-    if (!root) return;
-
-    var card = event.target.closest(".blockr-panel-nav-card");
-    if (!card) return;
-
-    var bid = card.getAttribute("data-block-id");
-
-    if (event.target.closest(".blockr-panel-nav-eye")) {
-      var wasShown = card.classList.contains("pn-shown");
-      card.classList.toggle("pn-shown", !wasShown);
-      card.classList.toggle("pn-hidden", wasShown);
-      updateCount(card);
-      send(root, { kind: "toggle", id: bid, to: wasShown ? "remove" : "add" });
-      return;
-    }
-
-    // Row body click: reveal (bring the panel to front) when it is shown.
-    if (card.classList.contains("pn-shown")) {
-      send(root, { kind: "focus", id: bid });
-    }
-  });
-
-  document.addEventListener("input", function (event) {
-    var root = navRoot(event.target);
-    if (!root) return;
-    if (!event.target.classList.contains("blockr-panel-nav-search")) return;
-
-    if (window.BlockrUI && window.BlockrUI.cardSearch) {
-      window.BlockrUI.cardSearch.applySearch(root, event.target.value);
-    }
-  });
-
-  // ---- "+ New stack" ---------------------------------------------------
-
-  document.addEventListener("click", function (event) {
-    var root = navRoot(event.target);
-    if (!root) return;
-    if (event.target.closest(".blockr-panel-nav-add-stack")) {
-      send(root, { kind: "add_stack" });
-    }
-  });
-
-  // ---- drag a card to reassign (onto a stack) or reorder (between cards)-
-
-  function dropGroup(el) {
-    return el && el.closest ? el.closest(".blockr-panel-nav-group") : null;
-  }
-
-  // The would-be target ordering for `group` if `draggedId` were dropped at
-  // vertical position `clientY`: the group's cards (minus the dragged one)
-  // with the dragged id spliced in before the first card whose midpoint is
-  // below the cursor (else appended). `beforeCard` is that card, for the
-  // insertion indicator.
-  function reorderState(group, draggedId, clientY) {
-    var cards = Array.prototype.filter.call(
-      group.querySelectorAll(".blockr-panel-nav-card"),
-      function (c) {
-        return c.getAttribute("data-block-id") !== draggedId;
-      }
-    );
-    var beforeCard = null;
-    for (var i = 0; i < cards.length; i++) {
-      var r = cards[i].getBoundingClientRect();
-      if (clientY < r.top + r.height / 2) {
-        beforeCard = cards[i];
-        break;
-      }
-    }
-    var ids = cards.map(function (c) {
-      return c.getAttribute("data-block-id");
+  // ---- search ----------------------------------------------------------
+  function applySearch(root, query) {
+    var q = (query || "").trim().toLowerCase();
+    var any = false;
+    root.querySelectorAll(".blockr-panel-nav-row").forEach(function (row) {
+      var hit = q.length === 0 ||
+        (row.getAttribute("data-search") || "").indexOf(q) !== -1;
+      row.classList.toggle("hidden", !hit);
+      if (hit) any = true;
     });
-    var idx = beforeCard
-      ? ids.indexOf(beforeCard.getAttribute("data-block-id"))
-      : ids.length;
-    ids.splice(idx, 0, draggedId);
-    return { order: ids, beforeCard: beforeCard };
+    root.querySelectorAll(".blockr-panel-nav-grp").forEach(function (grp) {
+      var vis = grp.querySelectorAll(
+        ".blockr-panel-nav-row:not(.hidden)"
+      ).length;
+      // While searching, hide empty groups and open the matching ones so
+      // hits inside collapsed stacks are visible.
+      grp.classList.toggle("hidden", q.length > 0 && vis === 0);
+      if (q.length > 0 && vis > 0) grp.classList.add("open");
+    });
+    root.classList.toggle("is-empty", !any && q.length > 0);
   }
 
-  function clearIndicators(root) {
-    Array.prototype.forEach.call(
-      root.querySelectorAll(".pn-drop-before, .pn-drop-end"),
-      function (el) {
-        el.classList.remove("pn-drop-before", "pn-drop-end");
-      }
-    );
+  // ---- visibility toggle (the switch is the ONLY toggle) ---------------
+  function updateShown(row) {
+    var grp = row.closest(".blockr-panel-nav-grp");
+    if (!grp) return;
+    var n = grp.querySelectorAll(".blockr-panel-nav-row.on").length;
+    var vis = grp.querySelector(".blockr-panel-nav-gvis");
+    if (vis) vis.textContent = n + " shown";
   }
 
-  document.addEventListener("dragstart", function (event) {
-    var card = event.target.closest(".blockr-panel-nav-card");
-    if (!card || !navRoot(card)) return;
-    // The eye and an in-progress rename must not start a drag.
-    if (
-      card.getAttribute("data-editing") === "true" ||
-      event.target.closest(".blockr-panel-nav-eye")
-    ) {
-      event.preventDefault();
-      return;
+  function commitToggle(root, row) {
+    var on = row.getAttribute("data-on-view") === "true";
+    row.setAttribute("data-on-view", on ? "false" : "true");
+    row.classList.toggle("on", !on);
+    row.classList.toggle("off", on);
+    var sw = row.querySelector(".blockr-panel-nav-switch");
+    if (sw) sw.setAttribute("aria-checked", on ? "false" : "true");
+    updateShown(row);
+    commit(root, {
+      kind: "toggle",
+      id: row.getAttribute("data-panel-id"),
+      type: row.getAttribute("data-panel-type"),
+      to: on ? "remove" : "add"
+    });
+  }
+
+  function toggleCollapse(ghd) {
+    var grp = ghd.closest(".blockr-panel-nav-grp");
+    var open = grp.classList.toggle("open");
+    ghd.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  // ---- inline rename (canonical pattern; see nav_rename() in R) --------
+  function enterEdit(wrapper) {
+    if (wrapper.classList.contains("editing")) return;
+    var textEl = wrapper.querySelector(".blockr-panel-nav-rename-text");
+    var input = wrapper.querySelector(".blockr-panel-nav-rename-input");
+    if (!textEl || !input) return;
+    var host = wrapper.closest('[draggable="true"]');
+    if (host) { wrapper._navHost = host; host.setAttribute("draggable", "false"); }
+    input.value = textEl.textContent;
+    wrapper.classList.add("editing");
+    input.focus();
+    input.select();
+  }
+
+  function exitEdit(wrapper) {
+    wrapper.classList.remove("editing");
+    if (wrapper._navHost) {
+      wrapper._navHost.setAttribute("draggable", "true");
+      wrapper._navHost = null;
     }
-    event.dataTransfer.setData("text/plain", card.getAttribute("data-block-id"));
-    event.dataTransfer.effectAllowed = "move";
-    card.classList.add("pn-dragging");
-  });
+  }
 
-  document.addEventListener("dragend", function (event) {
-    var card = event.target.closest(".blockr-panel-nav-card");
-    if (card) card.classList.remove("pn-dragging");
-    Array.prototype.forEach.call(
-      document.querySelectorAll(".pn-drop-target"),
-      function (el) {
-        el.classList.remove("pn-drop-target");
-      }
-    );
-    var root = navRoot(card);
-    if (root) clearIndicators(root);
-  });
-
-  document.addEventListener("dragover", function (event) {
-    var grp = dropGroup(event.target);
-    var root = grp && navRoot(grp);
-    if (!root) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "move";
-
-    // Insertion indicator: the dragged card is known via `.pn-dragging`
-    // (dataTransfer is unreadable during dragover).
-    clearIndicators(root);
-    var dragged = root.querySelector(".pn-dragging");
-    if (!dragged) return;
-    var st = reorderState(grp, dragged.getAttribute("data-block-id"), event.clientY);
-    if (st.beforeCard) {
-      st.beforeCard.classList.add("pn-drop-before");
+  function commitRename(root, wrapper) {
+    var textEl = wrapper.querySelector(".blockr-panel-nav-rename-text");
+    var input = wrapper.querySelector(".blockr-panel-nav-rename-input");
+    var name = (input.value || "").trim();
+    exitEdit(wrapper);
+    if (!name || name === textEl.textContent) return;
+    textEl.textContent = name; // optimistic
+    if (wrapper.getAttribute("data-rename-kind") === "stack") {
+      var grp = wrapper.closest(".blockr-panel-nav-grp");
+      commit(root, {
+        kind: "rename_stack",
+        stack: grp ? grp.getAttribute("data-stack-id") || "" : "",
+        name: name
+      });
     } else {
-      var cards = grp.querySelector(".blockr-block-browser-cards");
-      if (cards) cards.classList.add("pn-drop-end");
-    }
-  });
-
-  document.addEventListener("dragenter", function (event) {
-    var grp = dropGroup(event.target);
-    if (grp && navRoot(grp)) grp.classList.add("pn-drop-target");
-  });
-
-  document.addEventListener("dragleave", function (event) {
-    var grp = dropGroup(event.target);
-    if (grp && !grp.contains(event.relatedTarget)) {
-      grp.classList.remove("pn-drop-target");
-      clearIndicators(navRoot(grp));
-    }
-  });
-
-  document.addEventListener("drop", function (event) {
-    var grp = dropGroup(event.target);
-    var root = grp && navRoot(grp);
-    if (!root) return;
-    event.preventDefault();
-    grp.classList.remove("pn-drop-target");
-    clearIndicators(root);
-
-    var bid = event.dataTransfer.getData("text/plain");
-    if (!bid) return;
-
-    // `data-stack-id` is the target stack ("" = Ungrouped / out of stack);
-    // `order` is the full target ordering, so the same event handles a
-    // cross-stack move, a reorder within a stack, and an append-on-heading.
-    var st = reorderState(grp, bid, event.clientY);
-    send(root, {
-      kind: "assign",
-      id: bid,
-      to: grp.getAttribute("data-stack-id") || "",
-      order: st.order
-    });
-  });
-
-  // ---- inline rename (double-click a block name or stack heading) ------
-
-  document.addEventListener("dblclick", function (event) {
-    var root = navRoot(event.target);
-    if (!root) return;
-
-    var nameEl = event.target.closest(".blockr-block-browser-card-name");
-    if (nameEl) {
-      var card = nameEl.closest(".blockr-panel-nav-card");
-      beginEdit(root, nameEl, "rename", card.getAttribute("data-block-id"), card);
-      return;
-    }
-
-    var headEl = event.target.closest(".blockr-panel-nav-group-head h3");
-    if (headEl) {
-      var grp = headEl.closest(".blockr-panel-nav-group");
-      var sid = grp.getAttribute("data-stack-id");
-      // Ungrouped (no id) is not a real stack and can't be renamed.
-      if (sid) beginEdit(root, headEl, "rename_stack", sid, null);
-    }
-  });
-
-  function beginEdit(root, el, kind, id, card) {
-    if (el.getAttribute("contenteditable") === "true") return;
-    var orig = el.textContent;
-    var done = false;
-
-    if (card) {
-      card.setAttribute("data-editing", "true");
-      card.setAttribute("draggable", "false");
-    }
-    el.setAttribute("contenteditable", "true");
-    el.classList.add("pn-editing");
-    el.focus();
-
-    var range = document.createRange();
-    range.selectNodeContents(el);
-    var sel = window.getSelection();
-    sel.removeAllRanges();
-    sel.addRange(range);
-
-    function finish(commit) {
-      if (done) return;
-      done = true;
-      el.removeAttribute("contenteditable");
-      el.classList.remove("pn-editing");
-      if (card) {
-        card.removeAttribute("data-editing");
-        card.setAttribute("draggable", "true");
+      var row = wrapper.closest(".blockr-panel-nav-row");
+      if (row) {
+        row.setAttribute(
+          "data-search",
+          (name + " " + (row.getAttribute("data-search") || "")).toLowerCase()
+        );
       }
-      el.removeEventListener("keydown", onKey);
-      el.removeEventListener("blur", onBlur);
-
-      var val = el.textContent.trim();
-      if (commit && val && val !== orig) {
-        send(root, { kind: kind, id: id, value: val });
-      } else {
-        el.textContent = orig;
-      }
+      commit(root, {
+        kind: "rename",
+        type: "block",
+        id: row ? row.getAttribute("data-panel-id") : null,
+        name: name
+      });
     }
-
-    function onKey(ev) {
-      if (ev.key === "Enter") {
-        ev.preventDefault();
-        finish(true);
-      } else if (ev.key === "Escape") {
-        ev.preventDefault();
-        finish(false);
-      }
-    }
-    function onBlur() {
-      finish(true);
-    }
-
-    el.addEventListener("keydown", onKey);
-    el.addEventListener("blur", onBlur);
   }
+
+  function wireRenameInput(root, wrapper) {
+    if (wrapper.dataset.navRenameWired === "1") return;
+    wrapper.dataset.navRenameWired = "1";
+    var input = wrapper.querySelector(".blockr-panel-nav-rename-input");
+    if (!input) return;
+    input.addEventListener("keydown", function (event) {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        input.blur();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        wrapper._navCancel = true;
+        input.blur();
+      }
+      event.stopPropagation();
+    });
+    input.addEventListener("blur", function () {
+      if (wrapper._navCancel) { wrapper._navCancel = false; exitEdit(wrapper); return; }
+      commitRename(root, wrapper);
+    });
+    input.addEventListener("click", function (e) { e.stopPropagation(); });
+    input.addEventListener("dblclick", function (e) { e.stopPropagation(); });
+  }
+
+  function startEdit(root, wrapper) {
+    wireRenameInput(root, wrapper);
+    enterEdit(wrapper);
+  }
+
+  // ---- grip drag: move between stacks (mostly) / reorder within --------
+  function clearDropMarks(root) {
+    root.querySelectorAll(".blockr-panel-nav-dropover").forEach(function (g) {
+      g.classList.remove("blockr-panel-nav-dropover");
+    });
+    root.querySelectorAll(".blockr-panel-nav-row.dropline").forEach(function (r) {
+      r.classList.remove("dropline");
+    });
+  }
+
+  function initNavigator(root) {
+    if (root.dataset.blockrPanelNavInit === "1") return;
+    root.dataset.blockrPanelNavInit = "1";
+
+    var search = root.querySelector(".blockr-panel-nav-search");
+    if (search) {
+      search.addEventListener("input", function () {
+        applySearch(root, search.value);
+      });
+    }
+
+    var body = root.querySelector(".blockr-panel-nav-body");
+    if (body) {
+      body.addEventListener("click", function (event) {
+        // The switch is the ONLY visibility toggle.
+        var sw = event.target.closest(".blockr-panel-nav-switch");
+        if (sw) {
+          var srow = sw.closest(".blockr-panel-nav-row");
+          if (srow) commitToggle(root, srow);
+          event.preventDefault();
+          return;
+        }
+        // The stack bar collapses — except its rename label (rename zone).
+        var ghd = event.target.closest(".blockr-panel-nav-ghd");
+        if (ghd) {
+          if (event.target.closest(".blockr-panel-nav-rename-text")) return;
+          toggleCollapse(ghd);
+          event.preventDefault();
+          return;
+        }
+        // Click a row body (not the name, which is a rename zone) -> reveal:
+        // bring a VISIBLE block's tab to the front. Never changes visibility
+        // (the switch owns that); clicking a hidden row is inert.
+        var frow = event.target.closest(".blockr-panel-nav-row");
+        if (frow &&
+            !event.target.closest(".blockr-panel-nav-rename-text") &&
+            !event.target.closest(".blockr-panel-nav-grip") &&
+            frow.getAttribute("data-on-view") === "true") {
+          commit(root, {
+            kind: "focus",
+            id: frow.getAttribute("data-panel-id"),
+            type: frow.getAttribute("data-panel-type")
+          });
+        }
+      });
+
+      body.addEventListener("dblclick", function (event) {
+        var rt = event.target.closest(".blockr-panel-nav-rename-text");
+        if (!rt) return;
+        event.preventDefault();
+        startEdit(root, rt.closest(".blockr-panel-nav-rename"));
+      });
+
+      body.addEventListener("keydown", function (event) {
+        var sw = event.target.closest(".blockr-panel-nav-switch");
+        if (sw && (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          var srow = sw.closest(".blockr-panel-nav-row");
+          if (srow) commitToggle(root, srow);
+          return;
+        }
+        if (event.key === "F2") {
+          var hostRow = event.target.closest(
+            ".blockr-panel-nav-row, .blockr-panel-nav-ghd"
+          );
+          if (hostRow) {
+            var w = hostRow.querySelector(".blockr-panel-nav-rename");
+            if (w) { event.preventDefault(); startEdit(root, w); }
+          }
+          return;
+        }
+        var ghd = event.target.closest(".blockr-panel-nav-ghd");
+        if (ghd && event.target === ghd &&
+            (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          toggleCollapse(ghd);
+        }
+      });
+
+      body.addEventListener("dragstart", function (event) {
+        var row = event.target.closest(".blockr-panel-nav-row");
+        if (!row || row.getAttribute("draggable") !== "true") return;
+        root._navDragId = row.getAttribute("data-panel-id");
+        root._navDragRow = row;
+        row.classList.add("dragging");
+        // Reveal an empty Ungrouped as a drop target for the drag.
+        root.classList.add("is-dragging");
+        if (event.dataTransfer) {
+          event.dataTransfer.effectAllowed = "move";
+          event.dataTransfer.setData("text/plain", root._navDragId);
+        }
+      });
+
+      body.addEventListener("dragend", function () {
+        if (root._navDragRow) root._navDragRow.classList.remove("dragging");
+        root.classList.remove("is-dragging");
+        clearDropMarks(root);
+        root._navDragId = null;
+        root._navDragRow = null;
+        root._navDropStack = null;
+        root._navDropBeforeId = null;
+      });
+
+      body.addEventListener("dragover", function (event) {
+        if (root._navDragId == null) return;
+        var grp = event.target.closest(".blockr-panel-nav-dropzone");
+        if (!grp) return;
+        event.preventDefault();
+        if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+        clearDropMarks(root);
+        grp.classList.add("blockr-panel-nav-dropover");
+        root._navDropStack = grp.getAttribute("data-stack-id") || "";
+        // Insert-before = the first row whose midpoint is below the cursor.
+        var rows = Array.prototype.slice
+          .call(grp.querySelectorAll(".blockr-panel-nav-row"))
+          .filter(function (r) { return r !== root._navDragRow; });
+        var beforeId = null;
+        for (var i = 0; i < rows.length; i++) {
+          var rect = rows[i].getBoundingClientRect();
+          if (event.clientY < rect.top + rect.height / 2) {
+            beforeId = rows[i].getAttribute("data-panel-id");
+            rows[i].classList.add("dropline");
+            break;
+          }
+        }
+        root._navDropBeforeId = beforeId;
+      });
+
+      body.addEventListener("drop", function (event) {
+        if (root._navDragId == null) return;
+        var grp = event.target.closest(".blockr-panel-nav-dropzone");
+        if (!grp) { clearDropMarks(root); return; }
+        event.preventDefault();
+        var id = root._navDragId;
+        var stack = root._navDropStack != null ? root._navDropStack
+          : (grp.getAttribute("data-stack-id") || "");
+        var before = root._navDropBeforeId || null;
+        clearDropMarks(root);
+        commit(root, { kind: "assign", id: id, stack: stack, before: before });
+      });
+    }
+
+    // ---- add-stack control ------------------------------------------
+    var addWrap = root.querySelector(".blockr-panel-nav-addstack");
+    if (addWrap) {
+      var btn = addWrap.querySelector(".blockr-panel-nav-addstack-btn");
+      var input = addWrap.querySelector(".blockr-panel-nav-addstack-input");
+      if (btn && input) {
+        btn.addEventListener("click", function () {
+          if (addWrap.classList.toggle("is-open")) input.focus();
+        });
+        input.addEventListener("keydown", function (event) {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            var name = input.value.trim();
+            if (!name) return;
+            commit(root, { kind: "add_stack", name: name });
+            input.value = "";
+            addWrap.classList.remove("is-open");
+          } else if (event.key === "Escape") {
+            input.value = "";
+            addWrap.classList.remove("is-open");
+          }
+        });
+      }
+    }
+  }
+
+  var binding = new Shiny.InputBinding();
+  $.extend(binding, {
+    find: function (scope) {
+      return $(scope).find(".blockr-panel-navigator");
+    },
+    initialize: function (el) { initNavigator(el); },
+    getValue: function (el) { return el._navValue || null; },
+    subscribe: function (el, callback) {
+      initNavigator(el);
+      var handler = function () { callback(); };
+      el._navHandler = handler;
+      el.addEventListener(EVT, handler);
+    },
+    unsubscribe: function (el) {
+      if (el._navHandler) {
+        el.removeEventListener(EVT, el._navHandler);
+        el._navHandler = null;
+      }
+    }
+  });
+
+  Shiny.inputBindings.register(binding, "blockr.ui.panelNavigator");
 })();

--- a/inst/assets/js/panel-navigator.js
+++ b/inst/assets/js/panel-navigator.js
@@ -70,4 +70,157 @@
       window.BlockrUI.cardSearch.applySearch(root, event.target.value);
     }
   });
+
+  // ---- "+ New stack" ---------------------------------------------------
+
+  document.addEventListener("click", function (event) {
+    var root = navRoot(event.target);
+    if (!root) return;
+    if (event.target.closest(".blockr-panel-nav-add-stack")) {
+      send(root, { kind: "add_stack" });
+    }
+  });
+
+  // ---- drag a card onto a stack heading to reassign --------------------
+
+  function dropGroup(el) {
+    return el && el.closest ? el.closest(".blockr-panel-nav-group") : null;
+  }
+
+  document.addEventListener("dragstart", function (event) {
+    var card = event.target.closest(".blockr-panel-nav-card");
+    if (!card || !navRoot(card)) return;
+    // The eye and an in-progress rename must not start a drag.
+    if (
+      card.getAttribute("data-editing") === "true" ||
+      event.target.closest(".blockr-panel-nav-eye")
+    ) {
+      event.preventDefault();
+      return;
+    }
+    event.dataTransfer.setData("text/plain", card.getAttribute("data-block-id"));
+    event.dataTransfer.effectAllowed = "move";
+    card.classList.add("pn-dragging");
+  });
+
+  document.addEventListener("dragend", function (event) {
+    var card = event.target.closest(".blockr-panel-nav-card");
+    if (card) card.classList.remove("pn-dragging");
+    var roots = document.querySelectorAll(".pn-drop-target");
+    Array.prototype.forEach.call(roots, function (el) {
+      el.classList.remove("pn-drop-target");
+    });
+  });
+
+  document.addEventListener("dragover", function (event) {
+    var grp = dropGroup(event.target);
+    if (!grp || !navRoot(grp)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+  });
+
+  document.addEventListener("dragenter", function (event) {
+    var grp = dropGroup(event.target);
+    if (grp && navRoot(grp)) grp.classList.add("pn-drop-target");
+  });
+
+  document.addEventListener("dragleave", function (event) {
+    var grp = dropGroup(event.target);
+    if (grp && !grp.contains(event.relatedTarget)) {
+      grp.classList.remove("pn-drop-target");
+    }
+  });
+
+  document.addEventListener("drop", function (event) {
+    var grp = dropGroup(event.target);
+    if (!grp || !navRoot(grp)) return;
+    event.preventDefault();
+    grp.classList.remove("pn-drop-target");
+    var bid = event.dataTransfer.getData("text/plain");
+    if (!bid) return;
+    // `data-stack-id` is the target stack ("" = Ungrouped / out of stack).
+    send(navRoot(grp), {
+      kind: "assign",
+      id: bid,
+      to: grp.getAttribute("data-stack-id") || ""
+    });
+  });
+
+  // ---- inline rename (double-click a block name or stack heading) ------
+
+  document.addEventListener("dblclick", function (event) {
+    var root = navRoot(event.target);
+    if (!root) return;
+
+    var nameEl = event.target.closest(".blockr-block-browser-card-name");
+    if (nameEl) {
+      var card = nameEl.closest(".blockr-panel-nav-card");
+      beginEdit(root, nameEl, "rename", card.getAttribute("data-block-id"), card);
+      return;
+    }
+
+    var headEl = event.target.closest(".blockr-panel-nav-group-head h3");
+    if (headEl) {
+      var grp = headEl.closest(".blockr-panel-nav-group");
+      var sid = grp.getAttribute("data-stack-id");
+      // Ungrouped (no id) is not a real stack and can't be renamed.
+      if (sid) beginEdit(root, headEl, "rename_stack", sid, null);
+    }
+  });
+
+  function beginEdit(root, el, kind, id, card) {
+    if (el.getAttribute("contenteditable") === "true") return;
+    var orig = el.textContent;
+    var done = false;
+
+    if (card) {
+      card.setAttribute("data-editing", "true");
+      card.setAttribute("draggable", "false");
+    }
+    el.setAttribute("contenteditable", "true");
+    el.classList.add("pn-editing");
+    el.focus();
+
+    var range = document.createRange();
+    range.selectNodeContents(el);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    function finish(commit) {
+      if (done) return;
+      done = true;
+      el.removeAttribute("contenteditable");
+      el.classList.remove("pn-editing");
+      if (card) {
+        card.removeAttribute("data-editing");
+        card.setAttribute("draggable", "true");
+      }
+      el.removeEventListener("keydown", onKey);
+      el.removeEventListener("blur", onBlur);
+
+      var val = el.textContent.trim();
+      if (commit && val && val !== orig) {
+        send(root, { kind: kind, id: id, value: val });
+      } else {
+        el.textContent = orig;
+      }
+    }
+
+    function onKey(ev) {
+      if (ev.key === "Enter") {
+        ev.preventDefault();
+        finish(true);
+      } else if (ev.key === "Escape") {
+        ev.preventDefault();
+        finish(false);
+      }
+    }
+    function onBlur() {
+      finish(true);
+    }
+
+    el.addEventListener("keydown", onKey);
+    el.addEventListener("blur", onBlur);
+  }
 })();

--- a/inst/assets/js/panel-navigator.js
+++ b/inst/assets/js/panel-navigator.js
@@ -1,0 +1,73 @@
+/* Panel navigator: client behaviour for the dock's "Blocks" sidebar.
+ *
+ * The body is injected dynamically (via blockr.ui::show_sidebar), so all
+ * handlers are delegated on `document` and scoped to the navigator root
+ * (`.blockr-panel-nav`). The root's `data-input-id` is the Shiny input the
+ * navigator's server observer reads (a multiplexed {kind, id, to, nonce}).
+ *
+ * Eye toggles are optimistic: the row's shown/hidden class is flipped (and
+ * the group count updated) immediately, then the event is sent for the
+ * server to apply via show/hide_block_panel(). Search reuses the shared
+ * card filter shipped by block_browser_dep() (window.BlockrUI.cardSearch).
+ */
+(function () {
+  "use strict";
+
+  var seq = 0;
+
+  function navRoot(el) {
+    return el && el.closest ? el.closest(".blockr-panel-nav") : null;
+  }
+
+  function send(root, payload) {
+    var id = root.getAttribute("data-input-id");
+    if (!id || !window.Shiny) return;
+    payload.nonce = ++seq;
+    Shiny.setInputValue(id, payload, { priority: "event" });
+  }
+
+  function updateCount(card) {
+    var group = card.closest(".blockr-panel-nav-group");
+    if (!group) return;
+    var total = group.querySelectorAll(".blockr-panel-nav-card").length;
+    var shown = group.querySelectorAll(
+      ".blockr-panel-nav-card.pn-shown"
+    ).length;
+    var count = group.querySelector(".blockr-panel-nav-count");
+    if (count) count.textContent = shown + "/" + total + " shown";
+  }
+
+  document.addEventListener("click", function (event) {
+    var root = navRoot(event.target);
+    if (!root) return;
+
+    var card = event.target.closest(".blockr-panel-nav-card");
+    if (!card) return;
+
+    var bid = card.getAttribute("data-block-id");
+
+    if (event.target.closest(".blockr-panel-nav-eye")) {
+      var wasShown = card.classList.contains("pn-shown");
+      card.classList.toggle("pn-shown", !wasShown);
+      card.classList.toggle("pn-hidden", wasShown);
+      updateCount(card);
+      send(root, { kind: "toggle", id: bid, to: wasShown ? "remove" : "add" });
+      return;
+    }
+
+    // Row body click: reveal (bring the panel to front) when it is shown.
+    if (card.classList.contains("pn-shown")) {
+      send(root, { kind: "focus", id: bid });
+    }
+  });
+
+  document.addEventListener("input", function (event) {
+    var root = navRoot(event.target);
+    if (!root) return;
+    if (!event.target.classList.contains("blockr-panel-nav-search")) return;
+
+    if (window.BlockrUI && window.BlockrUI.cardSearch) {
+      window.BlockrUI.cardSearch.applySearch(root, event.target.value);
+    }
+  });
+})();


### PR DESCRIPTION
> **WIP** — opening early for review of the approach. Verified live end-to-end; no dedicated unit tests yet (see *Follow-ups*).

## Panel Navigator — the "Blocks" sidebar

A right-side sidebar that lists **every** block on the board grouped by its
blockr.core stack (or *Ungrouped*), each row carrying a visibility **switch**
that reflects whether the block's panel is on the **active view**. It turns the
add-panel picker inside-out: instead of *"what can I add"* (the `setdiff` modal),
it shows *"here is everything you have, and where it is."*

Design spec: `_blockr.design/open/panel-navigator/` (motivation → requirements →
design → implementation).

## What it does
- **Open** via a new navbar **Blocks** button.
- Each stack is a coloured, collapsible **bar** with an **"N shown"** count;
  rows show a category-tinted icon tile, the name, and a switch.
- **The switch is the only visibility control** — drag and rename never flip it.
- **Click a visible row** → reveal its tab (`select_block_panel`).
- **Double-click a name** (block or stack) → inline rename.
- **Drag the grip** → move a block between stacks / reorder within a stack;
  drop on *Ungrouped* to clear its stack.
- **+ New stack**, search, an Ungrouped bucket, other-view tags.
- A **pinned** navigator stays live — it re-renders on a view switch and on
  external structure changes, but not on a plain toggle (keeps scroll/collapse).

## Architecture — self-contained in blockr.dock
This is a **reimplementation** of the earlier `feat/panel-navigator-stacks`
prototype, which split a "brain" into blockr.ui with blockr.dock as a thin
adapter. Here the navigator lives **entirely in blockr.dock** and needs **no
blockr.ui changes** — it builds on blockr.ui's existing sidebar primitives
(`sidebar_ui` / `show_sidebar` / `sidebar_state`) only. The CSS / JS (variant-B
"Visible blocks" design) are ported verbatim from the prototype and are fully
self-contained (no block-browser dependency).

- Visibility is a **view** concern (the dock layout, not the core board), so the
  switch routes through `show/hide_block_panel` on the active dock.
- Rename / regroup / new-stack go through the blockr.core `update()` channel as
  **deltas**, so the DAG extension and the assistant stay consistent and stack
  block order serialises.

## Files
- `R/panel-navigator.R` — observer, event handlers, model, and the variant-B renderer.
- `R/board-ui.R` — the navbar **Blocks** button + the sidebar mount.
- `R/board-server.R` — `panel_navigator_observer()` wired into `board_server_callback()`.
- `inst/assets/css/panel-navigator.css`, `inst/assets/js/panel-navigator.js` — self-contained.
- `dev/panel-navigator-demo.R` — a `load_all` harness (stack + ungrouped + two views).

## Follow-ups
- Unit tests for `nav_build_model` / `nav_reassign_payload` / `apply` handlers.
- Secondary entry point: open from a dock group's **+** (places new panels in that group).
- The agreed app-wide inline-rename widget should migrate the other rename sites.
