### PR TITLE
Redraw the manage-links table only when its id set changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # blockr.dock (development version)
 
+* The "Edit board" extension no longer flickers the manage-links table's
+  cell selectize inputs on a board re-emit (#279). The observer that keeps
+  the table in sync re-rendered every row whenever `upd$curr` was reset --
+  `observeEvent(names(upd$curr))` fires on each invalidation, not only when
+  the link ids change -- and the redundant `DT::replaceData` unbound and
+  rebound the From / To / Input inputs, briefly blanking a selectize until
+  the async redraw landed. A panel switch re-emits the board (via #201), so
+  plain navigation churned the table. The table now redraws only when the
+  set of link ids actually changes; value edits and no-op re-emits are
+  skipped, while applying staged changes still redraws through its own path.
+
 * The "Edit board" extension no longer loses unsaved link and stack edits
   when the board reactive re-emits (#277). Two observers reset the staged
   working copy (`upd$curr` / `stk$curr`) to the board's applied links and

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -682,6 +682,10 @@ create_link_obs_observer <- function(input, rv, upd, session, proxy) {
     {
       ids <- names(upd$curr)
 
+      if (setequal(ids, names(upd$obs))) {
+        return()
+      }
+
       DT::replaceData(
         proxy,
         dt_board_link(upd$curr, session$ns, rv$board),

--- a/tests/testthat/test-ext-edit.R
+++ b/tests/testthat/test-ext-edit.R
@@ -565,6 +565,54 @@ test_that("edit extension keeps staged link edits when the board re-emits", {
   )
 })
 
+test_that("edit extension redraws links only when the id set changes", {
+
+  redraws <- 0L
+
+  local_mocked_bindings(
+    replaceData = function(...) redraws <<- redraws + 1L,
+    .package = "DT"
+  )
+
+  testServer(
+    blk_ext_srv,
+    {
+      session$flushReact()
+
+      expect_identical(names(upd$curr), "aa")
+      expect_setequal(names(upd$obs), "aa")
+
+      base <- redraws
+
+      upd$curr <- links(aa = new_link(from = "a", to = ""))
+      session$flushReact()
+
+      expect_identical(names(upd$curr), "aa")
+      expect_identical(redraws, base)
+      expect_setequal(names(upd$obs), "aa")
+
+      upd$curr <- links(
+        aa = new_link(from = "a", to = ""),
+        bb = new_link(from = "b", to = "")
+      )
+      session$flushReact()
+
+      expect_gt(redraws, base)
+      expect_setequal(names(upd$obs), c("aa", "bb"))
+    },
+    args = list(
+      board = board_args(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        ),
+        links = links(aa = new_link(from = "a", to = "b"))
+      ),
+      update = reactiveVal()
+    )
+  )
+})
+
 test_that("edit extension keeps staged stack edits when the board re-emits", {
 
   testServer(


### PR DESCRIPTION
## Summary

- `create_link_obs_observer` re-rendered the whole manage-links table on every board re-emit: `observeEvent(names(upd$curr))` fires on each `upd$curr` invalidation, not only when the link ids change.
- A panel switch re-emits `board_links` (via #201), so plain navigation re-ran `DT::replaceData`, which unbound and rebound the cell selectizes and briefly blanked their To / From / Input values.
- Guard the redraw on `setequal(ids, names(upd$obs))`: adds and removes still change the id set and redraw, while value edits and no-op re-emits are skipped. Applying staged changes still redraws through its own path in `apply_changes_observer`.
- Regression test drives a same-id `upd$curr` re-emit and asserts no redundant `DT::replaceData`; it fails without the guard and passes with it.

blockr.core's manage-links plugin carries the identical observer (`plugin-links.R`, `create_link_obs_observer`) and wants the same guard — worth a follow-up there.

Fixes #279
