### PR TITLE
Add trace logging to the live-layout -> board commit path

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -179,9 +179,14 @@ live_view_data <- function(client_views, docks, client_active) {
       }
       ly <- dk$layout()
       if (is.null(ly)) {
+        log_trace("view_data: view {v_id} has no live layout yet")
         return(NULL)
       }
       out <- dockview_to_layout(ly)
+      log_trace(
+        "view_data: view {v_id} reports ",
+        "{length(layout_panel_ids(out))} live panel(s)"
+      )
       nm <- view_name(state[[v_id]])
       if (!is.null(nm)) {
         view_name(out) <- nm
@@ -224,6 +229,7 @@ layouts_to_board_observer <- function(view_data, update, board) {
     delta <- diff_dock_layouts(current, new_layouts)
 
     if (length(delta)) {
+      log_trace("committing live dock layout deltas back to the board")
       update(list(views = delta))
     }
   })


### PR DESCRIPTION
## Summary

- `live_view_data` logs, at `trace` level, each view's live panel count — and a note when a view has no live layout yet — so the per-view `view_data` reconstruction is observable.
- `layouts_to_board_observer` logs when it commits a live-layout delta back to the board.

These are off by default (they only emit at `trace` level) and change no behaviour. They make the live-dock-layout → committed-board-layout commit path legible. That path is where a transient or empty browser layout can get mirrored into the committed board layout, so these breadcrumbs help when debugging multi-view reconcile / layout-echo behaviour.
