### PR TITLE
Migrate to roxygen2 8.0.0 and regenerate man/

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ BugReports: https://github.com/BristolMyersSquibb/blockr.dock/issues
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Imports:
     blockr.core (>= 0.1.3),
     blockr.ui,
@@ -81,3 +80,4 @@ Collate:
     'view-ui.R'
     'views-delta.R'
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/man/action.Rd
+++ b/man/action.Rd
@@ -89,13 +89,13 @@ reactive values behave).
 Determine input options for a block by removing inputs that are already used
 and also takes into account some edge-cases, such as variadic blocks. If
 \code{mode} is set as "inputs", this will return a character vector, for
-"create", the return value of a \code{\link[shiny:selectInput]{shiny::selectizeInput()}} call and for
-"update", the return value of a \code{\link[shiny:updateSelectInput]{shiny::updateSelectizeInput()}} call.
+"create", the return value of a \code{\link[shiny:selectizeInput]{shiny::selectizeInput()}} call and for
+"update", the return value of a \code{\link[shiny:updateSelectizeInput]{shiny::updateSelectizeInput()}} call.
 }
 
 \section{\code{block_registry_selectize()}}{
 
-This creates UI for a block registry selector via \code{\link[shiny:selectInput]{shiny::selectizeInput()}}
+This creates UI for a block registry selector via \code{\link[shiny:selectizeInput]{shiny::selectizeInput()}}
 and returns an object that inherits from \code{shiny.tag}.
 }
 
@@ -103,6 +103,6 @@ and returns an object that inherits from \code{shiny.tag}.
 
 Block selection UI, enumerating all blocks in a board is available as
 \code{board_select()}. An object that inherits from \code{shiny.tag} is returned, which
-contains the result from a \code{\link[shiny:selectInput]{shiny::selectizeInput()}} call.
+contains the result from a \code{\link[shiny:selectizeInput]{shiny::selectizeInput()}} call.
 }
 

--- a/man/ids.Rd
+++ b/man/ids.Rd
@@ -57,9 +57,10 @@ panel IDs additionally inherit from \code{dock_panel_id}, while handle IDs
 inherit from \code{dock_handle_id}. For panel IDs, depending on whether the panel
 is showing a block or an extension, the inheritance structure additionally
 contains \code{block_panel_id} or \code{ext_panel_id}, respectively. Similarly, for
-handle IDs, we have \code{block_handle_id} and \code{ext_handle_id} for block / extension
-cards, plus \code{view_handle_id} for a view's DOM container. All \code{dock_id}
-objects can be converted back to native IDs, by calling \code{as_obj_id()}.
+handle IDs, we have \code{block_handle_id} and \code{ext_handle_id} for block /
+extension cards, plus \code{view_handle_id} for a view's DOM container. All
+\code{dock_id} objects can be converted back to native IDs, by calling
+\code{as_obj_id()}.
 The utility function \code{dock_id()} returns a (possibly namespaced) ID of the
 \code{dock} instance that is used to manage all visible panels.
 }

--- a/man/layout-json.Rd
+++ b/man/layout-json.Rd
@@ -24,7 +24,7 @@ layout_from_json(x, blocks = NULL, extensions = NULL)
 \item{x}{A \code{dock_layout} (for \code{layout_to_json()}), or a JSON string /
 parsed spec list (for \code{layout_from_json()}).}
 
-\item{...}{Forwarded to \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}}.}
+\item{...}{Forwarded to \code{\link[jsonlite:toJSON]{jsonlite::toJSON()}}.}
 
 \item{blocks, extensions}{Optional board components used to resolve and
 validate bare IDs in \code{layout_from_json()}.}


### PR DESCRIPTION
## Summary

- Bump the roxygen2 pin to 8.0.0 and regenerate `man/` on its own, so the mechanical diff is reviewed here rather than folded into a feature PR.
- The pin lands in `Config/roxygen2/version: 8.0.0` — 8.0.0's canonical version field (`RoxygenNote` is the deprecated 7.x name, still read for back-compat). dock's pin was the stale `RoxygenNote: 7.3.3`, so regenerating under 8.0.0 replaces it with the canonical field directly; this matches the fleet's canonical form and passes the central `ci / docs` gate. (The issue says "bump `RoxygenNote`"; 8.0.0 renamed that field.)
- The `man/` diff is purely `\link` retargeting — each link now points at the linked function's own help topic (`shiny:selectInput` → `selectizeInput`, `jsonlite:fromJSON` → `toJSON`) — plus 8.0.0's slightly different text rewrapping in `ids.Rd`. No data objects are documented here, so the `\docType{data}` / `\format{}` / `\keyword{datasets}` drop blockr.core saw does not apply; `NAMESPACE` is unchanged.

Fixes #287
