### PR TITLE
Guard manage-stacks redraw on the id set

### DIFF
--- a/R/ext-edit.R
+++ b/R/ext-edit.R
@@ -1158,6 +1158,10 @@ create_stack_obs_observer <- function(input, rv, upd, session, proxy) {
     {
       ids <- names(upd$curr)
 
+      if (setequal(ids, names(upd$obs))) {
+        return()
+      }
+
       DT::replaceData(
         proxy,
         dt_board_stack(upd$curr, session$ns, rv$board),


### PR DESCRIPTION
## Summary

- create_stack_obs_observer re-rendered the whole manage-stacks table on every board re-emit, flickering the Name/Color/Blocks cell inputs.
- Mirror the #279 fix for the links table: skip the replaceData when the stack id set is unchanged, so value edits and no-op re-emits no longer unbind the cell inputs.
- Add/remove still change the id set and reconcile the cell observers; apply_changes_observer issues its own replaceData for applied stacks.

Fixes #282