### PR TITLE
Make board_layouts authoritative, cut the layout echo loop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     shinyjs,
     bslib,
     glue,
-    dockViewR (>= 0.2.1),
+    dockViewR (>= 0.3.0),
     htmltools,
     cli,
     shinyWidgets,
@@ -36,6 +36,7 @@ Imports:
 Remotes:
     BristolMyersSquibb/blockr.ui,
     BristolMyersSquibb/blockr.core,
+    cynkra/dockViewR@70-state-provenance,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:
     testthat (>= 3.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,20 @@
 # blockr.dock (development version)
 
-* Live panel rearrangements are no longer lost when a board is saved
-  (#243). `view_data()`, the live dock layout that serialization reads,
-  was stuck at `NULL` for the whole session, so Export fell back to the
-  board's default layout. The live dock registry is now a
-  `reactiveValues` rather than a plain environment, so `view_data()`
-  takes a dependency on each view's entry and re-evaluates when reconcile
-  creates it -- whatever the init flush order -- instead of relying on a
-  reconcile observer priority to win that race.
+* The dock layout feedback loop is cut at its source (#257, #252).
+  The browser echoes its `_state` both for the dock's own programmatic
+  pushes (a restore, an add / remove) and for genuine user gestures;
+  folding a push's echo back into the board fed a restore / reconcile
+  loop that, on a slow client, could tear a board down to empty on load
+  (#252). dockViewR now tags each `_state` with its provenance (the
+  companion `_state-source` input, `"server"` / `"client"`), so the dock
+  folds only real user rearrangements into `board_layouts` and drops its
+  own echoes. `board_layouts` is now authoritative throughout:
+  serialization reads it directly instead of the round-tripped live echo
+  (so a save can no longer strand on a mid-flight `NULL`, superseding the
+  earlier #243 fix), and reconcile re-pushes from the layout each view
+  last realised rather than from the browser echo. The per-facet
+  echo-rejection guards (`live_view_data()` and the layout up-sync) are
+  removed. Requires the matching dockViewR (`_state-source` provenance).
 
 * The add and append block browsers are each pre-rendered once into a
   dedicated sidebar (`add_block_sidebar` / `append_block_sidebar`) and

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -10,8 +10,7 @@
 #' @param ... Extension server arguments.
 #' @param session Shiny session.
 #'
-#' @return List with `dock`, `actions`, `view_data`, and extension
-#'   results.
+#' @return List with `dock`, `actions`, and extension results.
 #'
 #' @noRd
 board_server_callback <- function(board, update, ..., session = get_session()) {
@@ -33,10 +32,11 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   # registry, keyed by view id; `client_active` / `client_views` mirror which
   # views the browser shows, diffed by reconcile_views() — the sole mutator.
   # Per-view panel membership lives on each dock proxy (`live_panels`), kept
-  # authoritative by the add/remove touchpoints, so reconcile compares against
-  # it rather than the lagging browser echo. `docks` is a `reactiveValues`, so
-  # live_view_data() depends on each view's entry and re-evaluates when
-  # reconcile creates it, whatever the init flush order.
+  # authoritative by the add/remove touchpoints; the arrangement each dock last
+  # realised lives on `last_applied`, so reconcile pushes from server intent
+  # rather than reading the lagging browser echo. board_layouts is the single
+  # source of truth: each dock folds only genuine user gestures (provenance
+  # `"client"`) back into it, so a server push never echoes into the board.
   docks <- reactiveValues()
   active_dock <- reactiveValues()
   client_active <- reactiveVal(NULL)
@@ -61,9 +61,6 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   # Extensions receive active_dock — a reactiveValues that always mirrors
   # whichever view is currently active (swapped by update_active_dock).
   dock <- active_dock
-  view_data <- live_view_data(client_views, docks, client_active)
-
-  sync_layouts_to_board(view_data, update, board)
 
   # Each extension can read the others' server results through the
   # `extensions` environment: one active binding per id, each resolving to
@@ -107,25 +104,24 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   c(
     list(
       dock = dock,
-      actions = triggers,
-      view_data = view_data
+      actions = triggers
     ),
     ext_res
   )
 }
 
 # The initial `client_views`: one bare (empty) layout per view, carrying the
-# display name. Gives live_view_data and the nav the view set before any
-# dockview has reported its live layout; the dock modules themselves are
-# created by the reconcile pass (its empty-`docks` case). Which view is active
-# is tracked solely by `client_active`, not here.
+# display name. Gives the nav the view set before any dockview has reported its
+# live layout; the dock modules themselves are created by the reconcile pass
+# (its empty-`docks` case). Which view is active is tracked solely by
+# `client_active`, not here.
 seed_view_state <- function(views) {
   reconstruct_dock_layouts(lapply(views, bare_view))
 }
 
 # An empty layout standing in for a view in `client_views`: carries the
-# view's display name so live_view_data / serialization keep the
-# id -> name mapping without duplicating the layout itself.
+# view's display name so the nav keeps the id -> name mapping without
+# duplicating the layout itself.
 bare_view <- function(x) {
   ly <- new_dock_layout()
   nm <- view_name(x)
@@ -159,121 +155,6 @@ switch_view_observer <- function(session, update, client_active) {
     },
     ignoreInit = TRUE
   )
-}
-
-# Returns NULL while any view is still pending — its dock not yet created by
-# reconcile, or its dockview layout not yet reported — so downstream observers
-# `req()` past the initial flush. Reading `docks[[v_id]]` (a reactiveValues)
-# takes a dependency on each view's entry, so this re-evaluates when reconcile
-# creates the dock — whatever the init flush order — rather than stranding on
-# the empty-`docks` early return. The active view comes from `client_active`,
-# not `client_views`.
-live_view_data <- function(client_views, docks, client_active) {
-  reactive({
-    state <- client_views()
-    v_list <- lapply(names(state), function(v_id) {
-      dk <- docks[[v_id]]
-      if (is.null(dk)) {
-        return(NULL)
-      }
-      ly <- dk$layout()
-      if (is.null(ly)) {
-        return(NULL)
-      }
-      out <- dockview_to_layout(ly)
-      nm <- view_name(state[[v_id]])
-      if (!is.null(nm)) {
-        view_name(out) <- nm
-      }
-      out
-    })
-
-    if (any(lgl_ply(v_list, is.null))) {
-      return(NULL)
-    }
-
-    res <- reconstruct_dock_layouts(set_names(v_list, names(state)))
-    ca <- client_active()
-    if (!is.null(ca)) {
-      active_view(res) <- ca
-    }
-    res
-  })
-}
-
-# Writes go through update(list(views = ...)) — board$board is
-# read-only at the plugin boundary; routing through the update channel
-# lets apply_board_update.dock_board mutate rv$board where it's writable
-# and composes with augment/apply hooks from other subclasses. Debounced
-# because drag-resize emits many rapid events per gesture.
-sync_layouts_to_board <- function(view_data, update, board, millis = 250) {
-  src <- if (millis > 0L) shiny::debounce(view_data, millis) else view_data
-  layouts_to_board_observer(src, update, board)
-}
-
-layouts_to_board_observer <- function(view_data, update, board) {
-  observe({
-    new_layouts <- req(view_data())
-    current <- isolate(board_layouts(board$board))
-
-    if (identical(current, new_layouts)) {
-      return()
-    }
-
-    delta <- diff_dock_layouts(current, new_layouts)
-
-    if (length(delta)) {
-      update(list(views = delta))
-    }
-  })
-}
-
-# Structured `views` delta between two `dock_layouts`, keyed by stable
-# view id, so live UI state mirrors back through the update lifecycle
-# without resending unchanged views. Per-view comparison uses the wire
-# spec (ignores volatile fields and the display name — renames travel on
-# their own slot); the active-view change rides the `$active` slot. Since
-# the id is stable across a rename, a rename never surfaces here as a
-# removal of the old view paired with an addition of a new one.
-diff_dock_layouts <- function(current, new_layouts) {
-
-  cur_ids <- names(current)
-  new_ids <- names(new_layouts)
-
-  add_ids <- setdiff(new_ids, cur_ids)
-  rm_ids <- setdiff(cur_ids, new_ids)
-  common <- intersect(cur_ids, new_ids)
-
-  mod_views <- list()
-  for (v in common) {
-
-    cur_spec <- layout_to_spec(current[[v]])
-    new_spec <- layout_to_spec(new_layouts[[v]])
-
-    if (!identical(cur_spec, new_spec)) {
-      mod_views[[v]] <- new_layouts[[v]]
-    }
-  }
-
-  cur_active <- active_view(current)
-  new_active <- active_view(new_layouts)
-
-  out <- list()
-
-  if (length(add_ids)) {
-    out$add <- as.list(unclass(new_layouts))[add_ids]
-  }
-  if (length(rm_ids)) {
-    out$rm <- rm_ids
-  }
-  if (length(mod_views)) {
-    out$mod <- mod_views
-  }
-  if (!identical(cur_active, new_active) && !is.null(new_active)) {
-    out$active <- new_active
-  }
-
-  out
 }
 
 #' Hide all block and extension UI for a view.
@@ -477,11 +358,15 @@ reconcile_views <- function(board, update, docks, active_dock,
 # authoritatively on the proxy (`live_panels`), kept in lockstep by the
 # add/remove touchpoints, so a mismatch there is a programmatic add / remove the
 # dock has not been told about (a views$mod, a board restore) — restore it and
-# record the new membership. When membership already agrees, only the
-# arrangement can differ; reconcile that against the browser's echoed state, but
-# skip until the echo has caught up to the current membership, so a just-added
-# panel (live_panels ahead of the echo) does not read as an arrangement change
-# and force a needless rebuild (#196).
+# record the new membership. When membership already agrees, decide a rebuild
+# from server intent — the layout this dock last realised (`last_applied`) —
+# never the browser's echoed `_state`, which lags a push and races the
+# membership set. A change in the panel SET since we last applied means a live
+# add / remove (the `+` / `x` buttons, a block add) the browser already placed:
+# recording it is enough, rebuilding would fight the live op (#191, #196). Only
+# a genuine arrangement change at the SAME membership — a programmatic views$mod
+# — warrants a push; `layouts_match` drops volatile sizes / ids / focus, so a
+# tab click never rebuilds.
 reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
 
   target_ids <- layout_panel_ids(target)
@@ -498,17 +383,16 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
     )
 
     dock$live_panels(target_ids)
+    dock$last_applied(target)
 
     return(invisible())
   }
 
-  live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
+  applied <- isolate(dock$last_applied())
+  same_membership <- setequal(layout_panel_ids(applied), target_ids)
 
-  if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
-    return(invisible())
-  }
+  if (same_membership && !layouts_match(applied, target)) {
 
-  if (!layouts_match(live, target)) {
     apply_layout_diff(
       view = view,
       target = target,
@@ -517,6 +401,8 @@ reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
       extensions = extensions
     )
   }
+
+  dock$last_applied(target)
 
   invisible()
 }
@@ -563,15 +449,24 @@ manage_dock <- function(
     # on the browser's `n-panels` echo.
     proxy <- set_dock_view_output(session = session)
     live_panels <- reactiveVal(as.character(layout_panel_ids(init_layout)))
+    last_applied <- reactiveVal(init_layout)
     prev_active_group <- reactiveVal()
     active_group_trail <- reactiveVal()
     n_panels <- reactive(length(live_panels()))
+
+    # `layout` is the browser's live `_state` echo; `layout_source` is its
+    # companion provenance flag (`"server"` for our own pushes, `"client"`
+    # for a user gesture). Both read straight off the dockview inputs.
+    layout <- reactive(dockViewR::get_dock(proxy))
+    layout_source <- reactive(input[[dock_input("state-source")]])
 
     dock <- list(
       proxy = proxy,
       board_ns = board_ns,
       live_panels = live_panels,
-      layout = reactive(dockViewR::get_dock(proxy)),
+      last_applied = last_applied,
+      layout = layout,
+      layout_source = layout_source,
       n_panels = n_panels,
       prev_active_group = prev_active_group,
       active_group_trail = active_group_trail
@@ -581,7 +476,9 @@ manage_dock <- function(
     # extension show / hide — back into board_layouts in the same flush, so the
     # panel set stays authoritative server-side and a later board change never
     # restores a layout that lags the live dock. Block add / remove fold through
-    # the update lifecycle already; this catches the dock-only paths.
+    # the update lifecycle already; this catches the dock-only paths. reconcile
+    # reads the new membership off `live_panels` and records it without a
+    # rebuild, so this only owns the board-side fold.
     observeEvent(
       live_panels(),
       {
@@ -594,6 +491,36 @@ manage_dock <- function(
           if (!is.null(folded)) {
             update(list(views = list(mod = set_names(list(folded), id))))
           }
+        }
+      },
+      ignoreInit = TRUE
+    )
+
+    # Fold a genuine user rearrangement (drag, sash resize, tab click) into
+    # board_layouts, the single source of truth. `arrangement_fold` keeps only
+    # `"client"`-sourced echoes: a `"server"` echo is our own push coming back,
+    # and folding it would feed reconcile and loop (#252). Recording the
+    # realised layout on `last_applied` stops the reconcile this fold triggers
+    # from pushing it straight back. Debounced because a drag bursts. Membership
+    # is left alone (adds / closes round-trip server-side, reading `"server"`).
+    live_layout <- shiny::debounce(layout, millis = 250)
+
+    observeEvent(
+      live_layout(),
+      {
+        layouts <- isolate(board_layouts(board$board))
+
+        if (!id %in% names(layouts)) {
+          return()
+        }
+
+        folded <- arrangement_fold(
+          live_layout(), isolate(layout_source()), layouts[[id]]
+        )
+
+        if (!is.null(folded)) {
+          last_applied(folded)
+          update(list(views = list(mod = set_names(list(folded), id))))
         }
       },
       ignoreInit = TRUE

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -1,6 +1,5 @@
 #' @export
-serialize_board.dock_board <- function(x, blocks, id = NULL, dock,
-                                       view_data = NULL, ...,
+serialize_board.dock_board <- function(x, blocks, id = NULL, dock, ...,
                                        session = get_session()) {
 
   state <- lapply(
@@ -20,7 +19,10 @@ serialize_board.dock_board <- function(x, blocks, id = NULL, dock,
     session
   )
 
-  layout_data <- view_data()
+  # board_layouts is authoritative: every genuine user rearrangement is folded
+  # in live, so the committed board already carries the on-screen arrangement
+  # and we never read the racy browser echo at save time.
+  layout_data <- board_layouts(x)
 
   do.call(
     blockr_ser,

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -407,6 +407,29 @@ fold_live_membership <- function(layout, live_ids) {
   out
 }
 
+# Decide whether a browser `_state` echo is a genuine user rearrangement to fold
+# into board_layouts. `source` is dockview's companion provenance flag: only a
+# `"client"` gesture (drag, sash resize, tab activation) is a real delta -- a
+# `"server"` echo is the dock's own push coming back, and folding it loops
+# through reconcile (#252). `live` is the dockview-shaped echo; `current` the
+# view's committed layout. Returns the replacement `dock_layout` when the
+# arrangement genuinely changed (compared by wire spec, so volatile sizes and
+# regenerated ids do not register), else NULL.
+arrangement_fold <- function(live, source, current) {
+
+  if (is.null(live) || !identical(source, "client")) {
+    return(NULL)
+  }
+
+  layout <- dockview_to_layout(live)
+
+  if (identical(layout_to_spec(layout), layout_to_spec(current))) {
+    return(NULL)
+  }
+
+  layout
+}
+
 # Merge user-supplied `views$mod` with the block-removal cleanup: when
 # both touch a view, the cleanup drops the removed block from whatever
 # layout the user submitted; otherwise the present one wins.

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1,7 +1,7 @@
 test_that("board server", {
 
   # Multi-view path is exercised by the default `dock_layouts(Page = ...)`
-  # layout — `board_server_callback` returns an extra `view_data` reactive.
+  # layout.
   board_rv_1 <- board_args(
     blocks = c(a = new_dataset_block())
   )
@@ -11,13 +11,12 @@ test_that("board server", {
       res <- board_server_callback(board_rv_1, update = reactiveVal())
 
       expect_type(res, "list")
-      expect_named(res, c("dock", "actions", "view_data"))
+      expect_named(res, c("dock", "actions"))
 
       # `dock` is the active-dock reactiveValues handle the extensions
       # receive; its contents are filled by the reconcile pass (init render),
       # exercised by the app test — here we assert only the returned shape.
       expect_s3_class(res[["dock"]], "reactivevalues")
-      expect_s3_class(res[["view_data"]], "reactive")
     }
   )
 
@@ -33,7 +32,7 @@ test_that("board server", {
       expect_type(res, "list")
       expect_named(
         res,
-        c("dock", "actions", "view_data", "edit_board_extension")
+        c("dock", "actions", "edit_board_extension")
       )
 
       expect_s3_class(res[["dock"]], "reactivevalues")
@@ -249,87 +248,44 @@ test_that("renaming a block refreshes the dock panel title (#193)", {
   expect_identical(title_set, "Renamed")
 })
 
-test_that("live_view_data is NULL while any view layout is uninitialized", {
-  ms <- new_mock_session()
-  withr::defer(if (!ms$isClosed()) ms$close())
+test_that("arrangement_fold gates the fold on client provenance (#257)", {
 
-  layouts <- with_mock_context(ms, {
-    list(A = reactiveVal(NULL), B = reactiveVal(NULL))
-  })
+  # The browser echoes its `_state` for our own pushes (provenance "server")
+  # and for genuine user gestures ("client") alike. Folding a server echo back
+  # into the board is the restore / reconcile loop (#252); only a client
+  # gesture is a real delta. This is the structural cut: same echo, different
+  # source, opposite outcome.
+  current <- dock_layout("a", "b")
+  reordered <- unclass(dock_layout("b", "a"))
+  unchanged <- unclass(dock_layout("a", "b"))
 
-  res <- with_mock_context(ms, {
-    client_views <- reactiveVal(
-      dock_layouts(A = new_dock_layout(), B = new_dock_layout())
-    )
-    ids <- names(client_views())
-    docks <- reactiveValues()
-    docks[[ids[[1L]]]] <- list(layout = layouts$A)
-    docks[[ids[[2L]]]] <- list(layout = layouts$B)
-    client_active <- reactiveVal(ids[[1L]])
-    list(vd = live_view_data(client_views, docks, client_active))
-  })
+  # A server echo -- our push coming back -- is never folded, even when it
+  # differs from the committed layout. This is what breaks the loop.
+  expect_null(arrangement_fold(reordered, "server", current))
 
-  expect_null(isolate(res$vd()))
+  # No provenance at all is treated as not-client: still dropped.
+  expect_null(arrangement_fold(reordered, NULL, current))
 
-  with_mock_context(ms, layouts$A(list(grid = list(), panels = list())))
-  expect_null(isolate(res$vd()))
+  # A not-yet-reported echo (NULL) is dropped rather than folded as empty.
+  expect_null(arrangement_fold(NULL, "client", current))
 
-  with_mock_context(ms, layouts$B(list(grid = list(), panels = list())))
+  # A client gesture that genuinely rearranges folds in, carrying the new order.
+  folded <- arrangement_fold(reordered, "client", current)
+  expect_s3_class(folded, "dock_layout")
+  expect_identical(layout_panel_ids(folded), c("b", "a"))
 
-  lys <- isolate(res$vd())
-  expect_s3_class(lys, "dock_layouts")
-  expect_identical(unname(view_names(lys)), c("A", "B"))
-  expect_identical(active_name(lys), "A")
+  # A client echo that matches the committed arrangement is a no-op (a tab
+  # click reporting the same grid), so nothing is folded.
+  expect_null(arrangement_fold(unchanged, "client", current))
 })
 
-test_that("live_view_data re-evaluates once docks are populated (#243)", {
+test_that("a client gesture folds in; a server echo does not (#257)", {
 
-  # Regression: live_view_data first evaluated with `docks` still empty (its
-  # dock module not yet created by reconcile) and hit the empty-dock early
-  # return. When `docks` was a plain environment that read took no reactive
-  # dependency, so reconcile populating `docks` never re-triggered it --
-  # view_data() stayed NULL for the session and serialize fell back to the
-  # default layout. As a `reactiveValues`, reading `docks[[v_id]]` (even for an
-  # absent key) subscribes, so creating the dock re-evaluates this -- with no
-  # separate signal and regardless of flush order.
-  ms <- new_mock_session()
-  withr::defer(if (!ms$isClosed()) ms$close())
-
-  res <- with_mock_context(ms, {
-    client_views <- reactiveVal(dock_layouts(A = new_dock_layout()))
-    docks <- reactiveValues()
-    client_active <- reactiveVal(NULL)
-    list(
-      vd = live_view_data(client_views, docks, client_active),
-      docks = docks,
-      view = names(client_views())[[1L]]
-    )
-  })
-
-  # First read with empty docks: NULL, but the absent-key read has subscribed.
-  expect_null(isolate(res$vd()))
-
-  # Mimic reconcile creating the dock: the reactiveValues write alone
-  # re-triggers live_view_data.
-  layout <- with_mock_context(
-    ms, reactiveVal(list(grid = list(), panels = list()))
-  )
-  with_mock_context(ms, res$docks[[res$view]] <- list(layout = layout))
-
-  lys <- isolate(res$vd())
-
-  expect_s3_class(lys, "dock_layouts")
-  expect_identical(unname(view_names(lys)), "A")
-})
-
-test_that("view_data() tracks a reported layout despite flush order (#243)", {
-
-  # The same regression through the real reconcile + live_view_data composition.
-  # Reading view_data() before the first flush reproduces the init order the
-  # bug needs -- the upsync reads live_view_data while `docks` is still empty,
-  # before reconcile creates the dock modules. The browser then reports a
-  # rearranged layout via the dock `_state` input, which view_data() must pick
-  # up rather than staying frozen at the seed.
+  # End-to-end through the real module: the browser reports a reordered grid via
+  # `_state`, tagged by `_state-source`. A "server" echo (our own push coming
+  # back) must not feed the board -- that is the #252 loop -- while a genuine
+  # "client" gesture must fold in, so board_layouts stays the single source of
+  # truth that serialization reads.
   board_rv <- board_args(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
     layouts = list(Page = dock_layout("a", "b"))
@@ -338,90 +294,80 @@ test_that("view_data() tracks a reported layout despite flush order (#243)", {
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
 
-  res <- with_mock_context(
-    ms, board_server_callback(board_rv, update = reactiveVal())
-  )
+  # `update` is the board's reactiveVal write channel; record every payload it
+  # carries so we can assert which echoes folded. The fold is debounced (a drag
+  # bursts), so each step advances the mock clock before flushing.
+  captured <- list()
+  update <- with_mock_context(ms, reactiveVal())
 
-  # Force the first read before reconcile runs: docks empty, so NULL.
-  expect_null(isolate(res$view_data()))
-
+  with_mock_context(ms, {
+    board_server_callback(board_rv, update = update)
+    observe({
+      payload <- update()
+      if (!is.null(payload)) captured[[length(captured) + 1L]] <<- payload
+    })
+  })
   ms$flushReact()
 
-  # The browser reports the live grid through the dock `_state` input, carrying
-  # the real `block_panel-*` ids reversed from the seeded order. It is built
-  # with the public dock_layout() constructor -- which dockview_to_layout()
-  # accepts unclassed -- rather than hand-rolled dockview JSON.
+  mods <- function() Filter(function(p) !is.null(p$views$mod), captured)
+
   reported <- unclass(dock_layout("block_panel-b", "block_panel-a"))
-  do.call(ms$setInputs, set_names(list(reported), "Page-dock_state"))
+
+  # A server-sourced echo of a reordering is our own push coming back: dropped.
+  ms$setInputs(
+    `Page-dock_state-source` = "server", `Page-dock_state` = reported
+  )
+  ms$elapse(300)
   ms$flushReact()
 
-  vd <- isolate(res$view_data())
+  expect_length(mods(), 0L)
 
-  # view_data() carries the reported order, not the frozen `[a, b]` default.
-  expect_s3_class(vd, "dock_layouts")
+  # The same reordering, now a genuine user gesture, folds into board_layouts.
+  ms$setInputs(
+    `Page-dock_state-source` = "client", `Page-dock_state` = reported
+  )
+  ms$elapse(300)
+  ms$flushReact()
+
+  folded <- mods()
+  expect_length(folded, 1L)
   expect_identical(
-    layout_panel_ids(vd[["Page"]]),
+    layout_panel_ids(folded[[1L]]$views$mod$Page),
     c("block_panel-b", "block_panel-a")
   )
 })
 
-test_that("layouts_to_board_observer fires update views on divergence", {
-  ms <- new_mock_session()
-  withr::defer(if (!ms$isClosed()) ms$close())
+test_that("serialize_board.dock_board reads board_layouts (#257)", {
 
+  # Serialization no longer round-trips the live browser echo: it reads
+  # board_layouts(x) directly, so it can never strand on a mid-flight NULL and
+  # always reflects whatever the fold path has committed.
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
-    layouts = list(A = list("a"), B = list("b"))
+    layouts = list(Page = dock_layout("b", "a"))
   )
 
-  rv <- with_mock_context(ms, reactiveValues(board = brd))
-  vd <- with_mock_context(ms, reactiveVal(NULL))
-
-  captured <- list()
-  upd <- function(payload) {
-    captured[[length(captured) + 1L]] <<- payload
-  }
-
-  with_mock_context(ms, layouts_to_board_observer(vd, upd, rv))
-  ms$flushReact()
-
-  expect_length(captured, 0L)
-
-  new_views <- isolate(board_layouts(rv$board))
-  b_id <- vid(new_views, "B")
-  active_view(new_views) <- b_id
-
-  with_mock_context(ms, vd(new_views))
-  ms$flushReact()
-
-  expect_length(captured, 1L)
-  expect_named(captured[[1L]], "views")
-  expect_identical(captured[[1L]]$views$active, b_id)
-  expect_null(captured[[1L]]$views$mod)
-})
-
-test_that("layouts_to_board_observer is idempotent when nothing changed", {
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
 
-  brd <- new_dock_board(
-    blocks = c(a = new_dataset_block()),
-    layouts = list(Page = list("a"))
+  ser <- with_mock_context(
+    ms,
+    serialize_board(
+      brd,
+      blocks = list(),
+      id = "brd",
+      dock = NULL,
+      session = ms
+    )
   )
 
-  rv <- with_mock_context(ms, reactiveValues(board = brd))
-  vd <- with_mock_context(ms, reactiveVal(NULL))
+  views <- ser$payload$layouts$payload$views
 
-  fire_count <- 0L
-  upd <- function(payload) fire_count <<- fire_count + 1L
-
-  with_mock_context(ms, layouts_to_board_observer(vd, upd, rv))
-  ms$flushReact()
-
-  with_mock_context(ms, vd(isolate(board_layouts(rv$board))))
-  ms$flushReact()
-
-  expect_identical(fire_count, 0L)
+  expect_named(views, "Page")
+  expect_identical(
+    layout_panel_ids(blockr_deser(views$Page)),
+    c("block_panel-b", "block_panel-a")
+  )
 })
 
 test_that("view nav renders one labelled item per view (#189)", {
@@ -472,8 +418,8 @@ test_that("reconcile_views adds a nav item only for unshown views (#189)", {
   # test keys off client_views, not docks.
   stub_create <- function(v_id, layout, board, update, session, docks, ...) {
     dock <- list(
-      layout = function() NULL,
-      live_panels = reactiveVal(as.character(layout_panel_ids(layout)))
+      live_panels = reactiveVal(as.character(layout_panel_ids(layout))),
+      last_applied = reactiveVal(layout)
     )
     docks[[v_id]] <- dock
   }
@@ -581,7 +527,7 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   expect_silent(isolate(board_block_ids(forwarded$board)))
 })
 
-test_that("reconcile_views skips an added panel pending its echo (#196)", {
+test_that("reconcile_views does not rebuild a dock already realised (#196)", {
 
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
@@ -592,31 +538,24 @@ test_that("reconcile_views skips an added panel pending its echo (#196)", {
     sendCustomMessage = function(type, message) invisible()
   )
 
-  # board_layouts holds both panels synchronously (the block-add fold) and the
-  # proxy's live_panels tracker has caught `b` from insert_block_ui, but the
-  # browser has not yet echoed `b` back through get_dock. reconcile must not
-  # restore here: membership agrees, so the only apparent difference is the
-  # not-yet-echoed panel insert_block_ui already placed -- restoring would wipe
-  # it (#196).
+  # A live-only membership change (the add-panel modal, a closed tab) has
+  # already run: the proxy op placed the panel, `live_panels` caught it, and the
+  # membership fold recorded the folded layout on `last_applied`. reconcile must
+  # not rebuild -- membership and arrangement both agree with what the dock has
+  # realised, so restoring would needlessly tear the live arrangement down
+  # (#196). Decided from `last_applied`, never the lagging browser echo.
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
     layouts = list(V = dock_layout("a", "b"))
   )
   board <- with_mock_context(ms, reactiveValues(board = brd))
 
-  target_ids <- layout_panel_ids(board_layouts(brd)[["V"]])
-
-  behind <- board_layouts(
-    new_dock_board(
-      blocks = c(a = new_dataset_block()),
-      layouts = list(V = dock_layout("a"))
-    )
-  )[["V"]]
+  target <- board_layouts(brd)[["V"]]
 
   docks <- with_mock_context(ms, reactiveValues())
   docks[["V"]] <- list(
-    layout = function() behind,
-    live_panels = with_mock_context(ms, reactiveVal(target_ids))
+    live_panels = with_mock_context(ms, reactiveVal(layout_panel_ids(target))),
+    last_applied = with_mock_context(ms, reactiveVal(target))
   )
 
   client_views <- with_mock_context(
@@ -680,8 +619,8 @@ test_that("reconcile_views pushes a programmatic membership change", {
 
   docks <- with_mock_context(ms, reactiveValues())
   docks[["V"]] <- list(
-    layout = function() NULL,
-    live_panels = live_panels
+    live_panels = live_panels,
+    last_applied = with_mock_context(ms, reactiveVal(new_dock_layout()))
   )
 
   client_views <- with_mock_context(
@@ -715,6 +654,75 @@ test_that("reconcile_views pushes a programmatic membership change", {
 
   # The push records the new membership, so a later pass is a no-op.
   expect_setequal(isolate(live_panels()), layout_panel_ids(target))
+})
+
+test_that("reconcile_views records a live add without rebuilding (#191)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  session <- list(
+    ns = identity,
+    sendInputMessage = function(input_id, message) invisible(),
+    sendCustomMessage = function(type, message) invisible()
+  )
+
+  # A block add places its panel via the live insert (insert_block_ui) and folds
+  # into board_layouts; `live_panels` catches it before reconcile runs.
+  # `last_applied` still holds the pre-add layout, so its panel SET differs from
+  # the target -- but the browser already realised the add. reconcile must
+  # record the new layout, NOT rebuild: a rebuild fights the live insert and
+  # drops the freshly-mounted block card (#191).
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(V = dock_layout("a", "b"))
+  )
+  board <- with_mock_context(ms, reactiveValues(board = brd))
+
+  target <- board_layouts(brd)[["V"]]
+
+  pre_add <- board_layouts(
+    new_dock_board(
+      blocks = c(a = new_dataset_block()),
+      layouts = list(V = dock_layout("a"))
+    )
+  )[["V"]]
+
+  last_applied <- with_mock_context(ms, reactiveVal(pre_add))
+
+  docks <- with_mock_context(ms, reactiveValues())
+  docks[["V"]] <- list(
+    live_panels = with_mock_context(
+      ms, reactiveVal(layout_panel_ids(target))
+    ),
+    last_applied = last_applied
+  )
+
+  client_views <- with_mock_context(
+    ms,
+    reactiveVal(seed_view_state(board_layouts(brd)))
+  )
+  client_active <- with_mock_context(ms, reactiveVal("V"))
+  active_dock <- with_mock_context(ms, reactiveValues())
+  update <- with_mock_context(ms, reactiveVal())
+
+  diffed <- 0L
+
+  with_mocked_bindings(
+    with_mock_context(
+      ms,
+      reconcile_views(
+        board, update, docks, active_dock, client_active, client_views,
+        session
+      )
+    ),
+    apply_layout_diff = function(...) diffed <<- diffed + 1L,
+    switch_active_view = function(...) invisible(),
+    .package = "blockr.dock"
+  )
+
+  expect_identical(diffed, 0L)
+  expect_true(layouts_match(isolate(last_applied()), target))
 })
 
 test_that("apply_board_update.dock_board switches active view", {

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -205,14 +205,14 @@ test_that("reconcile_views syncs the nav and live state on rename", {
 
   # Pre-populate the registry so reconcile sees the views as already
   # instantiated (no DOM surgery). The proxy's membership matches the board and
-  # the live layout is pending (NULL), so the layout check is a no-op and only
-  # the rename fires.
+  # the realised layout already equals the target, so the layout check is a
+  # no-op and only the rename fires.
   docks <- reactiveValues()
   for (id in names(board_layouts(brd))) {
     ids <- as.character(layout_panel_ids(board_layouts(brd)[[id]]))
     docks[[id]] <- list(
-      layout = function() NULL,
-      live_panels = reactiveVal(ids)
+      live_panels = reactiveVal(ids),
+      last_applied = reactiveVal(board_layouts(brd)[[id]])
     )
   }
   active_dock <- reactiveValues()
@@ -716,8 +716,8 @@ test_that("reconcile_views syncs the view_nav switcher on removal", {
     for (id in names(state)) {
       ids <- as.character(layout_panel_ids(state[[id]]))
       docks[[id]] <- list(
-        layout = function() NULL,
-        live_panels = reactiveVal(ids)
+        live_panels = reactiveVal(ids),
+        last_applied = reactiveVal(state[[id]])
       )
     }
     active_dock <- reactiveValues()


### PR DESCRIPTION
## Summary

- dockViewR's `_state` echoes both the dock's own programmatic pushes (restore, add, remove) and genuine user gestures, and folding a push's echo back into the board fed the restore/reconcile loop that empties a board on a slow client (#252). This consumes the new `_state-source` provenance (cynkra/dockViewR#71): only `"client"` gestures fold into `board_layouts`, so a server push no longer echoes back in — the loop's return arrow is cut at the source.
- `board_layouts` becomes the single source of truth. `serialize_board.dock_board` reads it directly instead of the round-tripped `view_data()` echo (which could strand on a mid-flight `NULL`), and `reconcile_view_layout()` decides a re-push from the layout each view last realised (`last_applied`) plus a membership comparison, never the racy browser echo.
- The per-facet echo-rejection machinery (`live_view_data()`, `sync_layouts_to_board()`, `diff_dock_layouts()`) is removed; the layout-tracking guard count goes down, not up.
- A live membership change (a block add, the built-in `+` / `x` tab buttons) is recorded as realised rather than rebuilt, so reconcile stops fighting the live insert that just mounted the card (#191, #196). The surgical `apply_layout_diff` for programmatic membership changes stays open at #223.

Depends on cynkra/dockViewR#71, pinned in `Remotes`; drop the pin once it lands on a dockViewR release.

Fixes #257