### PR TITLE
Persist the full managed board-option set on save

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # blockr.dock (development version)
 
+* Board options changed in the settings sidebar are no longer reset to
+  their defaults on save and reload (blockr.session#23). Serialization
+  persisted only the board's own `board_options()`, but the sidebar
+  manages the wider `blockr_app_options()` set -- options contributed by
+  blocks and the registry, such as the preview-row count -- so a changed
+  block-backed option was dropped and reverted on restore.
+  `serialize_board()` now persists the full managed set.
+
 * Live panel rearrangements are no longer lost when a board is saved
   (#243). `view_data()`, the live dock layout that serialization reads,
   was stuck at `NULL` for the whole session, so Export fell back to the

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -14,8 +14,14 @@ serialize_board.dock_board <- function(x, blocks, id = NULL, dock,
     reval_if
   )
 
+  # The settings UI manages `blockr_app_options()` (board options plus those
+  # contributed by blocks and the registry), a wider set than the board's own
+  # `board_options()`. Persist that set so a user-changed option backed by a
+  # block (e.g. preview rows) survives save and restore.
+  board_options(x) <- blockr_app_options(x)
+
   opts <- lapply(
-    set_names(nm = names(as_board_options(x))),
+    set_names(nm = names(board_options(x))),
     get_board_option_or_null,
     session
   )

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -676,3 +676,47 @@ test_that("producer version threads from the board down to layout reading", {
   des <- blockr_deser(ser)
   expect_identical(layout_panel_ids(des[["layouts"]][[1L]]), "block_panel-a")
 })
+
+# A board option the user can change in the settings sidebar must survive a
+# save / restore round-trip. An empty board owns only `board_name`, yet the
+# sidebar manages the wider `blockr_app_options()` set (options contributed by
+# registered blocks, e.g. the `n_rows` preview-row count). Serialize used to
+# read only the board's own options, so a changed block-backed option was
+# dropped and reverted to its default on reload.
+test_that("a user-changed block-backed board option survives save/restore", {
+
+  brd <- new_dock_board()
+
+  expect_false("n_rows" %in% names(board_options(brd)))
+  expect_true("n_rows" %in% names(blockr_app_options(brd)))
+
+  ser <- NULL
+
+  testServer(
+    get_s3_method("board_server", brd),
+    {
+      session$flushReact()
+
+      session$setInputs(n_rows = 100L)
+      session$flushReact()
+
+      ser <<- serialize_board(
+        rv$board, rv$blocks, id = "empty", dock = NULL,
+        view_data = function() NULL, session = session
+      )
+    },
+    args = list(
+      x = brd,
+      plugins = list(blockr.core::manage_blocks()),
+      options = blockr_app_options(brd)
+    )
+  )
+
+  loaded <- blockr_deser(ser)
+
+  expect_true("n_rows" %in% names(board_options(loaded)))
+  expect_identical(
+    board_option_value(blockr_app_options(loaded)[["n_rows"]]),
+    100L
+  )
+})


### PR DESCRIPTION
## Summary

On an empty dock board the settings sidebar shows a "Preview rows" control, but `n_rows` is contributed by registered blocks via `blockr_app_options()` — a wider set than the board's own `board_options()`. `serialize_board.dock_board` persisted only the board's own options, so a user's change to a block-backed option was never written and reverted to the registry default (50) on reload.

- Widen the persisted set to `blockr_app_options(x)` (board + extension + block + registry options) before serializing, matching what the sidebar actually manages. On restore `combine_board_options()` is first-wins, so the saved value takes precedence over the registry default.
- Regression test for the `n_rows` save → restore round-trip, verified to fail on the prior code.

Core's `serialize_board.board` carries the same narrow/wide mismatch for non-dock boards — filing that as a follow-up.

Fixes BristolMyersSquibb/blockr.core#238