### PR TITLE
Remove the board->dock arrangement push to cut the layout loop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     methods,
     withr,
     shinytest2,
+    chromote,
     xml2,
     knitr,
     rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # blockr.dock (development version)
 
+* The dock no longer loops forever or tears its panels down on a slow
+  client (#252). The live layout was held in two bindings that formed a
+  cycle: the live-sync fold pushed the dockview client's state into
+  `board_layouts` (dock -> board), and a reconcile step pushed
+  `board_layouts` back to the widget (board -> dock). A board update that
+  originated at the dock still triggered a re-push, whose echo folded back;
+  on a slow client a partial client state folded an impoverished layout
+  that the push then faithfully restored. The board -> dock arrangement
+  push (`reconcile_view_layout()` / `apply_layout_diff()`) is removed: a
+  view's arrangement is client-owned and now flows dock -> board only.
+  `reconcile_views()` still owns what the board is authoritative over --
+  which views exist, their names, the active view, and the initial layout
+  on load -- and the fold keeps `board_layouts` current for serialization
+  and live readers. With one direction live there is no echo to suppress
+  and no layout-tracking state to maintain.
+
 * Live panel rearrangements are no longer lost when a board is saved
   (#243). `view_data()`, the live dock layout that serialization reads,
   was stuck at `NULL` for the whole session, so Export fell back to the

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -33,10 +33,11 @@ board_server_callback <- function(board, update, ..., session = get_session()) {
   # registry, keyed by view id; `client_active` / `client_views` mirror which
   # views the browser shows, diffed by reconcile_views() — the sole mutator.
   # Per-view panel membership lives on each dock proxy (`live_panels`), kept
-  # authoritative by the add/remove touchpoints, so reconcile compares against
-  # it rather than the lagging browser echo. `docks` is a `reactiveValues`, so
-  # live_view_data() depends on each view's entry and re-evaluates when
-  # reconcile creates it, whatever the init flush order.
+  # authoritative by the add/remove touchpoints; it drives `n_panels` / the
+  # empty-dock prompt and the membership fold without waiting on the lagging
+  # browser echo. `docks` is a `reactiveValues`, so live_view_data() depends on
+  # each view's entry and re-evaluates when reconcile creates it, whatever the
+  # init flush order.
   docks <- reactiveValues()
   active_dock <- reactiveValues()
   client_active <- reactiveVal(NULL)
@@ -382,15 +383,17 @@ remove_view <- function(v_id, session, docks) {
 }
 
 # Make the live dock session match the committed board's view set:
-# instantiate added views, tear down removed ones, push layout changes to
-# surviving views, relabel renamed ones, and switch to the active view. Takes
-# the reactive board handle (not a snapshot) so the live list reaches
-# manage_dock, whose interaction observers read board$board after the fact
-# (#194); the committed board is snapshotted once here for this pass's reads.
-# Driven by board$board so apply_board_update.dock_board stays a pure reducer
-# and dock state never crosses the package boundary. Idempotent — a board
-# already matching the live state produces no surgery — so it composes with the
-# live-sync (DOM -> board) path without ping-ponging.
+# instantiate added views, tear down removed ones, relabel renamed ones, and
+# switch to the active view. The board owns which views exist, their names and
+# the active one; a view's per-view arrangement is client-owned and flows dock
+# -> board only (the live-sync fold), so reconcile never pushes a layout back to
+# its live dock. Takes the reactive board handle (not a snapshot) so the live
+# list reaches manage_dock, whose interaction observers read board$board after
+# the fact (#194); the committed board is snapshotted once here for this pass's
+# reads. Driven by board$board so apply_board_update.dock_board stays a pure
+# reducer and dock state never crosses the package boundary. Idempotent — a
+# board already matching the live view set produces no surgery — so it composes
+# with the live-sync (DOM -> board) path without ping-ponging.
 reconcile_views <- function(board, update, docks, active_dock,
                             client_active, client_views, session) {
 
@@ -451,14 +454,6 @@ reconcile_views <- function(board, update, docks, active_dock,
         list(rename = list(id = v, to = new_nm))
       )
     }
-
-    reconcile_view_layout(
-      docks[[v]],
-      v,
-      layouts[[v]],
-      board_blocks(brd),
-      dock_extensions(brd)
-    )
   }
 
   client_views(state)
@@ -467,54 +462,6 @@ reconcile_views <- function(board, update, docks, active_dock,
         !identical(server_active, isolate(client_active()))) {
     switch_active_view(
       server_active, docks, active_dock, client_active, session
-    )
-  }
-
-  invisible()
-}
-
-# Push one view's committed layout to its live dock. Panel membership is tracked
-# authoritatively on the proxy (`live_panels`), kept in lockstep by the
-# add/remove touchpoints, so a mismatch there is a programmatic add / remove the
-# dock has not been told about (a views$mod, a board restore) — restore it and
-# record the new membership. When membership already agrees, only the
-# arrangement can differ; reconcile that against the browser's echoed state, but
-# skip until the echo has caught up to the current membership, so a just-added
-# panel (live_panels ahead of the echo) does not read as an arrangement change
-# and force a needless rebuild (#196).
-reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
-
-  target_ids <- layout_panel_ids(target)
-  live_ids <- isolate(dock$live_panels())
-
-  if (!setequal(live_ids, target_ids)) {
-
-    apply_layout_diff(
-      view = view,
-      target = target,
-      dock = dock,
-      blocks = blocks,
-      extensions = extensions
-    )
-
-    dock$live_panels(target_ids)
-
-    return(invisible())
-  }
-
-  live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
-
-  if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
-    return(invisible())
-  }
-
-  if (!layouts_match(live, target)) {
-    apply_layout_diff(
-      view = view,
-      target = target,
-      dock = dock,
-      blocks = blocks,
-      extensions = extensions
     )
   }
 

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -522,51 +522,6 @@ apply_views_rename <- function(rename, board) {
   board
 }
 
