### PR TITLE
Scope the busy pulse to real computation, not panel switches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # blockr.dock (development version)
 
+* The busy pulse no longer flashes on a plain panel switch, only on real
+  computation (#285). `serve()` enables shiny's page pulse
+  (`useBusyIndicators(pulse = TRUE)`), which shows on any server-busy flush --
+  and a panel switch round-trips to the server (the on-screen visibility report
+  and the layout fold) without recomputing a visible output, so the pulse fired
+  for what is only layout bookkeeping. A CSS rule now gates the pulse on a
+  genuinely recalculating output inside the visible view container: startup and
+  block evaluation still pulse, a bare panel switch does not. A block still
+  pending evaluation in the (hidden) offcanvas pool sits outside the container,
+  so it never forces the pulse either.
+
 * The "Edit board" extension now re-syncs its staged working copy only
   when the board's links or stacks actually change, not on every board
   re-emit (#281). The two observers keying `upd$curr` / `stk$curr` off

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -1109,3 +1109,22 @@ label:has(input[type="file"]) {
   border-color: #15803d;
   color: #ffffff;
 }
+
+/* ============================================
+   Busy pulse — scope to real computation
+   ============================================ */
+
+/* Shiny's page pulse (enabled in serve() via useBusyIndicators(pulse = TRUE))
+   shows whenever the session is busy, i.e. on any observer flush. A plain panel
+   switch round-trips to the server -- the on-screen visibility report and the
+   layout fold -- without recomputing any visible output, so the pulse would
+   fire for what is only layout bookkeeping. Gate it on a genuinely
+   recalculating output inside the visible view container: block evaluation
+   marks its output "recalculating" there, bookkeeping does not. Scoping to the
+   view container is deliberate -- an off-screen block parked in the (hidden)
+   offcanvas pool stays "recalculating" while it waits for evaluation, and that
+   pool sits outside the container, so a pending hidden block never forces the
+   pulse. Startup and real recompute still pulse; a bare panel switch does not. */
+html[data-shiny-busy-pulse].shiny-busy:not(:has(.blockr-view-container .recalculating))::after {
+  display: none;
+}

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -647,3 +647,77 @@ test_that("single-page board renders one auto-named view (#236)", {
   expect_true(docks$active)
   expect_identical(docks$id, nav$id)
 })
+
+test_that("busy pulse tracks real work, not layout bookkeeping (#285)", {
+
+  skip_on_cran()
+
+  app <- shinytest2::AppDriver$new(
+    system.file("examples", "multi-view", "app.R", package = "blockr.dock"),
+    name = "busy-pulse",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 20 * 1000
+  )
+  withr::defer(app$stop())
+
+  app$wait_for_idle()
+
+  # serve() opts the dock into shiny's page pulse. A panel switch marks the
+  # session busy (the visibility report and layout fold round-trips) without
+  # recomputing a visible output, so the pulse would fire for what is only
+  # layout bookkeeping; block evaluation marks its output `.recalculating`
+  # inside the view container. The live pulse is a sub-second transient, racy
+  # to sample, so drive the two busy states directly and read the pulse
+  # pseudo-element's computed display (fixed positioning blockifies it when
+  # shown, so a visible pulse is "block"). The recalculating element is placed
+  # outside the view container (a hidden block still pending evaluation in the
+  # offcanvas pool) versus inside it (real visible work) to pin the scope.
+  probe <- jsonlite::fromJSON(
+    app$get_js(
+      r"(JSON.stringify((function () {
+        var html = document.documentElement;
+        var pulse = function () {
+          return getComputedStyle(html, '::after').display;
+        };
+        var mark = function (parent) {
+          var el = document.createElement('div');
+          el.className = 'recalculating';
+          parent.appendChild(el);
+          return el;
+        };
+
+        var enabled = html.dataset.shinyBusyPulse === 'true';
+        var container = document.querySelector('.blockr-view-container');
+        html.classList.add('shiny-busy');
+
+        var hidden = mark(document.body);
+        var bookkeeping = pulse();
+        hidden.remove();
+
+        var visible = mark(container);
+        var computing = pulse();
+        visible.remove();
+
+        html.classList.remove('shiny-busy');
+
+        return {
+          enabled: enabled, hasContainer: container !== null,
+          bookkeeping: bookkeeping, computing: computing
+        };
+      })()))"
+    )
+  )
+
+  # The dock opts into the pulse, and the view container the scope keys on is
+  # present.
+  expect_true(probe$enabled)
+  expect_true(probe$hasContainer)
+
+  # Busy with a recalculating output only outside the view container (a bare
+  # panel switch, or a hidden block still pending in the offcanvas) hides the
+  # pulse; busy with a recalculating output inside it (block evaluation) shows
+  # it.
+  expect_identical(probe$bookkeeping, "none")
+  expect_identical(probe$computing, "block")
+})


### PR DESCRIPTION
## Summary

`serve()` enables shiny's page pulse (`useBusyIndicators(pulse = TRUE)`), which shows on any server-busy flush. A panel switch round-trips to the server -- the on-screen visibility report (#201) and the layout fold -- without recomputing a visible output, so the pulse flashed for what is only layout bookkeeping.

- A CSS rule in `blockr-dock.css` now gates the pulse on a genuinely recalculating output *inside the visible view container*. Startup and block evaluation still pulse; a bare panel switch does not.
- Scoping to `.blockr-view-container` is deliberate: an off-screen block still awaiting evaluation stays `.recalculating` in the hidden offcanvas pool, which sits outside the container, so a pending hidden block never forces the pulse.
- Adds a deterministic shinytest2 regression test that reads the pulse pseudo-element's computed display under both busy states (the live pulse is a sub-second transient, racy to sample).

Stacked on #276 (base `275-name-or-position`), since the visibility report this builds on lives there; retarget to `main` once #276 lands.

Fixes #285