### PR TITLE
fix: break the dock layout-reconcile feedback loop ("loads forever" on slow clients)

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -181,6 +181,23 @@ live_view_data <- function(client_views, docks, client_active) {
         return(NULL)
       }
       out <- dockview_to_layout(ly)
+
+      # FIX #3: do not fold a mid-flight echo into the board. The browser's
+      # `_state` echo can fire while `apply_layout_diff` is tearing the dock
+      # down and rebuilding it, reporting a *partial* panel set. `live_panels`
+      # is the authoritative server-side membership; if the echo disagrees, it
+      # is mid-relayout -- folding it would corrupt `target` and make reconcile
+      # do another full teardown (the membership-diff loop). Hold this view
+      # (-> whole sync holds) until its echo membership catches up. Legitimate
+      # membership changes update `live_panels` via the add/remove touchpoints
+      # *first*, so they are not lost here.
+      if (!setequal(as.character(layout_panel_ids(out)),
+                    as.character(isolate(dk$live_panels())))) {
+        message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
+                "] sync-guard ", v_id, " echo-membership != live_panels -> HOLD")
+        return(NULL)
+      }
+
       nm <- view_name(state[[v_id]])
       if (!is.null(nm)) {
         view_name(out) <- nm
@@ -223,6 +240,10 @@ layouts_to_board_observer <- function(view_data, update, board) {
     delta <- diff_dock_layouts(current, new_layouts)
 
     if (length(delta)) {
+      message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] sync echo->board: mod=[",
+              paste(names(delta$mod), collapse = ","), "] add=",
+              length(delta$add), " rm=", length(delta$rm),
+              if (!is.null(delta$active)) paste0(" active=", delta$active) else "")
       update(list(views = delta))
     }
   })
@@ -489,6 +510,7 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
 
   if (!setequal(live_ids, target_ids)) {
 
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " membership-diff -> PUSH")
     apply_layout_diff(
       view = view,
       target = target,
@@ -498,6 +520,7 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
     )
 
     dock$live_panels(target_ids)
+    dock$last_applied(target)
 
     return(invisible())
   }
@@ -505,17 +528,35 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
   live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
 
   if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " echo-membership-lag -> skip")
     return(invisible())
   }
 
   if (!layouts_match(live, target)) {
-    apply_layout_diff(
-      view = view,
-      target = target,
-      dock = dock,
-      blocks = blocks,
-      extensions = extensions
-    )
+
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " arr-mismatch; target-changed-vs-last=",
+            !layouts_match(isolate(dock$last_applied()), target))
+
+    # The browser's echoed arrangement (`live`) differs from `target`. Only
+    # re-push when `target` itself changed since we last applied it -- a genuine
+    # server-side rearrange (block add, views$mod, restore). If `target` is
+    # unchanged, the mismatch is just the debounced `_state` echo lagging while
+    # the layout settles; re-pushing here tears the dock down and restores it,
+    # which makes the browser echo again -> reconcile -> re-push ... an infinite
+    # teardown/restore loop that never converges on a slow / CPU-contended
+    # client (the "loads forever" symptom). Wait for the echo to catch up.
+    if (!layouts_match(isolate(dock$last_applied()), target)) {
+
+      apply_layout_diff(
+        view = view,
+        target = target,
+        dock = dock,
+        blocks = blocks,
+        extensions = extensions
+      )
+
+      dock$last_applied(target)
+    }
   }
 
   invisible()
@@ -566,6 +607,12 @@ manage_dock <- function(
     prev_active_group <- reactiveVal()
     active_group_trail <- reactiveVal()
     n_panels <- reactive(length(live_panels()))
+    # The target layout we last pushed to this dock. Used by
+    # reconcile_view_layout() to tell a genuine server-side arrangement change
+    # from the browser's debounced `_state` echo merely lagging behind a stable
+    # target -- the latter must NOT trigger a re-push (else infinite loop on
+    # slow clients).
+    last_applied <- reactiveVal(init_layout)
 
     dock <- list(
       proxy = proxy,
@@ -574,7 +621,8 @@ manage_dock <- function(
       layout = reactive(dockViewR::get_dock(proxy)),
       n_panels = n_panels,
       prev_active_group = prev_active_group,
-      active_group_trail = active_group_trail
+      active_group_trail = active_group_trail,
+      last_applied = last_applied
     )
 
     # Fold live-only membership changes — the add-panel modal, a closed tab, an

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -193,8 +193,6 @@ live_view_data <- function(client_views, docks, client_active) {
       # *first*, so they are not lost here.
       if (!setequal(as.character(layout_panel_ids(out)),
                     as.character(isolate(dk$live_panels())))) {
-        message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
-                "] sync-guard ", v_id, " echo-membership != live_panels -> HOLD")
         return(NULL)
       }
 
@@ -240,10 +238,6 @@ layouts_to_board_observer <- function(view_data, update, board) {
     delta <- diff_dock_layouts(current, new_layouts)
 
     if (length(delta)) {
-      message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] sync echo->board: mod=[",
-              paste(names(delta$mod), collapse = ","), "] add=",
-              length(delta$add), " rm=", length(delta$rm),
-              if (!is.null(delta$active)) paste0(" active=", delta$active) else "")
       update(list(views = delta))
     }
   })