-# Whether two layouts describe the same panel arrangement, used to
-# short-circuit `restore_layout` when the live dockview state already
-# matches the target. Compares normalised wire specs (drops volatile
-# pixel sizes / regenerated group IDs) and additionally drops `focus`
-# so a tab click doesn't force a rebuild. `a` is the live wire shape
-# (`get_dock()`); `b` is the target `dock_layout`.
-layouts_match <- function(a, b) {
-
-  to_spec <- function(x) {
-
-    if (is.null(x)) {
-      return(NULL)
-    }
-
-    ly <- if (is_dock_layout(x)) {
-      x
-    } else {
-      tryCatch(dockview_to_layout(x), error = function(e) NULL)
-    }
-
-    if (is.null(ly)) {
-      return(NULL)
-    }
-
-    spec <- tryCatch(layout_to_spec(ly), error = function(e) NULL)
-
-    if (is.null(spec)) {
-      return(NULL)
-    }
-
-    spec[["focus"]] <- NULL
-
-    spec
-  }
-
-  spec_a <- to_spec(a)
-  spec_b <- to_spec(b)
-
-  if (is.null(spec_a) || is.null(spec_b)) {
-    return(FALSE)
-  }
-
-  identical(spec_a, spec_b)
-}
-
 apply_views_active <- function(active, board) {
 
   layouts <- board_layouts(board)
@@ -612,44 +567,4 @@ switch_active_view <- function(active, docks, active_dock, client_active,
   )
 
   invisible()
-}
-
-# Apply one view's layout change. v1 unconditionally restores the target
-# layout; surgical diff paths (noop / active-tab / reorder) are a
-# deferred follow-up that can dispatch here without touching callers.
-apply_layout_diff <- function(view, target, dock, blocks, extensions) {
-
-  log_debug("applying layout diff for view {view}")
-
-  # Block / extension UIs live in board-level wrapper elements (the
-  # offcanvas at init time, a dockview panel container while attached)
-  # and are moved between them via `move_dom_element`. `restore_dock`
-  # tears the panel containers down, taking the attached UIs with them,
-  # so we have to (a) park the UIs back in the offcanvas first and
-  # (b) reattach them to the freshly-rendered panels afterwards. Iterate
-  # object ids (as `hide_view_ui()` does): `for` over the classed id
-  # vector would drop the class and double-prefix the move target.
-  for (oid in as_obj_id(block_panel_ids(dock$proxy))) {
-    hide_block_panel(oid, rm_panel = FALSE, dock = dock)
-  }
-  for (oid in as_obj_id(ext_panel_ids(dock$proxy))) {
-    hide_ext_panel(oid, rm_panel = FALSE, dock = dock)
-  }
-
-  restore_layout(target, dock$proxy, blocks = blocks, extensions = extensions)
-
-  for (pid in as_dock_panel_id(target)) {
-    if (is_block_panel_id(pid)) {
-      show_block_panel(pid, add_panel = FALSE, dock = dock)
-    } else if (is_ext_panel_id(pid)) {
-      show_ext_panel(pid, add_panel = FALSE, dock = dock)
-    } else {
-      blockr_abort(
-        "Unknown panel type {class(pid)}.",
-        class = "dock_panel_invalid"
-      )
-    }
-  }
-
-  invisible(NULL)
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -115,49 +115,95 @@ read_view_docks <- function(app, board_id = "my_board") {
   )
 }
 
