### PR TITLE
Narrow edit-board sync to actual link and stack changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # blockr.dock (development version)
 
+* The "Edit board" extension now re-syncs its staged working copy only
+  when the board's links or stacks actually change, not on every board
+  re-emit (#281). The two observers keying `upd$curr` / `stk$curr` off
+  `board_links()` / `board_stacks()` fired on each board invalidation --
+  `observeEvent` does not value-dedupe -- so a benign dock interaction (a
+  panel switch or view fold, which re-emits the board via #201) churned
+  the editor's working copy even when no link or stack changed. A
+  `reactiveVal` + `identical()` guard now gates each re-sync on a real
+  change, so the #277 and #279 guards become defensive rather than
+  load-bearing.
+
 * The "Edit board" extension no longer flickers the manage-links table's
   cell selectize inputs on a board re-emit (#279). The observer that keeps
   the table in sync re-rendered every row whenever `upd$curr` was reset --

--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -173,12 +173,12 @@ blk_ext_srv <- function(id, board, update, ...) {
         edit = NULL
       )
 
+      applied_links <- deduped_board_reactive(board, board_links)
+
       observeEvent(
-        board_links(board$board),
+        applied_links(),
         {
-          upd$curr <- merge_staged_links(
-            board_links(board$board), upd$add, upd$rm
-          )
+          upd$curr <- merge_staged_links(applied_links(), upd$add, upd$rm)
         }
       )
 
@@ -205,11 +205,13 @@ blk_ext_srv <- function(id, board, update, ...) {
         edit = NULL
       )
 
+      applied_stacks <- deduped_board_reactive(board, board_stacks)
+
       observeEvent(
-        board_stacks(board$board),
+        applied_stacks(),
         {
           stk$curr <- merge_staged_stacks(
-            board_stacks(board$board), stk$add, stk$rm, stk$mod
+            applied_stacks(), stk$add, stk$rm, stk$mod
           )
         }
       )
@@ -235,6 +237,23 @@ blk_ext_srv <- function(id, board, update, ...) {
       NULL
     }
   )
+}
+
+deduped_board_reactive <- function(board, accessor) {
+
+  val <- reactiveVal(isolate(accessor(board$board)))
+
+  observe(
+    {
+      new <- accessor(board$board)
+
+      if (!identical(new, isolate(val()))) {
+        val(new)
+      }
+    }
+  )
+
+  val
 }
 
 add_block_observer <- function(input, board, update, session) {

--- a/tests/testthat/test-ext-edit.R
+++ b/tests/testthat/test-ext-edit.R
@@ -659,6 +659,63 @@ test_that("edit extension keeps staged stack edits when the board re-emits", {
   )
 })
 
+test_that("edit extension ignores no-op board re-emits", {
+
+  link_syncs <- 0L
+  stack_syncs <- 0L
+
+  real_merge_links <- merge_staged_links
+  real_merge_stacks <- merge_staged_stacks
+
+  local_mocked_bindings(
+    merge_staged_links = function(...) {
+      link_syncs <<- link_syncs + 1L
+      real_merge_links(...)
+    },
+    merge_staged_stacks = function(...) {
+      stack_syncs <<- stack_syncs + 1L
+      real_merge_stacks(...)
+    }
+  )
+
+  testServer(
+    blk_ext_srv,
+    {
+      session$flushReact()
+
+      expect_gt(link_syncs, 0L)
+      expect_gt(stack_syncs, 0L)
+
+      link_base <- link_syncs
+      stack_base <- stack_syncs
+
+      board$board <- new_dock_board(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        ),
+        links = links(aa = new_link(from = "a", to = "b")),
+        stacks = stacks(s1 = new_dock_stack(blocks = "a", name = "One"))
+      )
+      session$flushReact()
+
+      expect_identical(link_syncs, link_base)
+      expect_identical(stack_syncs, stack_base)
+    },
+    args = list(
+      board = board_args(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        ),
+        links = links(aa = new_link(from = "a", to = "b")),
+        stacks = stacks(s1 = new_dock_stack(blocks = "a", name = "One"))
+      ),
+      update = reactiveVal()
+    )
+  )
+})
+
 test_that("dummy edit extension ui test", {
 
   ui <- blk_ext_ui(


### PR DESCRIPTION
## Summary

- The edit-board extension's two board-sync observers keyed off `board_links()` / `board_stacks()` re-fired on *every* board re-emit — `observeEvent` does not value-dedupe — so a benign dock interaction that re-emits the board with unchanged links (a panel switch or view fold, which now folds live layout changes back into board state) churned the editor's staged working copy even when no link or stack changed.
- This over-subscription is the shared root of #277 (the re-sync reset `upd$curr`, dropping in-progress staged edits) and #279 (the reset re-fired the manage-links DT redraw and flickered the cell selectizes); both were point-fixes at the symptoms.
- `deduped_board_reactive()` now wraps a board accessor in a `reactiveVal` + `identical()` guard and keys each re-sync off the deduped value, so a `views` fold that leaves the links / stacks untouched never reaches the editor. The handler still reads `upd$add` / `upd$rm` non-reactively, as before.
- With no-op re-emits filtered out, the #277 (`merge_staged_*`) and #279 (`setequal`) guards become defensive rather than load-bearing.

The regression test drives a fresh board with byte-identical links and stacks through the extension and asserts neither sync handler fires; it fails against the pre-fix observers (each fires on the no-op re-emit) and passes with the guard.

Fixes #281