@@ -510,7 +504,6 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
 
   if (!setequal(live_ids, target_ids)) {
 
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " membership-diff -> PUSH")
     apply_layout_diff(
       view = view,
       target = target,
@@ -528,14 +521,10 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
   live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
 
   if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " echo-membership-lag -> skip")
     return(invisible())
   }
 
   if (!layouts_match(live, target)) {
-
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"), "] reconcile ", view, " arr-mismatch; target-changed-vs-last=",
-            !layouts_match(isolate(dock$last_applied()), target))
 
     # The browser's echoed arrangement (`live`) differs from `target`. Only
     # re-push when `target` itself changed since we last applied it -- a genuine

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -589,6 +589,10 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     return(invisible())
   }
 
+  message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
+          "] view-switch ", old, " -> ", active, " START")
+  .t0 <- Sys.time()
+
   if (active %in% names(docks)) {
 
     # switch-view must fire before show_view_ui so the target dock carries
@@ -600,8 +604,15 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     )
 
     hide_view_ui(old, docks)
+    .t_hide <- Sys.time()
     show_view_ui(active, docks)
+    .t_show <- Sys.time()
     update_active_dock(active_dock, docks[[active]])
+
+    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
+            "] view-switch ", active, " ui-done hide=",
+            round(as.numeric(.t_hide - .t0), 3), "s show=",
+            round(as.numeric(.t_show - .t_hide), 3), "s")
   }
 
   client_active(active)

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -589,10 +589,6 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     return(invisible())
   }
 
-  message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
-          "] view-switch ", old, " -> ", active, " START")
-  .t0 <- Sys.time()
-
   if (active %in% names(docks)) {
 
     # switch-view must fire before show_view_ui so the target dock carries
@@ -604,15 +600,8 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     )
 
     hide_view_ui(old, docks)
-    .t_hide <- Sys.time()
     show_view_ui(active, docks)
-    .t_show <- Sys.time()
     update_active_dock(active_dock, docks[[active]])
-
-    message("[loopdbg ", format(Sys.time(), "%H:%M:%OS2"),
-            "] view-switch ", active, " ui-done hide=",
-            round(as.numeric(.t_hide - .t0), 3), "s show=",
-            round(as.numeric(.t_show - .t_hide), 3), "s")
   }
 
   client_active(active)


### PR DESCRIPTION
Fixes #252. Prod-confirmed (Connect, exercised via Edge) — see the [analysis comment on #252](https://github.com/BristolMyersSquibb/blockr.dock/issues/252#issuecomment-4788282670).

## Problem

The full ~99-block cedx board **"loads forever"** on slow / CPU-contended clients (reliably in Safari and on production via Edge; never on local Chrome). It's a **timing race, not a browser engine** — reproduced deterministically by CPU-throttling Chromium (`Emulation.setCPUThrottlingRate`).

A mid-relayout `_state` echo from the browser gets folded into the board, which triggers a full view teardown, which emits more mid-flight echoes → repeat. Instrumenting a live Safari session showed `reconcile … membership-diff -> PUSH` firing **138× and never stopping**, all through the *membership* branch. The offending echoes are **not only empty grids** — they're **partial** panel sets captured mid-teardown (e.g. 3 of 5 panels), so an empty-grid-only guard doesn't cover the sustained loop.

## Fix

**Primary — `live_view_data()` membership guard.** Before folding a view's echoed layout into the board, require its membership to equal the dock's authoritative `live_panels()`; otherwise it's mid-relayout, so hold the whole sync until it catches up. Legitimate membership changes update `live_panels` via the add/remove touchpoints first, so nothing is lost.

**Complementary — `reconcile_view_layout()` arrangement branch.** Track a per-dock `last_applied` and only re-push on an *arrangement* mismatch when `target` actually changed since we last applied it (not merely when the browser echo lags a stable target). Doesn't fix the loop (which runs through the membership branch) but removes spurious full-restores on fast clients during normal interaction.

## Validation

- Live Safari session (server-side trace): `membership-diff -> PUSH` goes **138 → 0**, board settles.
- Deterministic repro under CPU-throttled Chromium reaches a quiet steady state instead of looping.
- **Production deploy: loads to a stable board — the "loads forever" is gone.**
- Chrome (fast client) view switches stay instant — no regression.

## Companion / follow-up

- **Companion:** cynkra/dockViewR `fix/break-resize-feedback` fixes a separate client-side resize storm (`onDidLayoutChange → resize → repeat`) that also pegged R at rest on Safari.
- **Follow-up (separate):** #255 — Safari view switches still take ~3-4s (instant on Chrome); an output suspend-policy / chart-render-cost question, not this loop.

## Notes

- A deeper rewrite of `apply_layout_diff()` (replace the full teardown with a surgical diff) is the longer-term direction discussed for a separate change.
- The diagnostic `[loopdbg]` tracing used against the live session has been stripped (final commit).
