### PR TITLE
Test the restore e2e's grid render and the visibility seed

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -237,6 +237,30 @@ block_panel_tabs <- function(app, board_id = "my_board") {
   sort(sub(".*-tab-(block_panel-.+)$", "\\1", xml2::xml_attr(nodes, "id")))
 }
 
+# The block panels whose tab is the *front* (active) tab of its dockview group,
+# scoped to one `view`'s dock (every view's dock is in the DOM, so an unscoped
+# read would mix in another view's front tabs). The client-rendered geometry a
+# server-side read cannot see: dockview marks the active tab by toggling
+# `dv-active-tab` on the `.dv-tab` wrapper of the custom tab element (id
+# `...-tab-block_panel-<id>`), so the front tab is that wrapper's descendant tab
+# id. A restored group shows exactly one front tab; a collapse to separate
+# leaves surfaces every panel as its own. The view's dock sits in the stable,
+# server-rendered `#<board>-view_handle-<view>` (not the client-toggled
+# `.blockr-view-dock-active`, which can lag).
+active_block_panel_tabs <- function(app, view, board_id = "my_board") {
+  html <- xml2::read_html(
+    app$get_html(paste0("#", board_id, "-view_handle-", view))
+  )
+  xpath <- paste0(
+    "//*[contains(@id, '-tab-block_panel-')]",
+    "[ancestor-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ",
+    "' dv-active-tab ')]]"
+  )
+  nodes <- xml2::xml_find_all(html, xpath)
+  ids <- sub(".*-tab-(block_panel-.+)$", "\\1", xml2::xml_attr(nodes, "id"))
+  sort(unique(ids))
+}
+
 # Shared helpers for the edit-board extension e2e tests (links, stacks). The
 # extension namespaces its inputs under `my_board-edit_board_extension-`. The
 # extension panel stays active in those tests (pre-seeded fixtures, no block

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -552,6 +552,42 @@ test_that("board_server_callback seeds visibility before the client reports", {
   })
 })
 
+test_that("the visibility seed reads the active view's open tabs", {
+
+  # An expressed tab group hides its back tab: only the front panel of each
+  # group seeds visibility (the active view's placed grid at birth).
+  board_rv <- board_args(
+    blocks = c(
+      a = new_dataset_block(), b = new_head_block(), d = new_head_block()
+    ),
+    grids = list(v = dock_grid(panels("a", "b", active = "b"), "d"))
+  )
+
+  with_mock_session({
+    visible <- reactiveVal()
+    board_server_callback(board_rv, update = reactiveVal(), visible = visible)
+
+    expect_setequal(isolate(visible()), c("b", "d"))
+  })
+})
+
+test_that("the visibility seed spans separate leaves", {
+
+  # Separate single-panel leaves each front their own tab, so every member is
+  # on-screen (none is a hidden back tab).
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    grids = list(page = dock_grid("a", "b"))
+  )
+
+  with_mock_session({
+    visible <- reactiveVal()
+    board_server_callback(board_rv, update = reactiveVal(), visible = visible)
+
+    expect_setequal(isolate(visible()), c("a", "b"))
+  })
+})
+
 test_that("view nav renders one labelled item per view (#189)", {
 
   board <- new_dock_board(

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -306,6 +306,11 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
     c("ext_panel-edit_board_extension", "block_panel-a", "block_panel-b")
   )
 
+  # Grid geometry survives deserialization, not just membership: the analysis
+  # view restores its authored a/b tab group with b fronted (a is the hidden
+  # back tab), so only b reads as visible.
+  expect_setequal(visible_block_ids(active_view_grid(restored)), "b")
+
   # Import the saved file. Restoring reloads the session: the probe, wiped by
   # the reload, both waits for and proves the reload fired.
   app$run_js("window.__serdes_probe = true;")
@@ -318,6 +323,41 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   # The deserialize + reconcile + re-render rebuilds the dock-owned view
   # structure and the blocks identically.
   expect_identical(read_dock_state(app), before)
+
+  # The restored board carries the per-view grid forward, not just the nav and
+  # blocks: re-exporting after the reload reproduces the stored geometry (the
+  # tab group, its active tab, the custom sizes) byte-for-byte. This reads the
+  # committed board's slots -- proving the stage / reload cycle preserved them
+  # and that the fixture re-importing its own (colliding) view ids does not drop
+  # them. It cannot see the client render, so that leg is asserted below.
+  path2 <- app$get_download("my_board-preserve_board-serialize")
+  ser2 <- jsonlite::fromJSON(path2, simplifyDataFrame = FALSE,
+                             simplifyMatrix = FALSE)
+
+  expect_identical(ser2[["payload"]][["grids"]], ser[["payload"]][["grids"]])
+  expect_identical(ser2[["payload"]][["views"]], ser[["payload"]][["views"]])
+
+  # Client leg: the byte checks read the stored slots, so they cannot observe
+  # whether the dockview client actually applied the grid. Assert one rendered
+  # DOM fact -- the analysis view's a/b tab group restores with `b` as the front
+  # tab (its authored active tab, not `a` the first). A client-side
+  # restore_layout failure, or a collapse to separate leaves, changes this set.
+  tab_diag <- function() {
+    app$get_js(paste0(
+      "JSON.stringify(Array.from(document.querySelectorAll('.dv-tab'))",
+      ".map(t => ({tab: (t.querySelector('[id*=\"-tab-\"]') || {}).id, ",
+      "active: t.classList.contains('dv-active-tab')})))"
+    ))
+  }
+  wait_js(
+    app,
+    paste0(
+      "document.querySelector('.dv-tab.dv-active-tab ",
+      "[id*=\"-tab-block_panel-b\"]') !== null"
+    ),
+    tab_diag
+  )
+  expect_identical(active_block_panel_tabs(app, "analysis"), "block_panel-b")
 })
 
 test_that("deleting a block via its card menu drops the panel and its link", {


### PR DESCRIPTION
## Summary

The last sub-issue of #293. Since #298 merged, the grid rework unit-tests most of #295 in the base itself — headless round-trip, ghost pruning, membership-authoritative placement, and the mirror. This narrows #295 to the two seams the base does not reach:

- **Restore round-trip (#233 e2e):** the existing test asserts nav and blocks only. This also asserts the grid — the restored `analysis` view keeps its authored a/b tab group with `b` fronted (headless), the re-export after the reload reproduces the `grids`/`views` payload byte-for-byte, and the dockview client renders `b` as the front tab (`active_block_panel_tabs()`, the client leg a server-side read cannot see).
- **Visibility seed:** the active view's open tabs — the front panel of a tab group, every panel of separate leaves.

Tests only.

Fixes #295
