### PR TITLE
Expose view_data to extensions; retire redundant layout plumbing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,26 @@
   the current arrangement of every view directly instead of folding it
   through `board_layouts(board$board)`. `view_data()` is `NULL` until
   every view has reported its layout once, so consumers should `req()`
-  it (#264).
+  it. The `dock` handle (the active-view `active_dock` mirror) is retired
+  from the extension surface at the same time: it is internal now, used
+  only by the board-level block insert / remove plugin (#264).
+
+* Multi-view boards no longer emit a burst of redundant board updates at
+  startup (#271). Restoring a multi-group layout makes the dockview client
+  transiently activate each group in turn, and the dock -> board arrangement
+  fold (`layouts_to_board_observer`) compared layouts through
+  `layout_to_spec`, whose `focus` field tracks the active group -- so each
+  cross-group focus tick read as a layout change and committed an
+  `update(list(views = ...))`, on the order of ten redundant updates before
+  the board settled (worst on large boards, e.g. 12 views / 99 blocks / 30
+  groups). That fold is removed: a view's live arrangement is now read on
+  demand -- on save, or by an extension via `view_data()` -- instead of
+  mirrored back into `board_layouts` on every dockview tick, so the burst is
+  gone. The removal is lossless, since `serialize_board.dock_board` already
+  reads the live layout from `view_data()` and the fold had no remaining
+  runtime reader; `board_layouts` still carries the committed view set,
+  names, active view and panel membership, kept current by the membership
+  fold (#264).
 
 * The dock no longer loops forever or tears its panels down on a slow
   client (#252). The live layout was held in two bindings that formed a
@@ -61,9 +80,8 @@
   view's arrangement is client-owned and now flows dock -> board only.
   `reconcile_views()` still owns what the board is authoritative over --
   which views exist, their names, the active view, and the initial layout
-  on load -- and the fold keeps `board_layouts` current for serialization
-  and live readers. With one direction live there is no echo to suppress
-  and no layout-tracking state to maintain.
+  on load. With one direction live there is no echo to suppress and no
+  layout-tracking state to maintain.
 
 * Live panel rearrangements are no longer lost when a board is saved
   (#243). `view_data()`, the live dock layout that serialization reads,

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,12 @@
   adjacent panel group is enough to re-emit the board, which is why #201
   surfaced this. The refresh now overlays the staged additions, edits and
   removals onto the refreshed applied state instead of clobbering them.
+* Dock extensions now receive `view_data`, the live all-views layout
+  reactive (the same one serialization reads), so an extension can read
+  the current arrangement of every view directly instead of folding it
+  through `board_layouts(board$board)`. `view_data()` is `NULL` until
+  every view has reported its layout once, so consumers should `req()`
+  it (#264).
 
 * The dock no longer loops forever or tears its panels down on a slow
   client (#252). The live layout was held in two bindings that formed a

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -68,8 +68,11 @@ board_server_callback <- function(board, update, visible, ...,
 
   report_visible_observer(visible, client_active, docks)
 
-  # Extensions receive active_dock — a reactiveValues that always mirrors
-  # whichever view is currently active (swapped by update_active_dock).
+  # Extensions receive `dock` (active_dock, a reactiveValues mirroring whichever
+  # view is currently active, swapped by update_active_dock) for the active
+  # view, plus `view_data` for the live all-views layout — the same reactive
+  # serialization reads. `view_data()` is NULL until every view has reported its
+  # layout once (the all-or-nothing in live_view_data), so consumers req() it.
   dock <- active_dock
   view_data <- live_view_data(client_views, docks, client_active)
 
@@ -98,6 +101,7 @@ board_server_callback <- function(board, update, visible, ...,
       board = board,
       update = update,
       dock = dock,
+      view_data = view_data,
       actions = triggers,
       extensions = peers
     ),

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -33,10 +33,13 @@ board_server_callback <- function(board, update, visible, ...,
   triggers <- action_triggers(actions)
 
   # Per-session dock state, closure-private. `docks` is the live manage_dock()
-  # registry, keyed by view id; `client_active` / `client_views` mirror which
-  # views the browser shows, diffed by reconcile_views() — the sole mutator.
-  # Per-view panel membership lives on each dock proxy (`live_panels`), kept
-  # authoritative by the add/remove touchpoints; it drives `n_panels` / the
+  # registry of built dock modules, keyed by view id. `client_views` is the nav
+  # model: the nav-rendered set of views plus their display names, and
+  # live_view_data()'s name source. It is distinct from `docks` only during the
+  # init flush (board_ui seeds the nav statically); reconcile_views() is its
+  # sole mutator. `client_active` mirrors which view the browser shows as
+  # active. Per-view panel membership lives on each dock proxy (`live_panels`),
+  # kept authoritative by the add/remove touchpoints; it drives `n_panels` / the
   # empty-dock prompt and the membership fold without waiting on the lagging
   # browser echo. `docks` is a `reactiveValues`, so live_view_data() depends on
   # each view's entry and re-evaluates when reconcile creates it, whatever the
@@ -68,15 +71,12 @@ board_server_callback <- function(board, update, visible, ...,
 
   report_visible_observer(visible, client_active, docks)
 
-  # Extensions receive `dock` (active_dock, a reactiveValues mirroring whichever
-  # view is currently active, swapped by update_active_dock) for the active
-  # view, plus `view_data` for the live all-views layout — the same reactive
-  # serialization reads. `view_data()` is NULL until every view has reported its
-  # layout once (the all-or-nothing in live_view_data), so consumers req() it.
-  dock <- active_dock
+  # `view_data` is the live all-views layout -- the same reactive serialization
+  # reads. It is NULL until every view has reported its layout once (the
+  # all-or-nothing in live_view_data), so consumers req() it. A view's live
+  # arrangement is read on demand here; it no longer folds back into
+  # `board_layouts`.
   view_data <- live_view_data(client_views, docks, client_active)
-
-  sync_layouts_to_board(view_data, update, board)
 
   # Each extension can read the others' server results through the
   # `extensions` environment: one active binding per id, each resolving to
@@ -94,13 +94,23 @@ board_server_callback <- function(board, update, visible, ...,
     bind_peer(ext_id)
   }
 
+  # Two bundles of live handles, kept in step. Extension servers are called
+  # (below) with `board` + `update` (read / mutate the board), `view_data` +
+  # `actions` (the live products) and the `extensions` peer env. The callback
+  # RETURNS `dock`, `view_data`, `actions` and each extension's result to core,
+  # which spreads them into every plugin's args. `view_data` + `actions` are in
+  # both -- they are consumed on each side (serialization and the edit-block
+  # plugin read the returned pair). The gaps are deliberate: `dock`
+  # (active_dock) is returned for core's block insert / remove plugin but
+  # withheld from extensions, which read layout via `view_data`; `board` /
+  # `update` are core's own inputs, not echoed back; the peer env stays
+  # internal (core gets the resolved `ext_res`).
   ext_res <- lapply(
     exts,
     extension_server,
     list(
       board = board,
       update = update,
-      dock = dock,
       view_data = view_data,
       actions = triggers,
       extensions = peers
@@ -118,9 +128,12 @@ board_server_callback <- function(board, update, visible, ...,
 
   register_actions(actions, triggers, board, update, ext_res)
 
+  # Returned to core, spread into every plugin's args (see the two-bundle note
+  # above): `dock` for block placement, `view_data` for serialization, `actions`
+  # for the edit-block plugin, and each extension's resolved result.
   c(
     list(
-      dock = dock,
+      dock = active_dock,
       actions = triggers,
       view_data = view_data
     ),
@@ -239,82 +252,6 @@ live_view_data <- function(client_views, docks, client_active) {
   })
 }
 
-# Writes go through update(list(views = ...)) — board$board is
-# read-only at the plugin boundary; routing through the update channel
-# lets apply_board_update.dock_board mutate rv$board where it's writable
-# and composes with augment/apply hooks from other subclasses. Debounced
-# because drag-resize emits many rapid events per gesture.
-sync_layouts_to_board <- function(view_data, update, board, millis = 250) {
-  src <- if (millis > 0L) shiny::debounce(view_data, millis) else view_data
-  layouts_to_board_observer(src, update, board)
-}
-
-layouts_to_board_observer <- function(view_data, update, board) {
-  observe({
-    new_layouts <- req(view_data())
-    current <- isolate(board_layouts(board$board))
-
-    if (identical(current, new_layouts)) {
-      return()
-    }
-
-    delta <- diff_dock_layouts(current, new_layouts)
-
-    if (length(delta)) {
-      log_trace("committing live dock layout deltas back to the board")
-      update(list(views = delta))
-    }
-  })
-}
-
-# Structured `views` delta between two `dock_layouts`, keyed by stable
-# view id, so live UI state mirrors back through the update lifecycle
-# without resending unchanged views. Per-view comparison uses the wire
-# spec (ignores volatile fields and the display name — renames travel on
-# their own slot); the active-view change rides the `$active` slot. Since
-# the id is stable across a rename, a rename never surfaces here as a
-# removal of the old view paired with an addition of a new one.
-diff_dock_layouts <- function(current, new_layouts) {
-
-  cur_ids <- names(current)
-  new_ids <- names(new_layouts)
-
-  add_ids <- setdiff(new_ids, cur_ids)
-  rm_ids <- setdiff(cur_ids, new_ids)
-  common <- intersect(cur_ids, new_ids)
-
-  mod_views <- list()
-  for (v in common) {
-
-    cur_spec <- layout_to_spec(current[[v]])
-    new_spec <- layout_to_spec(new_layouts[[v]])
-
-    if (!identical(cur_spec, new_spec)) {
-      mod_views[[v]] <- new_layouts[[v]]
-    }
-  }
-
-  cur_active <- active_view(current)
-  new_active <- active_view(new_layouts)
-
-  out <- list()
-
-  if (length(add_ids)) {
-    out$add <- as.list(unclass(new_layouts))[add_ids]
-  }
-  if (length(rm_ids)) {
-    out$rm <- rm_ids
-  }
-  if (length(mod_views)) {
-    out$mod <- mod_views
-  }
-  if (!identical(cur_active, new_active) && !is.null(new_active)) {
-    out$active <- new_active
-  }
-
-  out
-}
-
 #' Hide all block and extension UI for a view.
 #'
 #' Moves block/extension cards off-screen (back to offcanvas) so they are
@@ -423,15 +360,16 @@ remove_view <- function(v_id, session, docks) {
 # Make the live dock session match the committed board's view set:
 # instantiate added views, tear down removed ones, relabel renamed ones, and
 # switch to the active view. The board owns which views exist, their names and
-# the active one; a view's per-view arrangement is client-owned and flows dock
-# -> board only (the live-sync fold), so reconcile never pushes a layout back to
-# its live dock. Takes the reactive board handle (not a snapshot) so the live
-# list reaches manage_dock, whose interaction observers read board$board after
-# the fact (#194); the committed board is snapshotted once here for this pass's
-# reads. Driven by board$board so apply_board_update.dock_board stays a pure
-# reducer and dock state never crosses the package boundary. Idempotent — a
-# board already matching the live view set produces no surgery — so it composes
-# with the live-sync (DOM -> board) path without ping-ponging.
+# the active one; a view's per-view arrangement is client-owned, read live via
+# view_data() and never folded back into board_layouts, so reconcile never
+# pushes a layout to its live dock. Takes the reactive board handle (not a
+# snapshot) so the live list reaches manage_dock, whose interaction observers
+# read board$board after the fact (#194); the committed board is snapshotted
+# once here for this pass's reads. Driven by board$board
+# so apply_board_update.dock_board stays a pure reducer and dock state never
+# crosses the package boundary. Idempotent — a board already matching the live
+# view set produces no surgery — so it composes with the membership fold
+# (DOM -> board) without ping-ponging.
 reconcile_views <- function(board, update, docks, active_dock,
                             client_active, client_views, session) {
 

--- a/R/ext-class.R
+++ b/R/ext-class.R
@@ -6,10 +6,13 @@
 #' can be combined into a `dock_extensions` object.
 #'
 #' @param server A function returning [shiny::moduleServer()]. Beyond
-#' `id`, it is called with the board handles `board`, `update`, `dock`
-#' and `actions`, plus `extensions` -- an environment exposing every
-#' extension's server result keyed by ID (each carrying its `state`),
-#' so one extension can read another's state via `extensions[[id]]`.
+#' `id`, it is called with the board handles `board`, `update`,
+#' `view_data` and `actions`, plus `extensions` -- an environment
+#' exposing every extension's server result keyed by ID (each carrying
+#' its `state`), so one extension can read another's state via
+#' `extensions[[id]]`. `view_data` is a reactive holding the live
+#' all-views layout (the committed board is `board`); it is `NULL`
+#' until every view has reported its layout once, so `req()` it.
 #' @param ui A function with a single argument (`ns`) returning a `shiny.tag`
 #' @param name Name for extension
 #' @param class Extension subclass

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -259,10 +259,11 @@ dock_panel_groups <- function(session = get_session()) {
 
 #' Swap the contents of the `active_dock` mirror to a different dock.
 #'
-#' Extensions hold a stable reference to the `active_dock` `reactiveValues`.
-#' When the user switches views, this function copies the new view's dock
-#' module result into it so extensions transparently see the new dock
-#' without needing to re-bind.
+#' `active_dock` is an internal `reactiveValues` mirror of whichever view is
+#' currently active. The board-level block insert / remove plugin places and
+#' removes panels through it, so it must always point at the active view. When
+#' the user switches views, this function copies the new view's dock module
+#' result into it so that handle follows the active dock without re-binding.
 #'
 #' @param rv The `active_dock` `reactiveValues` to update.
 #' @param dock A dock module result (list with `proxy`, `board_ns`,

--- a/man/extension.Rd
+++ b/man/extension.Rd
@@ -67,10 +67,13 @@ extension_block_callback(x, ...)
 }
 \arguments{
 \item{server}{A function returning \code{\link[shiny:moduleServer]{shiny::moduleServer()}}. Beyond
-\code{id}, it is called with the board handles \code{board}, \code{update}, \code{dock}
-and \code{actions}, plus \code{extensions} -- an environment exposing every
-extension's server result keyed by ID (each carrying its \code{state}),
-so one extension can read another's state via \code{extensions[[id]]}.}
+\code{id}, it is called with the board handles \code{board}, \code{update},
+\code{view_data} and \code{actions}, plus \code{extensions} -- an environment
+exposing every extension's server result keyed by ID (each carrying
+its \code{state}), so one extension can read another's state via
+\code{extensions[[id]]}. \code{view_data} is a reactive holding the live
+all-views layout (the committed board is \code{board}); it is \code{NULL}
+until every view has reported its layout once, so \code{req()} it.}
 
 \item{ui}{A function with a single argument (\code{ns}) returning a \code{shiny.tag}}
 

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -966,6 +966,35 @@ test_that("extension servers can read peer extension state", {
   )
 })
 
+test_that("extension servers receive the live view_data reactive (#264)", {
+
+  captured <- NULL
+
+  probe <- new_dock_extension(
+    server = function(id, ...) {
+      captured <<- list(...)[["view_data"]]
+      moduleServer(id, function(input, output, session) list(state = list()))
+    },
+    ui = function(id) tagList(),
+    name = "Probe",
+    class = "probe_extension",
+    ctor = function(...) NULL
+  )
+
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block()),
+    extensions = as_dock_extensions(list(probe))
+  )
+
+  with_mock_session(
+    {
+      board_server_callback(board_rv, update = reactiveVal())
+
+      expect_true(is.reactive(captured))
+    }
+  )
+})
+
 test_that("New view modal confirm submits an add-and-activate delta", {
 
   brd <- new_dock_board(

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -17,9 +17,10 @@ test_that("board server", {
       expect_type(res, "list")
       expect_named(res, c("dock", "actions", "view_data"))
 
-      # `dock` is the active-dock reactiveValues handle the extensions
-      # receive; its contents are filled by the reconcile pass (init render),
-      # exercised by the app test — here we assert only the returned shape.
+      # `dock` is the internal active-dock reactiveValues handle (the block
+      # insert / remove plugin places panels through it), still returned to the
+      # board server; its contents are filled by the reconcile pass (init
+      # render), exercised by the app test — here we assert only the shape.
       expect_s3_class(res[["dock"]], "reactivevalues")
       expect_s3_class(res[["view_data"]], "reactive")
     }
@@ -492,65 +493,6 @@ test_that("board_server_callback seeds visibility before the client reports", {
   })
 })
 
-test_that("layouts_to_board_observer fires update views on divergence", {
-  ms <- new_mock_session()
-  withr::defer(if (!ms$isClosed()) ms$close())
-
-  brd <- new_dock_board(
-    blocks = c(a = new_dataset_block(), b = new_head_block()),
-    layouts = list(A = list("a"), B = list("b"))
-  )
-
-  rv <- with_mock_context(ms, reactiveValues(board = brd))
-  vd <- with_mock_context(ms, reactiveVal(NULL))
-
-  captured <- list()
-  upd <- function(payload) {
-    captured[[length(captured) + 1L]] <<- payload
-  }
-
-  with_mock_context(ms, layouts_to_board_observer(vd, upd, rv))
-  ms$flushReact()
-
-  expect_length(captured, 0L)
-
-  new_views <- isolate(board_layouts(rv$board))
-  b_id <- vid(new_views, "B")
-  active_view(new_views) <- b_id
-
-  with_mock_context(ms, vd(new_views))
-  ms$flushReact()
-
-  expect_length(captured, 1L)
-  expect_named(captured[[1L]], "views")
-  expect_identical(captured[[1L]]$views$active, b_id)
-  expect_null(captured[[1L]]$views$mod)
-})
-
-test_that("layouts_to_board_observer is idempotent when nothing changed", {
-  ms <- new_mock_session()
-  withr::defer(if (!ms$isClosed()) ms$close())
-
-  brd <- new_dock_board(
-    blocks = c(a = new_dataset_block()),
-    layouts = list(Page = list("a"))
-  )
-
-  rv <- with_mock_context(ms, reactiveValues(board = brd))
-  vd <- with_mock_context(ms, reactiveVal(NULL))
-
-  fire_count <- 0L
-  upd <- function(payload) fire_count <<- fire_count + 1L
-
-  with_mock_context(ms, layouts_to_board_observer(vd, upd, rv))
-  ms$flushReact()
-
-  with_mock_context(ms, vd(isolate(board_layouts(rv$board))))
-  ms$flushReact()
-
-  expect_identical(fire_count, 0L)
-})
-
 test_that("view nav renders one labelled item per view (#189)", {
 
   board <- new_dock_board(
@@ -966,13 +908,13 @@ test_that("extension servers can read peer extension state", {
   )
 })
 
-test_that("extension servers receive the live view_data reactive (#264)", {
+test_that("extension servers receive view_data, not the active dock (#264)", {
 
   captured <- NULL
 
   probe <- new_dock_extension(
     server = function(id, ...) {
-      captured <<- list(...)[["view_data"]]
+      captured <<- list(...)
       moduleServer(id, function(input, output, session) list(state = list()))
     },
     ui = function(id) tagList(),
@@ -988,9 +930,17 @@ test_that("extension servers receive the live view_data reactive (#264)", {
 
   with_mock_session(
     {
-      board_server_callback(board_rv, update = reactiveVal())
+      board_server_callback(
+        board_rv,
+        update = reactiveVal(),
+        visible = reactiveVal()
+      )
 
-      expect_true(is.reactive(captured))
+      expect_true(is.reactive(captured[["view_data"]]))
+
+      # `dock` (active_dock) is retired from the extension surface -- it is
+      # internal now (#264).
+      expect_false("dock" %in% names(captured))
     }
   )
 })


### PR DESCRIPTION
## Summary

Completes #264, stacked on #260. Exposes the live `view_data` reactive to dock extensions and retires the dock-server layout plumbing that #260 left redundant.

- **Expose `view_data` to extensions** — extension servers now receive the live all-views layout reactive (the same one `serialize_board.dock_board` reads), so an extension reads every view's current arrangement directly instead of folding through `board_layouts(board$board)`. `view_data()` is `NULL` until every view has reported its layout once, so consumers `req()` it.
- **Retire `active_dock` from the extension surface** — extensions no longer receive the `dock` handle. `active_dock` stays internal: the active-view mirror through which the board-level block insert / remove plugin places panels. The board-server return value (consumed by serialization and that plugin) is unchanged.
- **Drop the arrangement fold** — `sync_layouts_to_board` (with its `layouts_to_board_observer` / `diff_dock_layouts` helpers) folded the live arrangement back into `board_layouts` for no remaining live reader, since serialization reads `view_data()` directly. It is removed. The membership fold (`fold_live_membership`) stays — it keeps `board_layouts` a valid skeleton (view set, names, active view, panel membership).
- **Document `client_views` as the nav model** — the nav-rendered view set plus display names, and `live_view_data()`'s name source, distinct from the built-module `docks` registry only during the init flush. (Name kept; documentation added.)
- **Document the two handle bundles `board_server_callback` feeds** — the extension-server args and the spread return value, kept in step: the overlap is `view_data` + `actions` (consumed on both sides), and each difference is reasoned (`dock` returned for core's block plugin but withheld from extensions; `board` / `update` are core's own inputs; the peer env stays internal, core gets the resolved `ext_res`).
- **NEWS + extension-contract note** — the `@param server` doc for `new_dock_extension()` now documents `view_data` (live layout) and `board` (committed state); NEWS covers the contract change and the fold removal.

Downstream: blockr.assistant migrates its two `board_layouts` reads to `view_data` (BristolMyersSquibb/blockr.assistant#60). ui / session / uat need no change.

Stacked on #260 — base is `259-cut-layout-loop`; retarget to `main` once #260 lands.

Fixes #264

Closes #271