### PR TITLE
Align the link editor with core's name-or-position variadic inputs

### DIFF
--- a/R/action-utils.R
+++ b/R/action-utils.R
@@ -52,6 +52,8 @@ block_input_select <- function(block = NULL, block_id = NULL, links = NULL,
 
     if (is.na(block_arity(block))) {
 
+      inps <- c(inps, "")
+
       opts <- list(create = TRUE)
 
     } else if (length(inps)) {

--- a/R/action-utils.R
+++ b/R/action-utils.R
@@ -52,22 +52,6 @@ block_input_select <- function(block = NULL, block_id = NULL, links = NULL,
 
     if (is.na(block_arity(block))) {
 
-      num <- suppressWarnings(as.integer(curr))
-      nna <- is.na(num)
-
-      if (all(nna)) {
-        inps <- c(inps, "1")
-      } else {
-        num <- num[!nna]
-        max <- max(num)
-        mis <- setdiff(seq_len(max), num)
-        if (length(mis)) {
-          inps <- c(inps, as.character(min(mis)))
-        } else {
-          inps <- c(inps, as.character(max + 1L))
-        }
-      }
-
       opts <- list(create = TRUE)
 
     } else if (length(inps)) {

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -448,17 +448,11 @@ dt_board_link <- function(lnk, ns, board) {
     names(to_avail)[to_avail > 0L]
   )
 
-  cnt_to <- table(lnk$to)[names(blks[is.na(arity)])]
-  cnt_to[is.na(cnt_to)] <- 0L
-
-  cur_inp <- split(lnk$input, lnk$to)
-
   in_avail <- c(
     lapply(blks[!is.na(arity)], block_inputs),
-    Map(
-      union,
-      lapply(lapply(cnt_to, seq_len), as.character),
-      cur_inp[names(cnt_to)]
+    set_names(
+      rep(list(character()), sum(is.na(arity))),
+      names(arity)[is.na(arity)]
     )
   )
 
@@ -597,7 +591,7 @@ create_dt_link_obs <- function(ids, upd, ...) {
             hit <- upd$curr$to == new
 
             if (is.na(ary)) {
-              inp <- as.character(sum(hit) + 1L)
+              inp <- character()
               opt <- list(create = TRUE)
             } else {
               inp <- setdiff(block_inputs(blk), upd$curr$input[hit])

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -448,12 +448,11 @@ dt_board_link <- function(lnk, ns, board) {
     names(to_avail)[to_avail > 0L]
   )
 
+  cur_inp <- lapply(split(lnk$input, lnk$to), filter_empty)
+
   in_avail <- c(
     lapply(blks[!is.na(arity)], block_inputs),
-    set_names(
-      rep(list(character()), sum(is.na(arity))),
-      names(arity)[is.na(arity)]
-    )
+    cur_inp[intersect(names(cur_inp), names(arity)[is.na(arity)])]
   )
 
   rm_inp <- lapply(
@@ -591,7 +590,7 @@ create_dt_link_obs <- function(ids, upd, ...) {
             hit <- upd$curr$to == new
 
             if (is.na(ary)) {
-              inp <- character()
+              inp <- filter_empty(upd$curr[[row]][["input"]])
               opt <- list(create = TRUE)
             } else {
               inp <- setdiff(block_inputs(blk), upd$curr$input[hit])

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -553,7 +553,7 @@ create_dt_link_obs <- function(ids, upd, ...) {
         new <- input[[inp]]
         cur <- upd$curr[[row]][[col]]
 
-        if (new == cur || new == "") {
+        if (new == cur || (new == "" && col != "input")) {
           return()
         }
 

--- a/tests/testthat/test-action-utils.R
+++ b/tests/testthat/test-action-utils.R
@@ -7,5 +7,5 @@ test_that("action utils", {
     mode = "inputs"
   )
 
-  expect_identical(inps, character())
+  expect_identical(inps, "")
 })

--- a/tests/testthat/test-action-utils.R
+++ b/tests/testthat/test-action-utils.R
@@ -7,5 +7,5 @@ test_that("action utils", {
     mode = "inputs"
   )
 
-  expect_identical(inps, "1")
+  expect_identical(inps, character())
 })

--- a/tests/testthat/test-ext-edit.R
+++ b/tests/testthat/test-ext-edit.R
@@ -760,3 +760,32 @@ test_that("a named variadic link input renders as the selected option", {
   expect_match(dt$Input[[1L]], "value=\"left\"[^>]*selected")
   expect_false(grepl("value=\"left\"", dt$Input[[2L]]))
 })
+
+test_that("clearing a variadic link's name stages a positional edit", {
+
+  board_rv <- reactiveValues(
+    board = new_dock_board(
+      blocks = c(
+        a = new_dataset_block("BOD"),
+        b = new_dataset_block("BOD"),
+        c = new_rbind_block()
+      ),
+      links = links(ac = new_link("a", "c", "left"))
+    )
+  )
+
+  testServer(
+    blk_ext_srv,
+    {
+      session$flushReact()
+
+      session$setInputs(ac_input = "")
+      session$flushReact()
+
+      expect_length(upd$add, 1L)
+      expect_identical(upd$add[["ac"]][["input"]], "")
+      expect_true("ac" %in% upd$rm)
+    },
+    args = list(board = board_rv, update = reactiveVal())
+  )
+})

--- a/tests/testthat/test-ext-edit.R
+++ b/tests/testthat/test-ext-edit.R
@@ -743,3 +743,20 @@ test_that("variadic link inputs offer no positional-integer options", {
   expect_false(grepl("<option[^>]*value=\"[0-9]", dt$Input[[1L]]))
   expect_false(grepl("<option[^>]*value=\"[0-9]", dt$Input[[2L]]))
 })
+
+test_that("a named variadic link input renders as the selected option", {
+
+  board <- new_dock_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      b = new_dataset_block("BOD"),
+      c = new_rbind_block()
+    ),
+    links = links(ac = new_link("a", "c", "left"), bc = new_link("b", "c", ""))
+  )
+
+  dt <- dt_board_link(board_links(board), NS("x"), board)
+
+  expect_match(dt$Input[[1L]], "value=\"left\"[^>]*selected")
+  expect_false(grepl("value=\"left\"", dt$Input[[2L]]))
+})

--- a/tests/testthat/test-ext-edit.R
+++ b/tests/testthat/test-ext-edit.R
@@ -726,3 +726,20 @@ test_that("dummy edit extension ui test", {
   expect_s3_class(ui, "shiny.tag")
   expect_identical(htmltools::tagGetAttribute(ui, "class"), "blockr-ext-edit")
 })
+
+test_that("variadic link inputs offer no positional-integer options", {
+
+  board <- new_dock_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      b = new_dataset_block("BOD"),
+      c = new_rbind_block()
+    ),
+    links = links(ac = new_link("a", "c"), bc = new_link("b", "c"))
+  )
+
+  dt <- dt_board_link(board_links(board), NS("x"), board)
+
+  expect_false(grepl("<option[^>]*value=\"[0-9]", dt$Input[[1L]]))
+  expect_false(grepl("<option[^>]*value=\"[0-9]", dt$Input[[2L]]))
+})


### PR DESCRIPTION
## Summary

- blockr.core#211 makes a variadic link's `input` a genuine optional name (empty means positional, order given by link order) and drops the integer `...args` convention. blockr.dock carries its own copy of the link editor and variadic input-option logic, both still encoding that convention — against the new core they name what should be positional.
- `dt_board_link()` and its input observer no longer offer `seq_len` integers as input choices or auto-number the next slot; the Input field is now free text — a name, or empty for a positional slot.
- The variadic branch of `block_input_select()` drops the next-integer suggestion, keeping free-text entry.
- This mirrors the two core#211 editor commits ("Drop the integer `...args` convention for name-or-position slots" and "Stop the link editor from suggesting integer input names"). The new regression asserts a variadic target's input choices carry no positional-integer options.

Stacked on #201, which pins `blockr.core#211`; retarget to `main` once #201 and core#211 land.

Fixes #275