-# Wait until the server-rendered dock shell is in place: the view nav, every
-# block card and the active view's handle. These render independently of the
-# dockview client, so the serialization e2e can read them without racing the
-# (client-side) panel layout.
-wait_dock_loaded <- function(app, n_blocks, board_id = "my_board") {
-  app$wait_for_js(
-    sprintf("document.querySelector('#%s-view_nav') !== null", board_id),
-    timeout = 30 * 1000
+# Wrap `wait_for_js` so a timeout dumps the page state before failing. The
+# queue-only e2e flakes never reproduce locally, so a residual timeout has to
+# carry enough context to be actionable rather than an opaque "JS did not
+# evaluate to true" (mirrors setup-idle-debug.R). `diagnose` is a closure that
+# returns a one-shot status string.
+wait_js <- function(app, cond, diagnose, timeout = 30 * 1000) {
+  tryCatch(
+    app$wait_for_js(cond, timeout = timeout),
+    error = function(e) {
+      message("\n--- [e2e-wait] timed out waiting for: ", cond)
+      message(diagnose())
+      message("----------------------------------------------------")
+      stop(e)
+    }
   )
-  app$wait_for_js(
+}
+
+# A snapshot of the dock shell for the wait diagnostics: which markers are
+# present, the server-rendered active view (nav), and the client-toggled dock
+# handles -- the latter can lag or stall on a loaded runner, which is exactly
+# why the waits below gate on the nav marker and not on these.
+dock_shell_diag <- function(app, board_id) {
+  js <- r"(JSON.stringify((function () {
+    var nav = document.querySelector('#__BID__-view_nav');
+    var activeSel = '#__BID__-view_nav .blockr-view-item.active';
+    var active = document.querySelector(activeSel);
+    var dockActive = document.querySelector('.blockr-view-dock-active');
+    return {
+      nav: nav !== null,
+      blocks: document.querySelectorAll('[id^="__BID__-block_handle-"]').length,
+      navActive: active ? active.getAttribute('data-view-id') : null,
+      dockHandles: Array.from(document.querySelectorAll('.blockr-view-dock'))
+        .map(function (e) { return e.id; }),
+      dockActive: dockActive ? dockActive.id : null
+    };
+  })()))"
+
+  app$get_js(gsub("__BID__", board_id, js, fixed = TRUE))
+}
+
+# Wait until the server-rendered dock shell is in place: the view nav, every
+# block card and the active view. These render independently of the dockview
+# client, so the serialization e2e can read them without racing the
+# (client-side) panel layout. The active view is gated on the server-rendered
+# nav marker (`.blockr-view-item.active`), not the client-toggled
+# `.blockr-view-dock-active` class -- the latter is applied by the `switch-view`
+# handler whose retry budget can lapse on a loaded runner, leaving it
+# permanently off and ejecting a green PR.
+wait_dock_loaded <- function(app, n_blocks, board_id = "my_board") {
+
+  diagnose <- function() dock_shell_diag(app, board_id)
+
+  wait_js(
+    app,
+    sprintf("document.querySelector('#%s-view_nav') !== null", board_id),
+    diagnose
+  )
+  wait_js(
+    app,
     sprintf(
       "document.querySelectorAll('[id^=\"%s-block_handle-\"]').length === %d",
       board_id, n_blocks
     ),
-    timeout = 30 * 1000
+    diagnose
   )
-  app$wait_for_js(
-    "document.querySelector('.blockr-view-dock-active') !== null",
-    timeout = 30 * 1000
+  wait_js(
+    app,
+    sprintf(
+      paste0(
+        "document.querySelector(",
+        "'#%s-view_nav .blockr-view-item.active') !== null"
+      ),
+      board_id
+    ),
+    diagnose
   )
 }
 
 # The dock-owned board state observable in server-rendered DOM: the view nav
-# (one row per view), the active view's id (the `blockr-view-dock-active`
-# handle), and every block's card id. The serialization e2e captures this
-# before and after a save / restore reload to assert the round-trip rebuilds it
-# identically. Block cards live in a pool the dockview client teleports into
-# panels, so query their ids globally rather than from a fixed container.
+# (one row per view, including which is active), and every block's card id. The
+# serialization e2e captures this before and after a save / restore reload to
+# assert the round-trip rebuilds it identically. The active view is read off the
+# server-rendered nav marker rather than the client-toggled
+# `.blockr-view-dock-active` handle, which can stall on a loaded runner (see
+# wait_dock_loaded). Block cards live in a pool the dockview client teleports
+# into panels, so query their ids globally rather than from a fixed container.
 read_dock_state <- function(app, board_id = "my_board") {
-  container <- xml2::read_html(
-    app$get_html(paste0("#", board_id, "-view_container"))
-  )
-  active_node <- xml2::xml_find_all(
-    container,
-    paste0(
-      "//*[contains(concat(' ', normalize-space(@class), ' '), ",
-      "' blockr-view-dock-active ')]"
-    )
-  )
-  active_view <- sub(
-    paste0("^", board_id, "-view_handle-"), "",
-    xml2::xml_attr(active_node, "id")
-  )
+
+  nav <- read_view_nav(app, board_id)
 
   handles <- unlist(
     app$get_js(
@@ -173,8 +219,8 @@ read_dock_state <- function(app, board_id = "my_board") {
   block_ids <- sort(sub(paste0("^", board_id, "-block_handle-"), "", handles))
 
   list(
-    nav = read_view_nav(app, board_id),
-    active_view = active_view,
+    nav = nav,
+    active_view = nav$id[nav$active],
     blocks = block_ids
   )
 }
@@ -208,21 +254,51 @@ set_in <- function(app, id, value) {
 click <- function(app, id) app$click(nsid(id))
 
 # A DataTables redraw (e.g. after adding a row) re-renders the cell inputs,
-# which the table's `drawCallback` re-binds via `Shiny.bindAll` -- but only
-# once the async redraw completes, which can land *after* the server reports
-# idle. So idle alone does not mean the new inputs are drivable: wait for idle,
-# then poll for the `.shiny-bound-input` marker the rebind adds, both under one
-# generous budget. A fixed 15s window let a slow CI runner's redraw outlast it
-# and eject green PRs from the merge queue.
+# which the table's `drawCallback` re-binds via `Shiny.bindAll` once the async
+# redraw lands -- which can be after the server reports idle. The old approach
+# polled for the `.shiny-bound-input` marker, but `Shiny.unbindAll` strips that
+# class on *every* redraw, so a poll can sample an unbound window (or a stalled
+# rebind can leave it off for the whole budget) and eject a green PR. Instead
+# latch a sticky flag the first time a `shiny:bound` event reports the target
+# bound: set once, it survives the later unbind/rebind churn. `draw.dt` is
+# counted only to make a residual timeout diagnosable. The triggering click has
+# already awaited idle, so wait_bound adds no idle wait of its own (one would
+# only re-expose the separate idle-check flake).
 wait_bound <- function(app, id, timeout = 30 * 1000) {
 
-  app$wait_for_idle(timeout = timeout)
+  target <- nsid(id)
 
-  app$wait_for_js(
-    paste0(
-      "document.querySelector('#", nsid(id), ".shiny-bound-input') !== null"
-    ),
-    timeout = timeout
+  js <- r"((function () {
+    var id = '__ID__';
+    var bound = function () {
+      var el = document.getElementById(id);
+      return !!(el && el.classList.contains('shiny-bound-input'));
+    };
+    var st = {done: bound(), draws: 0, existed: !!document.getElementById(id)};
+    window.__blockrWaitBound = st;
+    if (st.done) return;
+    $(document).on('draw.dt.blockrWaitBound', function () { st.draws += 1; });
+    $(document).on('shiny:bound.blockrWaitBound', function () {
+      if (bound()) { st.done = true; $(document).off('.blockrWaitBound'); }
+    });
+  })())"
+
+  app$run_js(gsub("__ID__", target, js, fixed = TRUE))
+
+  diagnose <- function() {
+    sprintf(
+      "[wait_bound] id=%s state=%s tables=%s",
+      target,
+      app$get_js("JSON.stringify(window.__blockrWaitBound)"),
+      app$get_js("document.querySelectorAll('table.dataTable').length")
+    )
+  }
+
+  wait_js(
+    app,
+    "window.__blockrWaitBound && window.__blockrWaitBound.done === true",
+    diagnose,
+    timeout
   )
 }
 

--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -1,0 +1,40 @@
+# CI hardening for the chromote-driven shinytest2 e2e tests.
+
+# Give Chrome longer to open its remote-debugging port. chromote's default is
+# 10s (`getOption("chromote.timeout", 10)` in launch_chrome_impl), too short on
+# loaded CI runners -- Windows especially -- where launch intermittently aborts
+# with "Chrome debugging port not open after 10 seconds".
+options(chromote.timeout = 30)
+
+# Chrome leaves scratch dirs (com.google.Chrome.* / org.chromium.Chromium.*,
+# scoped_dir variants included) in the session temp parent (`$TMPDIR`), which
+# R CMD check then flags as "detritus in the temp directory" -- a NOTE the CI
+# gate fails on. `app$stop()` only ends the shinytest2 session; the shared
+# browser stays alive until R exits, so its scratch is never reclaimed. At the
+# end of the suite, close the browser (a clean shutdown reclaims its scratch),
+# then sweep anything that still leaked -- but only what this run created, so a
+# shared `$TMPDIR` on a developer machine keeps its other dirs.
+local({
+
+  pat <- "^(com\\.google\\.Chrome|org\\.chromium\\.Chromium)"
+  tmp_parent <- dirname(tempdir())
+  before <- list.files(tmp_parent, pattern = pat)
+
+  withr::defer(
+    {
+      if (isTRUE(chromote::has_default_chromote_object())) {
+        try(chromote::default_chromote_object()$close(), silent = TRUE)
+      }
+
+      unlink(
+        file.path(
+          tmp_parent,
+          setdiff(list.files(tmp_parent, pattern = pat), before)
+        ),
+        recursive = TRUE,
+        force = TRUE
+      )
+    },
+    testthat::teardown_env()
+  )
+})

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -581,7 +581,7 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   expect_silent(isolate(board_block_ids(forwarded$board)))
 })
 
-test_that("reconcile_views skips an added panel pending its echo (#196)", {
+test_that("reconcile_views never pushes a layout back to a live dock (#259)", {
 
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
@@ -592,80 +592,19 @@ test_that("reconcile_views skips an added panel pending its echo (#196)", {
     sendCustomMessage = function(type, message) invisible()
   )
 
-  # board_layouts holds both panels synchronously (the block-add fold) and the
-  # proxy's live_panels tracker has caught `b` from insert_block_ui, but the
-  # browser has not yet echoed `b` back through get_dock. reconcile must not
-  # restore here: membership agrees, so the only apparent difference is the
-  # not-yet-echoed panel insert_block_ui already placed -- restoring would wipe
-  # it (#196).
+  # board_layouts carries `a` + `b` for view V while the live dock's tracked
+  # membership is only `a`: the committed board and the live dock have diverged.
+  # A view's arrangement is client-owned and flows dock -> board only, so
+  # reconcile must never restore the dock from board_layouts. That board -> dock
+  # push -- restore_dock faithfully replaying a board_layouts that lagged the
+  # live dock -- is exactly the feedback loop that tore panels down on a slow
+  # client (#252). Pre-#259 this divergence drove apply_layout_diff ->
+  # restore_layout; now nothing pushes.
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
     layouts = list(V = dock_layout("a", "b"))
   )
   board <- with_mock_context(ms, reactiveValues(board = brd))
-
-  target_ids <- layout_panel_ids(board_layouts(brd)[["V"]])
-
-  behind <- board_layouts(
-    new_dock_board(
-      blocks = c(a = new_dataset_block()),
-      layouts = list(V = dock_layout("a"))
-    )
-  )[["V"]]
-
-  docks <- with_mock_context(ms, reactiveValues())
-  docks[["V"]] <- list(
-    layout = function() behind,
-    live_panels = with_mock_context(ms, reactiveVal(target_ids))
-  )
-
-  client_views <- with_mock_context(
-    ms,
-    reactiveVal(seed_view_state(board_layouts(brd)))
-  )
-  client_active <- with_mock_context(ms, reactiveVal("V"))
-  active_dock <- with_mock_context(ms, reactiveValues())
-  update <- with_mock_context(ms, reactiveVal())
-
-  diffed <- 0L
-
-  with_mocked_bindings(
-    with_mock_context(
-      ms,
-      reconcile_views(
-        board, update, docks, active_dock, client_active, client_views,
-        session
-      )
-    ),
-    apply_layout_diff = function(...) diffed <<- diffed + 1L,
-    switch_active_view = function(...) invisible(),
-    .package = "blockr.dock"
-  )
-
-  expect_identical(diffed, 0L)
-})
-
-test_that("reconcile_views pushes a programmatic membership change", {
-
-  ms <- new_mock_session()
-  withr::defer(if (!ms$isClosed()) ms$close())
-
-  session <- list(
-    ns = identity,
-    sendInputMessage = function(input_id, message) invisible(),
-    sendCustomMessage = function(type, message) invisible()
-  )
-
-  # board_layouts now carries `a` + `b`, but the dock's tracked membership is
-  # only `a`: a programmatic views$mod added `b`'s panel with no live op, so
-  # reconcile must push the new layout to the dock and record the new set.
-  brd <- new_dock_board(
-    blocks = c(a = new_dataset_block(), b = new_head_block()),
-    layouts = list(V = dock_layout("a", "b"))
-  )
-  board <- with_mock_context(ms, reactiveValues(board = brd))
-
-  target <- board_layouts(brd)[["V"]]
 
   behind_ids <- layout_panel_ids(
     board_layouts(
@@ -676,12 +615,10 @@ test_that("reconcile_views pushes a programmatic membership change", {
     )[["V"]]
   )
 
-  live_panels <- with_mock_context(ms, reactiveVal(behind_ids))
-
   docks <- with_mock_context(ms, reactiveValues())
   docks[["V"]] <- list(
     layout = function() NULL,
-    live_panels = live_panels
+    live_panels = with_mock_context(ms, reactiveVal(behind_ids))
   )
 
   client_views <- with_mock_context(
@@ -692,7 +629,7 @@ test_that("reconcile_views pushes a programmatic membership change", {
   active_dock <- with_mock_context(ms, reactiveValues())
   update <- with_mock_context(ms, reactiveVal())
 
-  captured <- NULL
+  restored <- 0L
 
   with_mocked_bindings(
     with_mock_context(
@@ -702,19 +639,12 @@ test_that("reconcile_views pushes a programmatic membership change", {
         session
       )
     ),
-    apply_layout_diff = function(view, target, ...) {
-      captured <<- list(view = view, target = target)
-    },
+    restore_layout = function(...) restored <<- restored + 1L,
     switch_active_view = function(...) invisible(),
     .package = "blockr.dock"
   )
 
-  expect_false(is.null(captured))
-  expect_identical(captured$view, "V")
-  expect_true(layouts_match(captured$target, target))
-
-  # The push records the new membership, so a later pass is a no-op.
-  expect_setequal(isolate(live_panels()), layout_panel_ids(target))
+  expect_identical(restored, 0L)
 })
 
 test_that("apply_board_update.dock_board switches active view", {


### PR DESCRIPTION
## Summary

The dock held its live layout in two bindings that formed a cycle: the live-sync fold pushed the dockview client's `_state` into `board_layouts` (dock → board), and `reconcile_view_layout()` pushed `board_layouts` back to the widget via `restore_dock` (board → dock). A `board_layouts` update that *originated* at the dock still triggered a re-push, whose echo folded back — the feedback loop. On a slow client a partial `_state` folds an impoverished layout that the push then faithfully restores, tearing panels down (#252).

- Removes the board → dock arrangement push: `reconcile_view_layout()` and `apply_layout_diff()` (its only caller, and the only `restore_dock` rebuild outside init), plus the now-dead `layouts_match()`. A view's per-view arrangement is client-owned and now flows dock → board only.
- `reconcile_views()` keeps the structural job the board *is* authoritative over — create / destroy / rename / switch views — and the init-time `restore_layout()`. The dock → board fold (`sync_layouts_to_board` + the membership fold) is untouched, so `board_layouts` stays current for serialization and live readers (e.g. `blockr.assistant`).
- With only one direction live there is nothing to feed back on, so no echo to suppress: no `_state` provenance, no `last_applied`, no dockViewR dependency. Net deletion (+45/−237), no new layout-tracking state.
- A genuine *server-initiated* arrangement change has no callers today; if one is added it makes its own `restore_dock` at the source rather than relying on a generic reconcile.

Supersedes #257 / #258 and obviates #223 (`apply_layout_diff` is removed, not made surgical).

Fixes #259
Fixes #252

Fixes #266
