### PR TITLE
Server-authoritative dock layout: provenance-gated board→dock push

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
 Remotes:
     BristolMyersSquibb/blockr.ui,
     BristolMyersSquibb/blockr.core,
+    cynkra/dockViewR@76-set-size,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:
     testthat (>= 3.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,16 @@
   flows both ways again, but the cycle is broken by provenance rather than
   by dropping a direction.
 
+* The 250 ms live-sync debounce is removed (#271). It only rate-limited a
+  startup board-update burst: restoring a multi-group layout makes dockview
+  cycle its active group, re-emitting `_state` per tick, and the fold read
+  each as a rearrangement and committed a redundant board update (~10 per
+  assembly on a large board). Those echoes now carry `_state-source:
+  "server"` and are dropped by the same `keep_foldable` guard that breaks the
+  push loop, so the burst is absorbed at its source and there is nothing left
+  to bound. Focus stays live in `_state`, so a settled tab activation is
+  still folded and serialized.
+
 * Live panel rearrangements are no longer lost when a board is saved
   (#243). `view_data()`, the live dock layout that serialization reads,
   was stuck at `NULL` for the whole session, so Export fell back to the

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,21 +43,17 @@
   surfaced this. The refresh now overlays the staged additions, edits and
   removals onto the refreshed applied state instead of clobbering them.
 
-* The dock no longer loops forever or tears its panels down on a slow
-  client (#252). The live layout was held in two bindings that formed a
-  cycle: the live-sync fold pushed the dockview client's state into
-  `board_layouts` (dock -> board), and a reconcile step pushed
-  `board_layouts` back to the widget (board -> dock). A board update that
-  originated at the dock still triggered a re-push, whose echo folded back;
-  on a slow client a partial client state folded an impoverished layout
-  that the push then faithfully restored. The board -> dock arrangement
-  push (`reconcile_view_layout()` / `apply_layout_diff()`) is removed: a
-  view's arrangement is client-owned and now flows dock -> board only.
-  `reconcile_views()` still owns what the board is authoritative over --
-  which views exist, their names, the active view, and the initial layout
-  on load -- and the fold keeps `board_layouts` current for serialization
-  and live readers. With one direction live there is no echo to suppress
-  and no layout-tracking state to maintain.
+* The board is the authoritative owner of dock arrangement, and the board
+  -> dock push no longer loops (#252). dockViewR now tags every `_state`
+  echo with its origin (`_state-source`: server or client), so the board
+  -> dock push (`reconcile_view_layout()` / `apply_layout_diff()`) is
+  restored: `reconcile_views()` pushes a view's committed layout to its
+  live dock, and the live-sync fold drops the "server"-tagged echo of that
+  push instead of re-committing it. A genuine user gesture echoes "client"
+  and still folds, so the board stays current for serialization and live
+  readers. This supersedes the one-direction stopgap (#259): arrangement
+  flows both ways again, but the cycle is broken by provenance rather than
+  by dropping a direction.
 
 * Live panel rearrangements are no longer lost when a board is saved
   (#243). `view_data()`, the live dock layout that serialization reads,

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -73,7 +73,7 @@ board_server_callback <- function(board, update, visible, ...,
   dock <- active_dock
   view_data <- live_view_data(client_views, docks, client_active)
 
-  sync_layouts_to_board(view_data, update, board, docks)
+  layouts_to_board_observer(view_data, update, board, docks)
 
   # Each extension can read the others' server results through the
   # `extensions` environment: one active binding per id, each resolving to
@@ -235,17 +235,15 @@ live_view_data <- function(client_views, docks, client_active) {
   })
 }
 
-# Writes go through update(list(views = ...)) — board$board is
-# read-only at the plugin boundary; routing through the update channel
-# lets apply_board_update.dock_board mutate rv$board where it's writable
-# and composes with augment/apply hooks from other subclasses. Debounced
-# because drag-resize emits many rapid events per gesture.
-sync_layouts_to_board <- function(view_data, update, board, docks,
-                                  millis = 250) {
-  src <- if (millis > 0L) shiny::debounce(view_data, millis) else view_data
-  layouts_to_board_observer(src, update, board, docks)
-}
-
+# Fold the live dock arrangement (grid and focused group) back into the board
+# when a settled gesture diverges from the committed layout. Writes go through
+# update(list(views = ...)) — board$board is read-only at the plugin boundary;
+# routing through the update channel lets apply_board_update.dock_board mutate
+# rv$board where it's writable and composes with augment/apply hooks from other
+# subclasses. No debounce: dockViewR emits `_state` once per settled gesture
+# (discrete boundaries plus sash-end, coalesced), and `keep_foldable` drops the
+# server-tagged echoes a restore's active-group cycling produces, so view_data
+# turns over only on settled client gestures -- no event burst is left to bound.
 layouts_to_board_observer <- function(view_data, update, board, docks) {
   observe({
     new_layouts <- req(view_data())

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -73,7 +73,7 @@ board_server_callback <- function(board, update, visible, ...,
   dock <- active_dock
   view_data <- live_view_data(client_views, docks, client_active)
 
-  sync_layouts_to_board(view_data, update, board)
+  sync_layouts_to_board(view_data, update, board, docks)
 
   # Each extension can read the others' server results through the
   # `extensions` environment: one active binding per id, each resolving to
@@ -240,12 +240,13 @@ live_view_data <- function(client_views, docks, client_active) {
 # lets apply_board_update.dock_board mutate rv$board where it's writable
 # and composes with augment/apply hooks from other subclasses. Debounced
 # because drag-resize emits many rapid events per gesture.
-sync_layouts_to_board <- function(view_data, update, board, millis = 250) {
+sync_layouts_to_board <- function(view_data, update, board, docks,
+                                  millis = 250) {
   src <- if (millis > 0L) shiny::debounce(view_data, millis) else view_data
-  layouts_to_board_observer(src, update, board)
+  layouts_to_board_observer(src, update, board, docks)
 }
 
-layouts_to_board_observer <- function(view_data, update, board) {
+layouts_to_board_observer <- function(view_data, update, board, docks) {
   observe({
     new_layouts <- req(view_data())
     current <- isolate(board_layouts(board$board))
@@ -256,11 +257,55 @@ layouts_to_board_observer <- function(view_data, update, board) {
 
     delta <- diff_dock_layouts(current, new_layouts)
 
+    delta$mod <- keep_foldable(delta$mod, docks)
+
+    if (!length(delta$mod)) {
+      delta$mod <- NULL
+    }
+
     if (length(delta)) {
       log_trace("committing live dock layout deltas back to the board")
       update(list(views = delta))
     }
   })
+}
+
+# Fold a view's arrangement echo back into the board only when it is a settled
+# user gesture. Two echoes are dropped. A server-origin echo (source "server")
+# is a board -> dock push reporting its own result; folding it re-commits the
+# push and loops -- the reason the push could not coexist with the fold until
+# provenance arrived to tell the two apart. A membership-lagging echo, whose
+# panel set is behind the dock's authoritative `live_panels` tracker (a paint
+# before a server restore has landed, or an add / remove the touchpoint has not
+# yet recorded), is stale: folding it commits an impoverished layout the push
+# then faithfully restores, wiping the view. A settled client gesture echoes
+# "client" with membership matching the tracker, and still folds.
+keep_foldable <- function(mod, docks) {
+
+  if (!length(mod)) {
+    return(mod)
+  }
+
+  foldable <- function(view, layout) {
+
+    dk <- docks[[view]]
+
+    if (is.null(dk)) {
+      return(TRUE)
+    }
+
+    if (identical(isolate(dk$source()), "server")) {
+      return(FALSE)
+    }
+
+    if (is.null(dk$live_panels)) {
+      return(TRUE)
+    }
+
+    setequal(layout_panel_ids(layout), isolate(dk$live_panels()))
+  }
+
+  mod[lgl_mply(foldable, names(mod), mod)]
 }
 
 # Structured `views` delta between two `dock_layouts`, keyed by stable
@@ -488,6 +533,14 @@ reconcile_views <- function(board, update, docks, active_dock,
         list(rename = list(id = v, to = new_nm))
       )
     }
+
+    reconcile_view_layout(
+      docks[[v]],
+      v,
+      layouts[[v]],
+      board_blocks(brd),
+      dock_extensions(brd)
+    )
   }
 
   client_views(state)
@@ -496,6 +549,54 @@ reconcile_views <- function(board, update, docks, active_dock,
         !identical(server_active, isolate(client_active()))) {
     switch_active_view(
       server_active, docks, active_dock, client_active, session
+    )
+  }
+
+  invisible()
+}
+
+# Push one view's committed layout to its live dock. Panel membership is tracked
+# authoritatively on the proxy (`live_panels`), kept in lockstep by the
+# add/remove touchpoints, so a mismatch there is a programmatic add / remove the
+# dock has not been told about (a views$mod, a board restore) — restore it and
+# record the new membership. When membership already agrees, only the
+# arrangement can differ; reconcile that against the browser's echoed state, but
+# skip until the echo has caught up to the current membership, so a just-added
+# panel (live_panels ahead of the echo) does not read as an arrangement change
+# and force a needless rebuild (#196).
+reconcile_view_layout <- function(dock, view, target, blocks, extensions) {
+
+  target_ids <- layout_panel_ids(target)
+  live_ids <- isolate(dock$live_panels())
+
+  if (!setequal(live_ids, target_ids)) {
+
+    apply_layout_diff(
+      view = view,
+      target = target,
+      dock = dock,
+      blocks = blocks,
+      extensions = extensions
+    )
+
+    dock$live_panels(target_ids)
+
+    return(invisible())
+  }
+
+  live <- tryCatch(isolate(dock$layout()), error = function(e) NULL)
+
+  if (is.null(live) || !setequal(grid_panel_ids(live[["grid"]]), target_ids)) {
+    return(invisible())
+  }
+
+  if (!layouts_match(live, target)) {
+    apply_layout_diff(
+      view = view,
+      target = target,
+      dock = dock,
+      blocks = blocks,
+      extensions = extensions
     )
   }
 
@@ -553,6 +654,7 @@ manage_dock <- function(
       board_ns = board_ns,
       live_panels = live_panels,
       layout = reactive(dockViewR::get_dock(proxy)),
+      source = reactive(input[[dock_input("state-source")]]),
       n_panels = n_panels,
       prev_active_group = prev_active_group,
       active_group_trail = active_group_trail

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -522,6 +522,51 @@ apply_views_rename <- function(rename, board) {
   board
 }
 
+# Whether two layouts describe the same panel arrangement, used to
+# short-circuit `restore_layout` when the live dockview state already
+# matches the target. Compares normalised wire specs (drops volatile
+# pixel sizes / regenerated group IDs) and additionally drops `focus`
+# so a tab click doesn't force a rebuild. `a` is the live wire shape
+# (`get_dock()`); `b` is the target `dock_layout`.
+layouts_match <- function(a, b) {
+
+  to_spec <- function(x) {
+
+    if (is.null(x)) {
+      return(NULL)
+    }
+
+    ly <- if (is_dock_layout(x)) {
+      x
+    } else {
+      tryCatch(dockview_to_layout(x), error = function(e) NULL)
+    }
+
+    if (is.null(ly)) {
+      return(NULL)
+    }
+
+    spec <- tryCatch(layout_to_spec(ly), error = function(e) NULL)
+
+    if (is.null(spec)) {
+      return(NULL)
+    }
+
+    spec[["focus"]] <- NULL
+
+    spec
+  }
+
+  spec_a <- to_spec(a)
+  spec_b <- to_spec(b)
+
+  if (is.null(spec_a) || is.null(spec_b)) {
+    return(FALSE)
+  }
+
+  identical(spec_a, spec_b)
+}
+
 apply_views_active <- function(active, board) {
 
   layouts <- board_layouts(board)
@@ -567,4 +612,44 @@ switch_active_view <- function(active, docks, active_dock, client_active,
   )
 
   invisible()
+}
+
+# Apply one view's layout change. v1 unconditionally restores the target
+# layout; surgical diff paths (noop / active-tab / reorder) are a deferred
+# follow-up that can dispatch here without touching callers.
+apply_layout_diff <- function(view, target, dock, blocks, extensions) {
+
+  log_debug("applying layout diff for view {view}")
+
+  # Block / extension UIs live in board-level wrapper elements (the
+  # offcanvas at init time, a dockview panel container while attached)
+  # and are moved between them via `move_dom_element`. `restore_dock`
+  # tears the panel containers down, taking the attached UIs with them,
+  # so we have to (a) park the UIs back in the offcanvas first and
+  # (b) reattach them to the freshly-rendered panels afterwards. Iterate
+  # object ids (as `hide_view_ui()` does): `for` over the classed id
+  # vector would drop the class and double-prefix the move target.
+  for (oid in as_obj_id(block_panel_ids(dock$proxy))) {
+    hide_block_panel(oid, rm_panel = FALSE, dock = dock)
+  }
+  for (oid in as_obj_id(ext_panel_ids(dock$proxy))) {
+    hide_ext_panel(oid, rm_panel = FALSE, dock = dock)
+  }
+
+  restore_layout(target, dock$proxy, blocks = blocks, extensions = extensions)
+
+  for (pid in as_dock_panel_id(target)) {
+    if (is_block_panel_id(pid)) {
+      show_block_panel(pid, add_panel = FALSE, dock = dock)
+    } else if (is_ext_panel_id(pid)) {
+      show_ext_panel(pid, add_panel = FALSE, dock = dock)
+    } else {
+      blockr_abort(
+        "Unknown panel type {class(pid)}.",
+        class = "dock_panel_invalid"
+      )
+    }
+  }
+
+  invisible(NULL)
 }

--- a/inst/examples/focus/app.R
+++ b/inst/examples/focus/app.R
@@ -1,0 +1,13 @@
+library(blockr.core)
+library(blockr.dock)
+
+# A single view laid out as two side-by-side groups, so a focus change can be
+# driven by activating the second group's panel. Used by the focus-persistence
+# e2e test: a pure focus change must still turn the dock's `_state` over.
+serve(
+  new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_dataset_block()),
+    layouts = list(Page = dock_layout("a", "b"))
+  ),
+  "my_board"
+)

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -708,7 +708,7 @@ test_that("reconcile_views forwards the live board to created views (#194)", {
   expect_silent(isolate(board_block_ids(forwarded$board)))
 })
 
-test_that("reconcile_views never pushes a layout back to a live dock (#259)", {
+test_that("reconcile_views skips an added panel pending its echo (#196)", {
 
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
@@ -719,33 +719,31 @@ test_that("reconcile_views never pushes a layout back to a live dock (#259)", {
     sendCustomMessage = function(type, message) invisible()
   )
 
-  # board_layouts carries `a` + `b` for view V while the live dock's tracked
-  # membership is only `a`: the committed board and the live dock have diverged.
-  # A view's arrangement is client-owned and flows dock -> board only, so
-  # reconcile must never restore the dock from board_layouts. That board -> dock
-  # push -- restore_dock faithfully replaying a board_layouts that lagged the
-  # live dock -- is exactly the feedback loop that tore panels down on a slow
-  # client (#252). Pre-#259 this divergence drove apply_layout_diff ->
-  # restore_layout; now nothing pushes.
+  # board_layouts holds both panels synchronously (the block-add fold) and the
+  # proxy's live_panels tracker has caught `b` from insert_block_ui, but the
+  # browser has not yet echoed `b` back through get_dock. reconcile must not
+  # restore here: membership agrees, so the only apparent difference is the
+  # not-yet-echoed panel insert_block_ui already placed -- restoring would wipe
+  # it (#196).
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
     layouts = list(V = dock_layout("a", "b"))
   )
   board <- with_mock_context(ms, reactiveValues(board = brd))
 
-  behind_ids <- layout_panel_ids(
-    board_layouts(
-      new_dock_board(
-        blocks = c(a = new_dataset_block()),
-        layouts = list(V = dock_layout("a"))
-      )
-    )[["V"]]
-  )
+  target_ids <- layout_panel_ids(board_layouts(brd)[["V"]])
+
+  behind <- board_layouts(
+    new_dock_board(
+      blocks = c(a = new_dataset_block()),
+      layouts = list(V = dock_layout("a"))
+    )
+  )[["V"]]
 
   docks <- with_mock_context(ms, reactiveValues())
   docks[["V"]] <- list(
-    layout = function() NULL,
-    live_panels = with_mock_context(ms, reactiveVal(behind_ids))
+    layout = function() behind,
+    live_panels = with_mock_context(ms, reactiveVal(target_ids))
   )
 
   client_views <- with_mock_context(
@@ -756,7 +754,7 @@ test_that("reconcile_views never pushes a layout back to a live dock (#259)", {
   active_dock <- with_mock_context(ms, reactiveValues())
   update <- with_mock_context(ms, reactiveVal())
 
-  restored <- 0L
+  diffed <- 0L
 
   with_mocked_bindings(
     with_mock_context(
@@ -766,12 +764,118 @@ test_that("reconcile_views never pushes a layout back to a live dock (#259)", {
         session
       )
     ),
-    restore_layout = function(...) restored <<- restored + 1L,
+    apply_layout_diff = function(...) diffed <<- diffed + 1L,
     switch_active_view = function(...) invisible(),
     .package = "blockr.dock"
   )
 
-  expect_identical(restored, 0L)
+  expect_identical(diffed, 0L)
+})
+
+test_that("reconcile_views pushes a programmatic membership change", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  session <- list(
+    ns = identity,
+    sendInputMessage = function(input_id, message) invisible(),
+    sendCustomMessage = function(type, message) invisible()
+  )
+
+  # board_layouts now carries `a` + `b`, but the dock's tracked membership is
+  # only `a`: a programmatic views$mod added `b`'s panel with no live op, so
+  # reconcile must push the new layout to the dock and record the new set.
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(V = dock_layout("a", "b"))
+  )
+  board <- with_mock_context(ms, reactiveValues(board = brd))
+
+  target <- board_layouts(brd)[["V"]]
+
+  behind_ids <- layout_panel_ids(
+    board_layouts(
+      new_dock_board(
+        blocks = c(a = new_dataset_block()),
+        layouts = list(V = dock_layout("a"))
+      )
+    )[["V"]]
+  )
+
+  live_panels <- with_mock_context(ms, reactiveVal(behind_ids))
+
+  docks <- with_mock_context(ms, reactiveValues())
+  docks[["V"]] <- list(
+    layout = function() NULL,
+    live_panels = live_panels
+  )
+
+  client_views <- with_mock_context(
+    ms,
+    reactiveVal(seed_view_state(board_layouts(brd)))
+  )
+  client_active <- with_mock_context(ms, reactiveVal("V"))
+  active_dock <- with_mock_context(ms, reactiveValues())
+  update <- with_mock_context(ms, reactiveVal())
+
+  captured <- NULL
+
+  with_mocked_bindings(
+    with_mock_context(
+      ms,
+      reconcile_views(
+        board, update, docks, active_dock, client_active, client_views,
+        session
+      )
+    ),
+    apply_layout_diff = function(view, target, ...) {
+      captured <<- list(view = view, target = target)
+    },
+    switch_active_view = function(...) invisible(),
+    .package = "blockr.dock"
+  )
+
+  expect_false(is.null(captured))
+  expect_identical(captured$view, "V")
+  expect_true(layouts_match(captured$target, target))
+
+  # The push records the new membership, so a later pass is a no-op.
+  expect_setequal(isolate(live_panels()), layout_panel_ids(target))
+})
+
+test_that("the live-sync fold keeps only settled client echoes", {
+
+  # Folding the wrong echo loops or wipes the view. A server-origin echo is a
+  # board -> dock push reporting itself, so folding it re-commits the push. An
+  # echo whose membership is behind the dock's `live_panels` tracker is a
+  # transient paint, so folding it commits an impoverished layout the push then
+  # restores -- wiping the view. Only a settled client gesture -- "client" with
+  # membership matching the tracker -- folds.
+  tracked <- layout_panel_ids(dock_layout("a", "b"))
+
+  docks <- list(
+    server = list(
+      source = function() "server",
+      live_panels = function() tracked
+    ),
+    lagging = list(
+      source = function() "client",
+      live_panels = function() tracked
+    ),
+    settled = list(
+      source = function() "client",
+      live_panels = function() tracked
+    )
+  )
+
+  mod <- list(
+    server = dock_layout("a", "b"),
+    lagging = dock_layout("a"),
+    settled = dock_layout("a", "b")
+  )
+
+  expect_named(keep_foldable(mod, docks), "settled")
 })
 
 test_that("apply_board_update.dock_board switches active view", {

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -571,6 +571,71 @@ test_that("dock panel move updates layout state and serialization (#234)", {
   )
 })
 
+test_that("a focus change lands in layout state and serialization (#271)", {
+
+  skip_on_cran()
+
+  app <- shinytest2::AppDriver$new(
+    system.file("examples", "focus", "app.R", package = "blockr.dock"),
+    name = "focus-persist",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 20 * 1000
+  )
+  withr::defer(app$stop())
+
+  wait_dock_loaded(app, n_blocks = 2)
+  dock <- paste0("my_board-", read_dock_state(app)$active_view, "-dock")
+
+  read_layout <- function() {
+    dockview_to_layout(app$get_value(input = paste0(dock, "_state")))
+  }
+
+  await_groups <- function(n) {
+    app$wait_for_js(
+      paste0(
+        "HTMLWidgets.find('#", dock, "')",
+        ".getWidget().groups.length === ", n
+      ),
+      timeout = 15 * 1000
+    )
+    app$wait_for_idle()
+  }
+
+  # Activating a panel is a pure focus change -- no structural rearrangement.
+  # It reaches the live dockview API directly, the client path a real tab
+  # click takes, so the echo is reported as a "client" gesture.
+  activate <- function(panel) {
+    app$run_js(
+      paste0(
+        "HTMLWidgets.find('#", dock, "')",
+        ".getWidget().getPanel('", panel, "').api.setActive();"
+      )
+    )
+    app$wait_for_idle()
+  }
+
+  await_groups(2L)
+
+  # Focus a panel in each group in turn: the focused panel the client reports
+  # through `_state` moves with the activation. A pure focus change must still
+  # turn `_state` over -- the board owns arrangement, but focus stays live on
+  # the wire, or a tab click is lost on save.
+  activate("block_panel-a")
+  focus_a <- layout_to_spec(read_layout())[["focus"]]
+
+  activate("block_panel-b")
+  layout_b <- read_layout()
+  focus_b <- layout_to_spec(layout_b)[["focus"]]
+
+  expect_identical(focus_b, "block_panel-b")
+  expect_false(identical(focus_a, focus_b))
+
+  # The dock-owned serializer round-trips the focused panel.
+  reparsed <- layout_from_json(layout_to_json(layout_b))
+  expect_identical(layout_to_spec(reparsed)[["focus"]], "block_panel-b")
+})
+
 test_that("locked board hides block actions, shows lock indicator (#236)", {
 
   skip_on_cran()


### PR DESCRIPTION
Restores the board→dock arrangement push that #259 removed, made safe by a provenance + membership fold guard (`keep_foldable`) — so the board, not the client, is the authoritative owner of dock arrangement. The consumer side of the dockViewR `_state-source` provenance work.

Closes #273

Settles the dock-arrangement direction as server-owned: it supersedes #273 (the client-owned object split) and conflicts with #265 (which retires the `layouts_to_board_observer` fold this PR relies on — only one of the two can land).

dockViewR is pinned to `cynkra/dockViewR@76-set-size`. Before merge: land that stack, drop the pin, and bump `Imports: dockViewR (>= 0.3.0)`.
