### PR TITLE
Preserve staged link and stack edits when the board re-emits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # blockr.dock (development version)
 
+* The "Edit board" extension no longer loses unsaved link and stack edits
+  when the board reactive re-emits (#277). Two observers reset the staged
+  working copy (`upd$curr` / `stk$curr`) to the board's applied links and
+  stacks on every re-emit, so a staged row vanished from the table while
+  its half-filled entry lingered in `upd$add` and later failed apply with
+  "Expecting all links to refer to known block IDs". A layout change in an
+  adjacent panel group is enough to re-emit the board, which is why #201
+  surfaced this. The refresh now overlays the staged additions, edits and
+  removals onto the refreshed applied state instead of clobbering them.
+
 * The dock no longer loops forever or tears its panels down on a slow
   client (#252). The live layout was held in two bindings that formed a
   cycle: the live-sync fold pushed the dockview client's state into

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -176,7 +176,9 @@ blk_ext_srv <- function(id, board, update, ...) {
       observeEvent(
         board_links(board$board),
         {
-          upd$curr <- board_links(board$board)
+          upd$curr <- merge_staged_links(
+            board_links(board$board), upd$add, upd$rm
+          )
         }
       )
 
@@ -206,7 +208,9 @@ blk_ext_srv <- function(id, board, update, ...) {
       observeEvent(
         board_stacks(board$board),
         {
-          stk$curr <- board_stacks(board$board)
+          stk$curr <- merge_staged_stacks(
+            board_stacks(board$board), stk$add, stk$rm, stk$mod
+          )
         }
       )
 
@@ -719,6 +723,20 @@ edit_link_observer <- function(upd, rv) {
   )
 }
 
+merge_staged_links <- function(applied, add, rm) {
+
+  keep <- setdiff(names(applied), setdiff(rm, names(add)))
+  out <- applied[keep]
+
+  edited <- intersect(keep, names(add))
+
+  if (length(edited)) {
+    out[edited] <- add[edited]
+  }
+
+  c(out, add[setdiff(names(add), names(applied))])
+}
+
 add_link_observer <- function(input, rv, upd, sess) {
 
   observeEvent(
@@ -1169,6 +1187,20 @@ edit_stack_observer <- function(upd, rv) {
       }
     }
   )
+}
+
+merge_staged_stacks <- function(applied, add, rm, mod) {
+
+  keep <- setdiff(names(applied), rm)
+  out <- applied[keep]
+
+  modded <- intersect(keep, names(mod))
+
+  if (length(modded)) {
+    out[modded] <- mod[modded]
+  }
+
+  c(out, add[setdiff(names(add), names(applied))])
 }
 
 add_stack_observer <- function(input, rv, upd, sess) {

--- a/tests/testthat/test-ext-edit.R
+++ b/tests/testthat/test-ext-edit.R
@@ -437,6 +437,180 @@ test_that("edit extension applies links and stacks together", {
   )
 })
 
+test_that("merge_staged_links overlays staged edits on refreshed links", {
+
+  applied <- links(
+    l1 = new_link(from = "a", to = "c", input = "1"),
+    l2 = new_link(from = "b", to = "c", input = "2")
+  )
+
+  expect_identical(
+    merge_staged_links(applied, links(), character()),
+    applied
+  )
+
+  added <- links(x = new_link(from = "", to = "", input = ""))
+  expect_identical(
+    merge_staged_links(applied, added, character()),
+    c(applied, added)
+  )
+
+  edited <- links(l1 = new_link(from = "a", to = "c", input = "9"))
+  in_place <- applied
+  in_place["l1"] <- edited
+  expect_identical(merge_staged_links(applied, edited, "l1"), in_place)
+
+  expect_named(merge_staged_links(applied, links(), "l2"), "l1")
+
+  expect_named(
+    merge_staged_links(applied["l1"], added, character()),
+    c("l1", "x")
+  )
+})
+
+test_that("merge_staged_stacks overlays staged edits on refreshed stacks", {
+
+  applied <- stacks(
+    k1 = new_dock_stack(name = "One", color = "#111111"),
+    k2 = new_dock_stack(name = "Two", color = "#222222")
+  )
+
+  expect_identical(
+    merge_staged_stacks(applied, stacks(), character(), stacks()),
+    applied
+  )
+
+  added <- stacks(z = new_dock_stack(name = "Zed", color = "#333333"))
+  expect_identical(
+    merge_staged_stacks(applied, added, character(), stacks()),
+    c(applied, added)
+  )
+
+  modded <- stacks(k1 = new_dock_stack(name = "Renamed", color = "#999999"))
+  in_place <- applied
+  in_place[["k1"]] <- modded[["k1"]]
+  expect_identical(
+    merge_staged_stacks(applied, stacks(), character(), modded),
+    in_place
+  )
+
+  expect_named(
+    merge_staged_stacks(applied, added, "k2", stacks()),
+    c("k1", "z")
+  )
+})
+
+test_that("edit extension keeps staged link edits when the board re-emits", {
+
+  testServer(
+    blk_ext_srv,
+    {
+      session$flushReact()
+
+      session$setInputs(add_link = 1)
+      session$flushReact()
+
+      row <- names(upd$add)
+      expect_length(upd$curr, 1L)
+      expect_identical(names(upd$curr), row)
+
+      board$board <- new_dock_board(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_dataset_block("mtcars"),
+          c = new_rbind_block()
+        )
+      )
+      session$flushReact()
+
+      expect_length(upd$curr, 1L)
+      expect_identical(names(upd$curr), row)
+      expect_identical(upd$add, upd$curr[row])
+
+      upd$edit <- list(row = row, col = "from", val = "a")
+      session$flushReact()
+      upd$edit <- list(row = row, col = "to", val = "c")
+      session$flushReact()
+      upd$edit <- list(row = row, col = "input", val = "1")
+      session$flushReact()
+
+      session$setInputs(add_link = 2)
+      session$flushReact()
+
+      row2 <- setdiff(names(upd$curr), row)
+      upd$edit <- list(row = row2, col = "from", val = "b")
+      session$flushReact()
+      upd$edit <- list(row = row2, col = "to", val = "c")
+      session$flushReact()
+      upd$edit <- list(row = row2, col = "input", val = "2")
+      session$flushReact()
+
+      session$setInputs(apply_changes = 1)
+
+      res <- update()$links
+
+      expect_s3_class(res$add, "links")
+      expect_length(res$add, 2L)
+    },
+    args = list(
+      board = board_args(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_dataset_block("mtcars"),
+          c = new_rbind_block()
+        )
+      ),
+      update = reactiveVal()
+    )
+  )
+})
+
+test_that("edit extension keeps staged stack edits when the board re-emits", {
+
+  testServer(
+    blk_ext_srv,
+    {
+      session$flushReact()
+
+      session$setInputs(new_stack_id = "s1", add_stack = 1)
+      session$flushReact()
+
+      stk$edit <- list(row = "s1", col = "blocks", val = "a")
+      session$flushReact()
+
+      expect_named(stk$add, "s1")
+      expect_true("s1" %in% names(stk$curr))
+
+      board$board <- new_dock_board(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        )
+      )
+      session$flushReact()
+
+      expect_true("s1" %in% names(stk$curr))
+      expect_named(stk$add, "s1")
+      expect_identical(stk$curr[["s1"]], stk$add[["s1"]])
+
+      session$setInputs(apply_changes = 1)
+
+      res <- update()$stacks
+
+      expect_named(res$add, "s1")
+    },
+    args = list(
+      board = board_args(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        )
+      ),
+      update = reactiveVal()
+    )
+  )
+})
+
 test_that("dummy edit extension ui test", {
 
   ui <- blk_ext_ui(


### PR DESCRIPTION
## Summary

- The "Edit board" extension's two board-sync observers reset the staged working copy (`upd$curr` / `stk$curr`) to the board's *applied* links/stacks on every re-emit of `board$board`. A layout change in an adjacent panel group is enough to re-emit the board (surfaced by #201), so an in-progress row vanished from the table while its half-filled entry lingered in `upd$add`/`stk$add` and later failed Apply with "Expecting all links to refer to known block IDs".
- The refresh now overlays the staged `add`/`rm`/`mod` deltas onto the refreshed applied state (`merge_staged_links` / `merge_staged_stacks`) rather than clobbering it. When the applied links/stacks are unchanged the merge reconstructs an `identical()` object, so `reactiveValues` deduplicates and the table isn't rebuilt; a genuine external change still flows through with staged edits preserved in place.
- Regression coverage: `testServer` tests asserting staged link and stack edits survive a fresh-object board re-emit (verified to fail against the unfixed observers), plus direct unit tests for the merge helpers across the no-op, add, edit-in-place, remove, and external-change branches.

Fixes #277
