### PR TITLE
Add and remove block condition UI by condition id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,13 @@
   `failed` blocks, so a board shows at a glance which blocks are not yet
   producing output.
 
+* Per-block condition UI (warnings, messages and errors) is now updated
+  surgically using the stable condition id blockr.core assigns each
+  condition, instead of tearing down and rebuilding the whole region on
+  every change (#36). An unchanged condition stays in place while a newly
+  raised one is inserted next to it and a resolved one is removed on its
+  own, so a persistent warning no longer flashes on each re-evaluation.
+
 * The busy pulse no longer flashes on a plain panel switch, only on real
   computation (#285). `serve()` enables shiny's page pulse
   (`useBusyIndicators(pulse = TRUE)`), which shows on any server-busy flush --

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -399,7 +399,7 @@ block_card_content <- function(ns, expr_ui, block_ui, ctrl_ui = NULL) {
     tagList(
       block_ui,
       uiOutput(ns("status_note")),
-      div(id = ns("outputs_issues_wrapper"))
+      block_issues_ui(ns)
     )
   )$allTags()
 
@@ -551,6 +551,9 @@ edit_block_server <- function(callbacks = list()) {
           }
         )
 
+        output$issues_count <- renderText(cond_issue_label(conds()))
+        outputOptions(output, "issues_count", suspendWhenHidden = FALSE)
+
         update_blk_cond_observer(conds, session)
 
         observeEvent(
@@ -599,102 +602,108 @@ block_cond_buckets <- function(df) {
 
   lapply(
     set_names(nm = c("error", "warning", "message")),
-    function(sev) df$message[df$severity == sev]
+    function(sev) {
+      rows <- df[df$severity == sev, , drop = FALSE]
+      rows <- rows[!duplicated(rows$id), , drop = FALSE]
+      set_names(rows$message, rows$id)
+    }
   )
 }
 
 update_blk_cond_observer <- function(conds, session = get_session()) {
 
   ns <- session$ns
+  rendered <- character()
 
   observeEvent(
     conds(),
     {
-      cnds <- conds()
+      specs <- cond_ui_specs(conds(), ns)
+      keep <- names(specs)
 
-      statuses <- drop_nulls(
-        lapply(
-          c("warning", "message"),
-          function(status) {
+      for (dom_id in setdiff(rendered, keep)) {
+        remove_ui(paste0("#", dom_id))
+      }
 
-            cl <- switch(
-              status,
-              warning = "warning",
-              message = "light"
-            )
-
-            msgs <- NULL
-
-            if (length(cnds[[status]])) {
-              msgs <- tags$div(
-                class = sprintf("alert alert-%s", cl),
-                HTML(
-                  cli::ansi_html(
-                    paste(
-                      unlist(cnds[[status]]),
-                      collapse = "\n"
-                    )
-                  )
-                )
-              )
-            }
-
-            msgs
-          }
-        )
-      )
-
-      remove_ui(
-        paste0("#", ns("outputs_issues"))
-      )
-
-      if (length(statuses)) {
+      for (dom_id in setdiff(keep, rendered)) {
         insert_ui(
-          selector = paste0("#", ns("outputs_issues_wrapper")),
-          ui = create_issues_ui(statuses, ns)
+          selector = specs[[dom_id]]$selector,
+          ui = specs[[dom_id]]$ui
         )
       }
 
-      msgs <- NULL
-
-      remove_ui(
-        paste0("#", ns("errors_block"), " > div")
-      )
-
-      if (length(cnds[["error"]])) {
-        msgs <- tags$div(
-          class = "blockr-error",
-          bsicons::bs_icon("exclamation-circle", class = "blockr-error-icon"),
-          tags$span(
-            HTML(
-              cli::ansi_html(
-                paste(
-                  unlist(cnds[["error"]]),
-                  collapse = "<br>"
-                )
-              )
-            )
-          )
-        )
-
-        insert_ui(
-          paste0("#", ns("errors_block")),
-          ui = msgs
-        )
-      }
+      rendered <<- keep
     }
   )
 }
 
-create_issues_ui <- function(statuses, ns) {
+cond_ui_specs <- function(cnds, ns) {
+
+  selectors <- c(
+    error = paste0("#", ns("errors_block")),
+    warning = paste0("#", ns("outputs_issues_warnings")),
+    message = paste0("#", ns("outputs_issues_messages"))
+  )
+
+  specs <- list()
+
+  for (severity in names(selectors)) {
+
+    msgs <- cnds[[severity]]
+    ids <- names(msgs)
+
+    for (i in seq_along(msgs)) {
+
+      dom_id <- ns(paste0("cond_", severity, "_", ids[[i]]))
+
+      specs[[dom_id]] <- list(
+        selector = selectors[[severity]],
+        ui = cond_alert(dom_id, msgs[[i]], severity)
+      )
+    }
+  }
+
+  specs
+}
+
+cond_alert <- function(dom_id, msg, severity) {
+
+  content <- HTML(cli::ansi_html(msg))
+
+  if (identical(severity, "error")) {
+    return(
+      tags$div(
+        id = dom_id,
+        class = "blockr-error",
+        bsicons::bs_icon("exclamation-circle", class = "blockr-error-icon"),
+        tags$span(content)
+      )
+    )
+  }
+
+  cl <- switch(severity, warning = "warning", message = "light")
+
+  tags$div(
+    id = dom_id,
+    class = sprintf("blockr-issue alert alert-%s", cl),
+    content
+  )
+}
+
+cond_issue_label <- function(cnds) {
+
+  n <- length(cnds$warning) + length(cnds$message)
+
+  paste(n, if (n == 1L) "issue" else "issues")
+}
+
+block_issues_ui <- function(ns) {
 
   collapse_id <- ns("outputs_issues_collapse")
-  n_issues <- length(statuses)
-  issue_text <- paste(n_issues, if (n_issues == 1) "issue" else "issues")
 
   div(
     id = ns("outputs_issues"),
-    class = "mt-3",
+    class = "mt-3 blockr-issues",
     tags$div(
       class = paste(
         "d-flex align-items-center justify-content-between",
@@ -704,14 +713,15 @@ create_issues_ui <- function(statuses, ns) {
       `data-bs-target` = paste0("#", collapse_id),
       `aria-expanded` = "false",
       `aria-controls` = collapse_id,
-      span(issue_text),
+      textOutput(ns("issues_count"), inline = TRUE),
       bsicons::bs_icon("chevron-down", class = "blockr-meta")
     ),
     collapse_container(
       id = collapse_id,
       div(
         class = "pt-2",
-        statuses
+        div(id = ns("outputs_issues_warnings")),
+        div(id = ns("outputs_issues_messages"))
       )
     )
   )

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -153,6 +153,10 @@
   margin-top: 3px;
 }
 
+.blockr-issues:not(:has(.blockr-issue)) {
+  display: none;
+}
+
 .blockr-issues-toggle {
   cursor: pointer;
   color: var(--blockr-color-text-meta);

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -111,17 +111,60 @@ test_that("renaming a block does not loop (#181)", {
   )
 })
 
-test_that("condition ui test", {
+test_that("block_cond_buckets keys messages by condition id (#36)", {
 
-  insert_count <- 0L
-  remove_count <- 0L
+  df <- data.frame(
+    block = "a",
+    phase = c("data", "eval", "eval", "status", "eval"),
+    severity = c("warning", "warning", "message", "message", "error"),
+    message = c("w one", "w two", "m one", "status note", "boom"),
+    id = c("id_w1", "id_w2", "id_m1", "id_status", "id_e1"),
+    stringsAsFactors = FALSE
+  )
+
+  buckets <- block_cond_buckets(df)
+
+  expect_named(buckets, c("error", "warning", "message"))
+
+  expect_false("status note" %in% buckets$message)
+
+  expect_identical(buckets$warning, c(id_w1 = "w one", id_w2 = "w two"))
+  expect_identical(buckets$message, c(id_m1 = "m one"))
+  expect_identical(buckets$error, c(id_e1 = "boom"))
+})
+
+test_that("block_cond_buckets de-duplicates repeated conditions (#36)", {
+
+  df <- data.frame(
+    block = "a",
+    phase = c("data", "eval"),
+    severity = "warning",
+    message = "same warning",
+    id = "dup_id",
+    stringsAsFactors = FALSE
+  )
+
+  expect_identical(
+    block_cond_buckets(df)$warning,
+    c(dup_id = "same warning")
+  )
+})
+
+test_that("condition UI updates surgically by condition id (#36)", {
+
+  inserted <- character()
+  removed <- character()
 
   local_mocked_bindings(
-    insert_ui = function(..., ui) {
-      insert_count <<- insert_count + 1L
+    insert_ui = function(selector, ..., ui) {
+      id <- ui$attribs$id
+      if (is.null(id)) id <- NA_character_
+      inserted[[length(inserted) + 1L]] <<- id
       expect_s3_class(ui, "shiny.tag")
     },
-    remove_ui = function(...) remove_count <<- remove_count + 1L
+    remove_ui = function(selector, ...) {
+      removed[[length(removed) + 1L]] <<- selector
+    }
   )
 
   with_mock_session(
@@ -130,29 +173,40 @@ test_that("condition ui test", {
 
       update_blk_cond_observer(cond)
 
-      expect_identical(insert_count, 0L)
-      expect_identical(remove_count, 0L)
-
       session$flushReact()
 
-      expect_identical(insert_count, 0L)
-      expect_identical(remove_count, 0L)
+      expect_length(inserted, 0L)
+      expect_length(removed, 0L)
 
       cond(
-        list(message = "hello", warning = list("world", "bye"))
+        list(
+          error = character(),
+          warning = c(a1 = "first warning", b2 = "second warning"),
+          message = c(c3 = "a message")
+        )
       )
 
       session$flushReact()
 
-      expect_identical(insert_count, 1L)
-      expect_identical(remove_count, 2L)
+      expect_length(inserted, 3L)
+      expect_length(removed, 0L)
+      expect_true(any(grepl("cond_warning_a1", inserted, fixed = TRUE)))
+      expect_true(any(grepl("cond_message_c3", inserted, fixed = TRUE)))
 
-      cond(list(error = "oh no"))
+      cond(
+        list(
+          error = c(d4 = "boom"),
+          warning = c(a1 = "first warning"),
+          message = c(c3 = "a message")
+        )
+      )
 
       session$flushReact()
 
-      expect_identical(insert_count, 2L)
-      expect_identical(remove_count, 4L)
+      expect_length(inserted, 4L)
+      expect_length(removed, 1L)
+      expect_true(any(grepl("cond_error_d4", inserted, fixed = TRUE)))
+      expect_match(removed[[1L]], "cond_warning_b2")
     }
   )
 })
@@ -201,11 +255,11 @@ test_that("block_cond_buckets drops status-phase rows from warnings (#290)", {
   expect_named(buckets, c("error", "warning", "message"))
 
   # The status-phase explanation is not painted as a warning ...
-  expect_identical(buckets$warning, "real warning")
+  expect_identical(buckets$warning, c(w1 = "real warning"))
 
-  # ... while genuine warnings and errors still surface.
-  expect_identical(buckets$error, "real error")
-  expect_identical(buckets$message, character(0))
+  # ... while genuine warnings and errors still surface, keyed by id.
+  expect_identical(buckets$error, c(e1 = "real error"))
+  expect_length(buckets$message, 0L)
 })
 
 test_that("block_status_style is the shared status-dot spec (#290)", {


### PR DESCRIPTION
## Summary

- `block_cond_buckets()` now keys each per-block condition message by the stable `id` blockr.core assigns it (deduped per severity), instead of discarding the id and returning bare message vectors. This is what makes individual conditions addressable.
- `update_blk_cond_observer()` diffs that id set against what is currently rendered and `insert_ui`/`remove_ui`s only the conditions that changed, rather than removing and re-inserting the entire warnings/messages/errors region on every condition change. A warning that persists across a re-evaluation now stays in the DOM instead of flashing.
- Each warning, message and error renders as its own element keyed `cond_<severity>_<id>`. The collapsible "N issues" panel is now static scaffolding with a live count (`renderText`, `suspendWhenHidden = FALSE`) and hides itself via CSS `:has()` when a block has no issues, so surgical child updates never rebuild it.

Stacked on #291 — its `block_cond_buckets` / `update_blk_cond_observer` changes are the base. Retarget to `main` once #291 lands.

Fixes #36