### PR TITLE
Drop bridge debounce, re-add _state-source skip; adopt move_panel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     shinyjs,
     bslib,
     glue,
-    dockViewR (>= 0.2.1),
+    dockViewR (>= 0.3.0),
     htmltools,
     cli,
     shinyWidgets,
@@ -45,7 +45,8 @@ Suggests:
     rmarkdown
 Remotes:
     nbenn/shinytest2@wait-for-app-serving,
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core,
+    cynkra/dockViewR@85-move-panel
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     shinyjs,
     bslib,
     glue,
-    dockViewR (>= 0.3.0),
+    dockViewR (>= 0.4.0),
     htmltools,
     cli,
     shinyWidgets,
@@ -46,7 +46,7 @@ Suggests:
 Remotes:
     nbenn/shinytest2@wait-for-app-serving,
     BristolMyersSquibb/blockr.core,
-    cynkra/dockViewR@85-move-panel
+    cynkra/dockViewR
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,11 @@
   (`add` / `rm` / `move` / `select`), with panels named by the new typed
   references `blk()` / `ext()` instead of wire-id prefixes. **Breaking:** the
   old set-replace membership form is retired.
+* The `views$mod` grammar gains a `resize` verb --
+  `resize = list(blk("a", size = 0.3))` sets a panel's group size along its
+  splitview axis (a ratio in `(0, 1)`), delivered through dockViewR's `set_size`
+  proxy. Like `move` / `select` it is client-owned geometry: pure delivery,
+  captured by the grid mirror, no board write (#320).
 * **Breaking:** an extension's id is now owned by its container (mirroring
   blocks), serving as its single identity everywhere -- the wire panel id, DOM
   handle, module namespace and `ext()` target.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -323,35 +323,31 @@ freeze_hidden_inputs <- function(board, visibility) {
 }
 
 # The grid mirror's observer, split from manage_dock for testability. It reacts
-# to the view's settled `_state` echo and commits the client layout verbatim in
-# canonical form, only when it differs (beyond the sash-size tolerance) from
-# what is stored -- so a sash drag or tab switch is at most one board commit, a
-# re-echo after quiescence none, and the echo of the mirror's own restore
-# converges without churn (it matches what was pushed). It does not restrict to
-# membership: a panel absent from the view is an inert ghost, pruned at the
-# compose / restore boundary, never by this writer.
-observe_grid_echo <- function(id, dock, board, commit_grid) {
-
-  # Bridge (#301): a server-side stand-in for the gesture-settled `_state`
-  # emission dockViewR does not yet ship. Current dockViewR streams per-frame
-  # states through a sash drag, so without this the mirror would commit per
-  # frame -- an interactive regression versus main's cadence. Unlike the
-  # pre-rework debounce (which raced a second writer and diffed specs), this
-  # mirror is the sole writer, commits verbatim canonical values, and diffs
-  # nothing: the only cost is 250 ms of bounded staleness on a slot whose
-  # readers are all boundaries. Remove once the settled `_state` chain lands.
-  settled <- debounce(reactive(dock$layout()), 250)
+# to the view's settled `_state` echo, ignores the echoes its own restores
+# provoke (`_state-source` == "server"), and commits the client layout verbatim
+# in canonical form, only when it differs (beyond the sash-size tolerance) from
+# what is stored -- so a sash drag or tab switch is at most one board commit and
+# a re-echo after quiescence none. It does not restrict to membership: a panel
+# absent from the view is an inert ghost, pruned at the compose / restore
+# boundary, never by this writer.
+observe_grid_echo <- function(id, dock, board, session, commit_grid) {
 
   observeEvent(
-    settled(),
+    dock$layout(),
     {
+      source <- isolate(session$input[[dock_input("state-source")]])
+
+      if (identical(source, "server")) {
+        return()
+      }
+
       views <- board_views(board$board)
 
       if (!id %in% names(views)) {
         return()
       }
 
-      state <- settled()
+      state <- dock$layout()
 
       if (is.null(state)) {
         return()
@@ -748,7 +744,7 @@ manage_dock <- function(
         update(list(views = list(grid = set_names(list(grid), id))))
       }
 
-      observe_grid_echo(id, dock, board, commit_grid)
+      observe_grid_echo(id, dock, board, session, commit_grid)
     }
 
     if (get_log_level() >= debug_log_level) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -323,33 +323,41 @@ freeze_hidden_inputs <- function(board, visibility) {
 }
 
 # The grid mirror's observer, split from manage_dock for testability. It reacts
-# to the view's settled `_state` echo, ignores the echoes its own restores
-# provoke (`_state-source` == "server"), and commits the client layout verbatim
-# in canonical form, only when it differs (beyond the sash-size tolerance) from
-# what is stored -- so a sash drag or tab switch is at most one board commit and
-# a re-echo after quiescence none. It does not restrict to membership: a panel
-# absent from the view is an inert ghost, pruned at the compose / restore
-# boundary, never by this writer.
-observe_grid_echo <- function(id, dock, board, session, commit_grid) {
+# to the view's settled `_state` echo and commits the client layout verbatim in
+# canonical form, only when it differs (beyond the sash-size tolerance) from
+# what is stored -- so a sash drag, a programmatic move / resize, or a tab
+# switch is at most one board commit and a re-echo after quiescence none.
+#
+# The one echo it must not commit is the initial restore's: manage_dock replays
+# this view's stored layout, and that echo is a replay of what we already hold,
+# not a client gesture -- committing its in-flight frames would persist a
+# transient mid-restore layout. `restoring` is the one-shot latch manage_dock
+# raises around that restore; the mirror consumes it on the next echo and skips
+# exactly that one. Move / resize / add echoes never raise it, so they fall
+# through and persist the geometry the client realised -- the only record of
+# where a moved or resized panel landed.
+#
+# It does not restrict to membership: a panel absent from the view is an inert
+# ghost, pruned at the compose / restore boundary, never by this writer.
+observe_grid_echo <- function(id, dock, board, restoring, commit_grid) {
 
   observeEvent(
     dock$layout(),
     {
-      source <- isolate(session$input[[dock_input("state-source")]])
+      state <- dock$layout()
 
-      if (identical(source, "server")) {
+      if (is.null(state)) {
+        return()
+      }
+
+      if (isTRUE(isolate(restoring()))) {
+        restoring(FALSE)
         return()
       }
 
       views <- board_views(board$board)
 
       if (!id %in% names(views)) {
-        return()
-      }
-
-      state <- dock$layout()
-
-      if (is.null(state)) {
         return()
       }
 
@@ -691,6 +699,7 @@ manage_dock <- function(
     live_panels <- reactiveVal(as.character(layout_panel_ids(init_layout)))
     prev_active_group <- reactiveVal()
     active_group_trail <- reactiveVal()
+    restoring <- reactiveVal(FALSE)
     n_panels <- reactive(length(live_panels()))
 
     dock <- list(
@@ -744,7 +753,7 @@ manage_dock <- function(
         update(list(views = list(grid = set_names(list(grid), id))))
       }
 
-      observe_grid_echo(id, dock, board, session, commit_grid)
+      observe_grid_echo(id, dock, board, restoring, commit_grid)
     }
 
     if (get_log_level() >= debug_log_level) {
@@ -761,6 +770,8 @@ manage_dock <- function(
     observeEvent(
       req(input[[dock_input("initialized")]]),
       {
+        restoring(TRUE)
+
         restore_layout(init_layout, dock$proxy,
                        blocks = init_blocks, extensions = init_exts)
 

--- a/R/dock-grid.R
+++ b/R/dock-grid.R
@@ -229,13 +229,21 @@ grid_size_tol <- function() {
 }
 
 # Approximate grid equality: structure exact, relative sizes within the supplied
-# `tolerance`. Deferring to `all.equal` keeps the stored sizes faithful (only
-# the comparison is fuzzy); comparing the unclassed list walks each pane's size
-# individually, and `scale = 1` makes the tolerance absolute on the ratio scale.
-# The R-default tolerance stays near-exact, so `all.equal()` / `expect_equal()`
-# on a grid is unaffected unless a caller passes a tolerance (the mirror does).
+# `tolerance`, ignoring the transient `focus` marker. Deferring to `all.equal`
+# keeps the stored sizes faithful (only the comparison is fuzzy); comparing the
+# unclassed list walks each pane's size individually, and `scale = 1` makes the
+# tolerance absolute on the ratio scale. The R-default tolerance stays near-
+# exact, so `all.equal()` / `expect_equal()` on a grid is unaffected unless a
+# caller passes a tolerance (the mirror does). `focus` -- which group holds UI
+# focus, set by the client after render -- is not authored geometry: the seed
+# grid carries none while the client's echo always does, so it is dropped
+# before the compare, keeping a focus-only echo from provoking a mirror commit
+# and the round-trip stable across a restore.
 #' @export
 all.equal.dock_grid <- function(target, current, ..., scale = 1) {
+  target[["focus"]] <- NULL
+  current[["focus"]] <- NULL
+
   all.equal(unclass(target), unclass(current), ..., scale = scale)
 }
 

--- a/R/dock-view.R
+++ b/R/dock-view.R
@@ -929,13 +929,14 @@ validate_views_delta <- function(views, board, upd) {
 }
 
 # The inner grammar of a `views$mod` entry: panel-op verbs on the panels of one
-# view, mirroring the user gesture set (`add` / `rm` / `move` / `select`).
-# Validation threads membership through the batch's application order (rm -> add
-# -> move -> select): `rm` targets a current member, `add` a non-member that
-# resolves to a block or extension, and `move` / `select` a member of the
-# post-add view. Hint refs (`near`) resolve against the same running membership.
+# view, mirroring the user gesture set (`add` / `rm` / `move` / `resize` /
+# `select`). Validation threads membership through the batch's application order
+# (rm -> add -> move -> resize -> select): `rm` targets a current member, `add`
+# a non-member that resolves to a block or extension, and `move` / `resize` /
+# `select` a member of the post-add view. Hint refs (`near`) resolve against the
+# same running membership.
 view_mod_verbs <- function() {
-  c("rm", "add", "move", "select")
+  c("rm", "add", "move", "resize", "select")
 }
 
 valid_panel_sides <- function() {
@@ -1018,6 +1019,13 @@ resolve_view_mod <- function(mod, view_id, members, post_block_ids, ext_ids) {
     mod[["move"]] <- resolve_placement_verb(
       mod[["move"]], view_id, "move", mem_blk, mem_ext, resolve_near,
       c("near", "side")
+    )
+  }
+
+  if (not_null(mod[["resize"]])) {
+    mod[["resize"]] <- resolve_placement_verb(
+      mod[["resize"]], view_id, "resize", mem_blk, mem_ext, resolve_near,
+      c("size")
     )
   }
 
@@ -1295,6 +1303,36 @@ validate_view_mod <- function(mod, view_id, members, ok_panels) {
 
   for (pid in move_ids) {
     validate_panel_hint(mod$move[[pid]], view_id, setdiff(post_add, pid))
+  }
+
+  resize_ids <- validate_mod_map(mod$resize, view_id, "resize")
+
+  bad_resize <- setdiff(resize_ids, post_add)
+
+  if (length(bad_resize)) {
+    blockr_abort(
+      paste0(
+        "Panel(s) in `views$mod$", view_id, "$resize` are not view members: ",
+        paste(bad_resize, collapse = ", "), "."
+      ),
+      class = "dock_views_mod_resize_unknown"
+    )
+  }
+
+  for (pid in resize_ids) {
+
+    hint <- mod$resize[[pid]]
+    validate_panel_hint(hint, view_id, character())
+
+    if (is.null(hint[["size"]])) {
+      blockr_abort(
+        paste0(
+          "`views$mod$", view_id, "$resize` for ", pid,
+          " needs a `size` ratio in (0, 1)."
+        ),
+        class = "dock_views_mod_resize_invalid"
+      )
+    }
   }
 
   sel <- mod$select

--- a/R/panel-ops.R
+++ b/R/panel-ops.R
@@ -53,7 +53,7 @@ apply_panel_ops <- function(mod, dock, board, rm_blocks = character(),
   }
 
   for (pid in names(mod[["move"]])) {
-    op_move_panel(pid, mod[["move"]][[pid]], dock, board, active)
+    op_move_panel(pid, mod[["move"]][[pid]], dock)
   }
 
   if (not_null(mod[["select"]])) {
@@ -145,18 +145,19 @@ op_remove_panel <- function(pid, dock, active = TRUE) {
   invisible()
 }
 
-# A first-class move awaits cynkra/dockViewR#85; until then a move decomposes
-# into remove + add-with-hint. The block / extension card is parked in the
-# offcanvas and re-homed by the remove / add pair, so its server state and
-# rendered output survive -- only the dockview panel wrapper is re-created.
-op_move_panel <- function(pid, hint, dock, board, active = TRUE) {
+# A first-class move: dockViewR relocates the panel next to the hint in one
+# step, carrying its block / extension card along, in place of the former
+# remove + add-with-hint decomposition. The move is server-driven, so the grid
+# mirror's server-source skip ignores the `_state` echo it provokes.
+op_move_panel <- function(pid, hint, dock) {
 
-  if (!panel_is_live(as_dock_panel_id(pid), dock)) {
+  pid <- as_dock_panel_id(pid)
+
+  if (!panel_is_live(pid, dock)) {
     return(invisible())
   }
 
-  op_remove_panel(pid, dock, active)
-  op_add_panel(pid, hint, dock, board, active)
+  move_dock_panel(pid, hint_to_position(hint, dock), dock$proxy)
 
   invisible()
 }

--- a/R/panel-ops.R
+++ b/R/panel-ops.R
@@ -56,6 +56,10 @@ apply_panel_ops <- function(mod, dock, board, rm_blocks = character(),
     op_move_panel(pid, mod[["move"]][[pid]], dock)
   }
 
+  for (pid in names(mod[["resize"]])) {
+    op_resize_panel(pid, mod[["resize"]][[pid]], dock)
+  }
+
   if (not_null(mod[["select"]])) {
     op_select_panel(mod[["select"]], dock)
   }
@@ -158,6 +162,23 @@ op_move_panel <- function(pid, hint, dock) {
   }
 
   move_dock_panel(pid, hint_to_position(hint, dock), dock$proxy)
+
+  invisible()
+}
+
+# A resize sets the size of the panel's group along its splitview axis. Geometry
+# is client-owned and captured by the grid mirror, so -- like move / select --
+# it writes nothing to the board and exists only as this delivery, idempotent
+# against the settled ratio.
+op_resize_panel <- function(pid, hint, dock) {
+
+  pid <- as_dock_panel_id(pid)
+
+  if (!panel_is_live(pid, dock)) {
+    return(invisible())
+  }
+
+  resize_dock_panel(pid, hint[["size"]], dock$proxy)
 
   invisible()
 }

--- a/R/panel-ops.R
+++ b/R/panel-ops.R
@@ -21,10 +21,12 @@ remove_panel_delta <- function(view_id, panel_id) {
 # Apply a view's panel-op batch to its live dock. Server-initiated ops land
 # here through the applied `views$mod` payload (the `set_panel_title`
 # precedent), the mirror image of the membership fold: `add` / `rm` write the
-# board and this places / removes the panel, `move` / `select` write nothing and
-# exist only as this client-side apply. Every op is idempotent against the live
-# panel set, so the fold's own capture echo and a re-augmented payload are
-# no-ops. Application order matches the reducer: rm -> add -> move -> select.
+# board and this places / removes the panel; `move` / `resize` / `select` write
+# nothing here and only deliver to the live dock -- the grid mirror then
+# captures the resulting geometry from the client echo, which is what persists
+# a move or resize. Every op is idempotent against the live panel set, so the
+# fold's own capture echo and a re-augmented payload are no-ops. Application
+# order matches the reducer: rm -> add -> move -> resize -> select.
 #
 # `active` marks whether this dock is the active view. A block / extension card
 # is a single board-level element, shown in whichever view is active, so only
@@ -151,8 +153,9 @@ op_remove_panel <- function(pid, dock, active = TRUE) {
 
 # A first-class move: dockViewR relocates the panel next to the hint in one
 # step, carrying its block / extension card along, in place of the former
-# remove + add-with-hint decomposition. The move is server-driven, so the grid
-# mirror's server-source skip ignores the `_state` echo it provokes.
+# remove + add-with-hint decomposition. It writes nothing to the board directly;
+# the settled `_state` echo the move provokes is committed by the grid mirror,
+# which is what persists the panel's new position.
 op_move_panel <- function(pid, hint, dock) {
 
   pid <- as_dock_panel_id(pid)
@@ -166,10 +169,10 @@ op_move_panel <- function(pid, hint, dock) {
   invisible()
 }
 
-# A resize sets the size of the panel's group along its splitview axis. Geometry
-# is client-owned and captured by the grid mirror, so -- like move / select --
-# it writes nothing to the board and exists only as this delivery, idempotent
-# against the settled ratio.
+# A resize sets the size of the panel's group along its splitview axis. It
+# writes nothing to the board directly; the settled `_state` echo it provokes
+# is committed by the grid mirror, which is what persists the new ratio.
+# Idempotent against the settled ratio, so a re-augmented payload is a no-op.
 op_resize_panel <- function(pid, hint, dock) {
 
   pid <- as_dock_panel_id(pid)

--- a/R/panel-ref.R
+++ b/R/panel-ref.R
@@ -26,7 +26,7 @@
 #' @param side Placement direction relative to `near`: one of `within`, `left`,
 #'   `right`, `above`, `below`.
 #' @param size Target size ratio in (0, 1) -- consumed by `resize`, and recorded
-#'   on `add` for when the `set_size` floor lands (#320).
+#'   on `add` for a later size-on-create pass.
 #' @param x An object.
 #' @param ... Ignored.
 #'

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -148,6 +148,16 @@ ext_panel_ids <- function(proxy = dock_proxy()) {
   )
 }
 
+move_dock_panel <- function(id, position, proxy = dock_proxy()) {
+  pid <- as_dock_panel_id(id)
+
+  log_debug("moving panel {pid}")
+
+  dockViewR::move_panel(proxy, pid, position)
+
+  invisible(NULL)
+}
+
 restore_layout <- function(layout, proxy, blocks = list(),
                            extensions = list()) {
   log_debug("restoring dockview layout")

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -158,6 +158,16 @@ move_dock_panel <- function(id, position, proxy = dock_proxy()) {
   invisible(NULL)
 }
 
+resize_dock_panel <- function(id, size, proxy = dock_proxy()) {
+  pid <- as_dock_panel_id(id)
+
+  log_debug("resizing panel {pid}")
+
+  dockViewR::set_size(proxy, pid, size)
+
+  invisible(NULL)
+}
+
 restore_layout <- function(layout, proxy, blocks = list(),
                            extensions = list()) {
   log_debug("restoring dockview layout")

--- a/R/utils-dock.R
+++ b/R/utils-dock.R
@@ -27,7 +27,7 @@ block_panel_ids <- function(proxy = dock_proxy()) {
 # Maintain the authoritative server-side panel-membership set. Every panel add /
 # remove flows through add_*_panel() / remove_*_panel(), so updating here keeps
 # `live_panels` in lockstep with the live dock without waiting for the browser's
-# debounced state echo -- which is what lets reconcile tell a just-added panel
+# settled state echo -- which is what lets reconcile tell a just-added panel
 # from a stale layout. `live_panels` is NULL for a dock with no tracker (a bare
 # test stub), in which case tracking is a no-op.
 track_panel_added <- function(live_panels, id) {

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -60,7 +60,7 @@ blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
 }
 
 # Round-trip stability: every view's stored grid must be the fixed point the
-# client echoes back, so the debounced echo the restore push provokes is
+# client echoes back, so the settled echo the restore push provokes is
 # absorbed by the mirror's `all.equal(tolerance = grid_size_tol())` guard rather
 # than committing. It holds when, for every view, the stored grid is
 # that-tolerance-equal to the live grid the client reports -- the comparison the

--- a/man/panel-ref.Rd
+++ b/man/panel-ref.Rd
@@ -24,7 +24,7 @@ is_panel_ref(x)
 \code{right}, \code{above}, \code{below}.}
 
 \item{size}{Target size ratio in (0, 1) -- consumed by \code{resize}, and recorded
-on \code{add} for when the \code{set_size} floor lands (#320).}
+on \code{add} for a later size-on-create pass.}
 
 \item{x}{An object.}
 

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -26,6 +26,23 @@ new_app_driver <- function(...) {
   shinytest2::AppDriver$new(...)
 }
 
+# The dockview `_state` a grid serialises from carries a transient `focus`
+# marker (which group holds UI focus) the client sets after render, independent
+# of the authored geometry -- so it is present or absent depending on when the
+# export samples the client, not on the layout the round-trip must preserve.
+# Strip it (anywhere in the nested grid) before a byte-for-byte grid compare.
+drop_focus <- function(x) {
+  if (!is.list(x)) {
+    return(x)
+  }
+
+  if (!is.null(names(x))) {
+    x <- x[names(x) != "focus"]
+  }
+
+  lapply(x, drop_focus)
+}
+
 board_args <- function(...) {
   generate_plugin_args(
     new_dock_board(...),
@@ -309,6 +326,41 @@ active_block_panel_tabs <- function(app, view, board_id = "my_board") {
   nodes <- xml2::xml_find_all(html, xpath)
   ids <- sub(".*-tab-(block_panel-.+)$", "\\1", xml2::xml_attr(nodes, "id"))
   sort(unique(ids))
+}
+
+# Wait until `view`'s dock has settled to exactly `expected` active (front)
+# block-panel tabs. dockviewR restores a tab group asynchronously and can
+# transiently surface its members as separate leaves (each its own front tab)
+# before collapsing the back tabs; under a heavier startup that transient
+# outlasts wait_dock_loaded (which gates on server DOM). Reading the tabs -- or
+# the mirrored grid the export serialises from the client layout -- before it
+# settles catches the separate-leaves state. `expected` is the settled
+# `block_panel-<id>` front tabs (matched exactly, like active_block_panel_tabs).
+wait_active_block_tabs <- function(app, view, expected, board_id = "my_board",
+                                   timeout = 30 * 1000) {
+  want <- paste(sort(expected), collapse = ",")
+
+  js <- sprintf(
+    paste0(
+      "(function(){",
+      "var d=document.querySelector('#%s-view_handle-%s');if(!d)return false;",
+      "var a=Array.from(d.querySelectorAll('[id*=\"-tab-block_panel-\"]'))",
+      ".filter(function(e){return e.closest('.dv-active-tab')!==null;})",
+      ".map(function(e){return e.id",
+      ".replace(/.*-tab-(block_panel-.+)$/,'$1');});",
+      "return Array.from(new Set(a)).sort().join(',')==='%s';})()"
+    ),
+    board_id, view, want
+  )
+
+  diagnose <- function() {
+    sprintf(
+      "[active-block-tabs] view=%s want=[%s] got=[%s]", view, want,
+      paste(active_block_panel_tabs(app, view, board_id), collapse = ",")
+    )
+  }
+
+  wait_js(app, js, diagnose, timeout)
 }
 
 # Shared helpers for the edit-board extension e2e tests (links, stacks). The

--- a/tests/testthat/test-grid-mirror.R
+++ b/tests/testthat/test-grid-mirror.R
@@ -6,13 +6,6 @@ echo_state <- function(layout) {
   list(grid = tree, activeGroup = focus_group_id(tree, grid[["focus"]]))
 }
 
-# Settle the mirror's 250 ms debounce bridge: flush so its internal observer
-# schedules the timer, then advance the mock clock past the window to fire it.
-settle <- function(ms) {
-  ms$flushReact()
-  ms$elapse(300)
-}
-
 test_that("as_dock_grid casts to a canonical dock_grid, sizes verbatim", {
 
   ly <- dock_grid("a", "b", sizes = c(0.301, 0.699))
@@ -78,8 +71,10 @@ test_that("grid mirror commits one echo, guards re-echoes", {
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
 
+    ms$setInputs(`dock_state-source` = "client")
+
     observe_grid_echo(
-      "V", list(layout = layout_rv), board,
+      "V", list(layout = layout_rv), board, ms,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
         board$board <- apply_board_update(
@@ -96,7 +91,7 @@ test_that("grid mirror commits one echo, guards re-echoes", {
       sizes = c(0.2, 0.3, 0.5)
     )
     layout_rv(echo_state(dragged))
-    settle(ms)
+    ms$flushReact()
 
     expect_length(committed, 1L)
     expect_false(is.null(board_grids(board$board)[["V"]]))
@@ -108,13 +103,23 @@ test_that("grid mirror commits one echo, guards re-echoes", {
       sizes = c(0.201, 0.299, 0.5)
     )
     layout_rv(echo_state(jittered))
-    settle(ms)
+    ms$flushReact()
+
+    expect_length(committed, 1L)
+
+    # A server-driven echo (the restore the mirror itself provokes) is ignored.
+    ms$setInputs(`dock_state-source` = "server")
+    layout_rv(echo_state(dock_grid(
+      "block_panel-a", "block_panel-b", "block_panel-d",
+      sizes = c(0.6, 0.2, 0.2)
+    )))
+    ms$flushReact()
 
     expect_length(committed, 1L)
   })
 })
 
-test_that("the debounce bridge coalesces per-frame echoes into one commit", {
+test_that("an absent _state-source reads as client (works without the stack)", {
 
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
@@ -132,34 +137,23 @@ test_that("the debounce bridge coalesces per-frame echoes into one commit", {
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
 
+    # No `_state-source` input is set: a dockViewR without the settled chain
+    # never emits it, so the read is NULL and the server-skip self-disables --
+    # the echo is treated as a client gesture and commits.
     observe_grid_echo(
-      "V", list(layout = layout_rv), board,
+      "V", list(layout = layout_rv), board, ms,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
       }
     )
     ms$flushReact()
 
-    # A sash drag streams several per-frame states before settling. Each frame
-    # arrives within the debounce window (no clock advance between them), so the
-    # bridge commits only the settled frame -- one board write for the gesture,
-    # not one per frame.
-    for (w in c(0.25, 0.30, 0.35, 0.40)) {
-      layout_rv(echo_state(dock_grid(
-        "block_panel-a", "block_panel-b", sizes = c(w, 1 - w)
-      )))
-      ms$flushReact()
-    }
-
-    expect_length(committed, 0L)
-
-    settle(ms)
+    layout_rv(echo_state(dock_grid(
+      "block_panel-a", "block_panel-b", sizes = c(0.3, 0.7)
+    )))
+    ms$flushReact()
 
     expect_length(committed, 1L)
-    expect_setequal(
-      layout_panel_ids(committed[[1L]]),
-      c("block_panel-a", "block_panel-b")
-    )
   })
 })
 
@@ -181,8 +175,10 @@ test_that("the mirror stores an in-flight echo verbatim; placement prunes it", {
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
 
+    ms$setInputs(`dock_state-source` = "client")
+
     observe_grid_echo(
-      "V", list(layout = layout_rv), board,
+      "V", list(layout = layout_rv), board, ms,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
         board$board <- apply_board_update(
@@ -200,7 +196,7 @@ test_that("the mirror stores an in-flight echo verbatim; placement prunes it", {
       "block_panel-a", "block_panel-b", "block_panel-gone",
       sizes = c(0.2, 0.3, 0.5)
     )))
-    settle(ms)
+    ms$flushReact()
 
     expect_true(
       "block_panel-gone" %in%

--- a/tests/testthat/test-grid-mirror.R
+++ b/tests/testthat/test-grid-mirror.R
@@ -41,6 +41,20 @@ test_that("all.equal.dock_grid absorbs sash jitter but not a real drag", {
   expect_false(isTRUE(all.equal(base, jitter)))
 })
 
+test_that("all.equal.dock_grid ignores the transient focus marker", {
+
+  # The client's echo carries a `focus` (the active group) the authored seed
+  # grid never has; a focus-only difference is not a geometry change, so the
+  # mirror's guard -- and the round-trip probe -- must read the two as equal
+  # (else a restore echo commits and the round-trip destabilises).
+  plain <- dock_grid("block_panel-a", "block_panel-b", sizes = c(0.3, 0.7))
+  focused <- plain
+  focused[["focus"]] <- "block_panel-b"
+
+  expect_true(isTRUE(all.equal(plain, focused)))
+  expect_true(isTRUE(all.equal(plain, focused, tolerance = grid_size_tol())))
+})
+
 test_that("the size tolerance is a tunable blockr_option", {
 
   expect_equal(grid_size_tol(), 0.005)

--- a/tests/testthat/test-grid-mirror.R
+++ b/tests/testthat/test-grid-mirror.R
@@ -65,7 +65,7 @@ test_that("the size tolerance is a tunable blockr_option", {
   )
 })
 
-test_that("grid mirror commits one echo, guards re-echoes", {
+test_that("grid mirror commits a client echo, guards re-echoes", {
 
   brd <- new_dock_board(
     blocks = c(
@@ -84,11 +84,10 @@ test_that("grid mirror commits one echo, guards re-echoes", {
 
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
-
-    ms$setInputs(`dock_state-source` = "client")
+    restoring <- reactiveVal(FALSE)
 
     observe_grid_echo(
-      "V", list(layout = layout_rv), board, ms,
+      "V", list(layout = layout_rv), board, restoring,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
         board$board <- apply_board_update(
@@ -120,20 +119,10 @@ test_that("grid mirror commits one echo, guards re-echoes", {
     ms$flushReact()
 
     expect_length(committed, 1L)
-
-    # A server-driven echo (the restore the mirror itself provokes) is ignored.
-    ms$setInputs(`dock_state-source` = "server")
-    layout_rv(echo_state(dock_grid(
-      "block_panel-a", "block_panel-b", "block_panel-d",
-      sizes = c(0.6, 0.2, 0.2)
-    )))
-    ms$flushReact()
-
-    expect_length(committed, 1L)
   })
 })
 
-test_that("an absent _state-source reads as client (works without the stack)", {
+test_that("the restore latch skips one echo; a later echo commits", {
 
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
@@ -150,18 +139,31 @@ test_that("an absent _state-source reads as client (works without the stack)", {
 
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
+    restoring <- reactiveVal(FALSE)
 
-    # No `_state-source` input is set: a dockViewR without the settled chain
-    # never emits it, so the read is NULL and the server-skip self-disables --
-    # the echo is treated as a client gesture and commits.
     observe_grid_echo(
-      "V", list(layout = layout_rv), board, ms,
+      "V", list(layout = layout_rv), board, restoring,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
       }
     )
     ms$flushReact()
 
+    # The restore push raises the latch: the settled echo it provokes replays a
+    # layout we already hold (often the composed, ghost-pruned grid), so it is
+    # consumed and skipped however much it differs from what is stored.
+    restoring(TRUE)
+    layout_rv(echo_state(dock_grid(
+      "block_panel-a", "block_panel-b", sizes = c(0.85, 0.15)
+    )))
+    ms$flushReact()
+
+    expect_length(committed, 0L)
+    expect_false(isolate(restoring()))
+
+    # One-shot: the next echo is not a restore replay -- a real drag or a
+    # server-driven move / resize -- so it commits. This is what persists a
+    # programmatic resize the blanket server-skip used to drop.
     layout_rv(echo_state(dock_grid(
       "block_panel-a", "block_panel-b", sizes = c(0.3, 0.7)
     )))
@@ -189,10 +191,10 @@ test_that("the mirror stores an in-flight echo verbatim; placement prunes it", {
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
 
-    ms$setInputs(`dock_state-source` = "client")
+    restoring <- reactiveVal(FALSE)
 
     observe_grid_echo(
-      "V", list(layout = layout_rv), board, ms,
+      "V", list(layout = layout_rv), board, restoring,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
         board$board <- apply_board_update(

--- a/tests/testthat/test-model-interleaving.R
+++ b/tests/testthat/test-model-interleaving.R
@@ -107,15 +107,22 @@ model_set_members <- function(st, members) {
   list(st = st, commit = as.integer(!setequal(before, model_members(st))))
 }
 
-# The grid mirror, reproduced from observe_grid_echo(): cast the pending echo to
-# a `dock_grid`, skip the commit when it is within the size tolerance of what is
-# stored (the all.equal guard), else store it verbatim. Returns the commit count
-# so the "one gesture, at most one commit" bound is checkable.
-model_deliver_echo <- function(st) {
+# The grid mirror, reproduced from observe_grid_echo(): a server-sourced echo --
+# an intermediate frame dockviewR streams while applying a restore -- is dropped
+# by the `_state-source` skip and never commits; a client echo casts to a
+# `dock_grid` and commits only when it falls outside the size tolerance of what
+# is stored (the all.equal guard), else no-ops. Returns the commit count so the
+# "one gesture, at most one commit" bound is checkable.
+model_deliver_echo <- function(st, source = "client") {
 
   echo <- st$client$pending
 
   if (is.null(echo)) {
+    return(list(st = st, commit = 0L))
+  }
+
+  if (identical(source, "server")) {
+    st$client$pending <- NULL
     return(list(st = st, commit = 0L))
   }
 
@@ -356,6 +363,66 @@ test_that("restore rebuilds a view whose membership emptied under a ghost", {
   expect_length(model_shown(st), 0L)
   expect_length(model_members(st), 0L)
   expect_no_error(validate_board(st$board))
+})
+
+test_that("a restore's staged frames never overwrite the authored grid", {
+
+  # dockviewR applies a restored grid incrementally, streaming intermediate
+  # `_state` frames -- a tab group transiently split into separate leaves before
+  # the back tabs collapse. Each is server-sourced (the mirror's own restore
+  # push provoked it), so the `_state-source` skip drops it and the committed
+  # grid holds at the authored value: an export mid-load persists the pushed
+  # arrangement, not a frame that was never anyone's intent. The invariant --
+  # between a boundary push and its client ack the committed grid never diverges
+  # from authored absent a membership change -- is why the skip is a cause
+  # filter where the old debounce was only a (defeatable) time filter.
+  st <- model_new()
+  members <- model_members(st)
+
+  # Authored: the members grouped into one tab (a leaf beside a group). The
+  # restore push settles it as the stored, authoritative grid.
+  st$client$pending <- client_grid(members, nested = TRUE)
+  st <- model_deliver_echo(st)$st
+  st <- model_restore(st)
+  authored <- model_stored(st)
+  expect_false(is.null(authored))
+
+  # The restore application streams the group as separate leaves, in shifting
+  # orders and sizes -- flat frames, structurally unlike the grouped authored,
+  # so only the `_state-source` skip (not the all.equal tolerance) holds them.
+  staged <- list(
+    client_grid(members),
+    client_grid(rev(members)),
+    client_grid(members, sizes = c(0.7, 0.2, 0.1))
+  )
+
+  for (i in seq_along(staged)) {
+
+    st$client$pending <- staged[[i]]
+
+    expect_false(
+      isTRUE(all.equal(authored, as_dock_grid(staged[[i]]),
+                       tolerance = grid_size_tol())),
+      info = sprintf("frame %d differs from authored", i)
+    )
+
+    res <- model_deliver_echo(st, source = "server")
+    st <- res$st
+
+    expect_identical(res$commit, 0L, info = sprintf("frame %d no commit", i))
+    expect_true(
+      isTRUE(all.equal(
+        model_stored(st), authored, tolerance = grid_size_tol()
+      )),
+      info = sprintf("frame %d holds authored", i)
+    )
+  }
+
+  # The user's own reorder is the ack: a client-sourced echo commits, exactly as
+  # a gesture always has.
+  st$client$pending <- client_grid(rev(members))
+
+  expect_identical(model_deliver_echo(st, source = "client")$commit, 1L)
 })
 
 test_that("seeded interleavings hold the invariants and converge", {

--- a/tests/testthat/test-model-interleaving.R
+++ b/tests/testthat/test-model-interleaving.R
@@ -107,13 +107,14 @@ model_set_members <- function(st, members) {
   list(st = st, commit = as.integer(!setequal(before, model_members(st))))
 }
 
-# The grid mirror, reproduced from observe_grid_echo(): a server-sourced echo --
-# an intermediate frame dockviewR streams while applying a restore -- is dropped
-# by the `_state-source` skip and never commits; a client echo casts to a
-# `dock_grid` and commits only when it falls outside the size tolerance of what
-# is stored (the all.equal guard), else no-ops. Returns the commit count so the
-# "one gesture, at most one commit" bound is checkable.
-model_deliver_echo <- function(st, source = "client") {
+# The grid mirror, reproduced from observe_grid_echo(): the restore push raises
+# a one-shot latch, and the settled echo it provokes -- a replay of what we
+# already hold -- is consumed and dropped, never committing; every other echo
+# (a client gesture, a server-driven move / resize) casts to a `dock_grid` and
+# commits only when it falls outside the size tolerance of what is stored (the
+# all.equal guard), else no-ops. Returns the commit count so the "one gesture,
+# at most one commit" bound is checkable.
+model_deliver_echo <- function(st, restoring = FALSE) {
 
   echo <- st$client$pending
 
@@ -121,7 +122,7 @@ model_deliver_echo <- function(st, source = "client") {
     return(list(st = st, commit = 0L))
   }
 
-  if (identical(source, "server")) {
+  if (isTRUE(restoring)) {
     st$client$pending <- NULL
     return(list(st = st, commit = 0L))
   }
@@ -365,17 +366,17 @@ test_that("restore rebuilds a view whose membership emptied under a ghost", {
   expect_no_error(validate_board(st$board))
 })
 
-test_that("a restore's staged frames never overwrite the authored grid", {
+test_that("the restore echo never overwrites the authored grid", {
 
-  # dockviewR applies a restored grid incrementally, streaming intermediate
-  # `_state` frames -- a tab group transiently split into separate leaves before
-  # the back tabs collapse. Each is server-sourced (the mirror's own restore
-  # push provoked it), so the `_state-source` skip drops it and the committed
-  # grid holds at the authored value: an export mid-load persists the pushed
-  # arrangement, not a frame that was never anyone's intent. The invariant --
-  # between a boundary push and its client ack the committed grid never diverges
-  # from authored absent a membership change -- is why the skip is a cause
-  # filter where the old debounce was only a (defeatable) time filter.
+  # dockviewR coalesces a restore into one settled `_state` echo (its
+  # onDidLayoutChange is buffered), and that echo replays what the mirror just
+  # pushed -- often the composed, ghost-pruned layout, structurally unlike the
+  # authored grid the board holds. The one-shot restore latch marks it, so the
+  # mirror skips exactly that echo and the committed grid holds at authored: an
+  # export mid-load persists the pushed arrangement, not a restore frame that
+  # was never anyone's intent. The latch is a cause filter where the old
+  # debounce was only a (defeatable) time filter, and -- unlike the blanket
+  # server-skip it replaces -- it frees a later move / resize echo to commit.
   st <- model_new()
   members <- model_members(st)
 
@@ -387,42 +388,31 @@ test_that("a restore's staged frames never overwrite the authored grid", {
   authored <- model_stored(st)
   expect_false(is.null(authored))
 
-  # The restore application streams the group as separate leaves, in shifting
-  # orders and sizes -- flat frames, structurally unlike the grouped authored,
-  # so only the `_state-source` skip (not the all.equal tolerance) holds them.
-  staged <- list(
-    client_grid(members),
-    client_grid(rev(members)),
-    client_grid(members, sizes = c(0.7, 0.2, 0.1))
+  # The restore's settled echo: the members as separate leaves, flat and
+  # structurally unlike the grouped authored, so only the latch (not the
+  # all.equal tolerance) holds it.
+  frame <- client_grid(members, sizes = c(0.7, 0.2, 0.1))
+  st$client$pending <- frame
+
+  expect_false(
+    isTRUE(
+      all.equal(authored, as_dock_grid(frame), tolerance = grid_size_tol())
+    )
   )
 
-  for (i in seq_along(staged)) {
+  res <- model_deliver_echo(st, restoring = TRUE)
+  st <- res$st
 
-    st$client$pending <- staged[[i]]
+  expect_identical(res$commit, 0L)
+  expect_true(
+    isTRUE(all.equal(model_stored(st), authored, tolerance = grid_size_tol()))
+  )
 
-    expect_false(
-      isTRUE(all.equal(authored, as_dock_grid(staged[[i]]),
-                       tolerance = grid_size_tol())),
-      info = sprintf("frame %d differs from authored", i)
-    )
-
-    res <- model_deliver_echo(st, source = "server")
-    st <- res$st
-
-    expect_identical(res$commit, 0L, info = sprintf("frame %d no commit", i))
-    expect_true(
-      isTRUE(all.equal(
-        model_stored(st), authored, tolerance = grid_size_tol()
-      )),
-      info = sprintf("frame %d holds authored", i)
-    )
-  }
-
-  # The user's own reorder is the ack: a client-sourced echo commits, exactly as
-  # a gesture always has.
+  # The user's own reorder is the ack: a latch-down echo commits, exactly as a
+  # gesture always has.
   st$client$pending <- client_grid(rev(members))
 
-  expect_identical(model_deliver_echo(st, source = "client")$commit, 1L)
+  expect_identical(model_deliver_echo(st)$commit, 1L)
 })
 
 test_that("seeded interleavings hold the invariants and converge", {

--- a/tests/testthat/test-panel-ops.R
+++ b/tests/testthat/test-panel-ops.R
@@ -208,6 +208,29 @@ test_that("op_move_panel relocates a live panel to the hint in one step", {
   expect_null(seen)
 })
 
+test_that("op_resize_panel sizes a live panel, skips an absent one", {
+
+  seen <- NULL
+
+  local_mocked_bindings(
+    resize_dock_panel = function(id, size, proxy) {
+      seen <<- list(id = as.character(id), size = size)
+      invisible()
+    }
+  )
+
+  dock <- fake_dock(live = c("block_panel-a", "block_panel-b"))
+
+  op_resize_panel("block_panel-a", list(size = 0.3), dock)
+  expect_identical(seen$id, "block_panel-a")
+  expect_identical(seen$size, 0.3)
+
+  # A panel not live -> no-op.
+  seen <- NULL
+  op_resize_panel("block_panel-ghost", list(size = 0.3), dock)
+  expect_null(seen)
+})
+
 test_that("op_add_panel on an inactive view places the wrapper, not the card", {
 
   # The card is a single board-level element shown in the active view; moving it

--- a/tests/testthat/test-panel-ops.R
+++ b/tests/testthat/test-panel-ops.R
@@ -8,7 +8,7 @@
 
 # A dock stub carrying only what the ops read: an authoritative live-panel set
 # the idempotency guards key on, and a placeholder proxy. The show / hide mocks
-# keep `live_panels` in step so a decomposed move behaves like the real thing.
+# keep `live_panels` in step so the idempotency guards see the real membership.
 fake_dock <- function(live = character()) {
   list(proxy = "PROXY", board_ns = identity, layout = function() NULL,
        live_panels = shiny::reactiveVal(as.character(live)))
@@ -174,43 +174,38 @@ test_that("op_select_panel selects a live member, skips an absent one", {
   expect_null(selected)
 })
 
-test_that("op_move_panel decomposes into remove + add-with-hint", {
+test_that("op_move_panel relocates a live panel to the hint in one step", {
 
-  log <- character()
+  seen <- NULL
 
   local_mocked_bindings(
-    hide_block_panel = function(id, rm_panel, dock, ...) {
-      log <<- c(log, paste0("hide:", as.character(id)))
-      track_rm(dock, id)
+    move_dock_panel = function(id, position, proxy) {
+      seen <<- list(id = as.character(id), position = position)
       invisible()
-    },
-    show_block_panel = function(block, add_panel, dock, ...) {
-      pid <- as_block_panel_id(block)
-      log <<- c(log, paste0("show:", as.character(pid), "@",
-                            add_panel$referencePanel, "/", add_panel$direction))
-      track_add(dock, pid)
-      invisible()
-    },
-    ensure_block_ui = function(...) NULL
+    }
   )
 
-  brd <- new_dock_board(
-    blocks = c(a = new_dataset_block(), b = new_head_block())
-  )
   dock <- fake_dock(live = c("block_panel-a", "block_panel-b"))
 
   op_move_panel(
-    "block_panel-a", list(near = "block_panel-b", side = "right"), dock, brd
+    "block_panel-a", list(near = "block_panel-b", side = "right"), dock
   )
 
-  # Remove then re-add at the hint; membership is unchanged (still both live).
+  # A first-class move: one dockview relocation to the hint, no remove / re-add,
+  # and membership is unchanged (the panel stays live).
+  expect_identical(seen$id, "block_panel-a")
   expect_identical(
-    log,
-    c("hide:block_panel-a", "show:block_panel-a@block_panel-b/right")
+    seen$position,
+    list(referencePanel = "block_panel-b", direction = "right")
   )
   expect_setequal(
     isolate(dock$live_panels()), c("block_panel-a", "block_panel-b")
   )
+
+  # A panel not live (a captured gesture already applied) -> no-op.
+  seen <- NULL
+  op_move_panel("block_panel-ghost", list(near = "block_panel-b"), dock)
+  expect_null(seen)
 })
 
 test_that("op_add_panel on an inactive view places the wrapper, not the card", {

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -274,6 +274,13 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   # The full three-block board is asserted against the exported artifact below.
   wait_dock_loaded(app, n_blocks = 2)
 
+  # wait_dock_loaded gates on the server-rendered cards; the dockview client
+  # restores the a/b tab group asynchronously. Wait for it to settle (b fronted,
+  # a a hidden back tab) before reading the exported grid, or the export can
+  # capture a transient separate-leaves state -- the grid mirror commits
+  # whatever the client last reported.
+  wait_active_block_tabs(app, "analysis", "block_panel-b")
+
   before <- read_dock_state(app)
 
   # The fixture seeds the dock-owned state the round-trip must preserve: two
@@ -311,11 +318,10 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
     c("ext_panel-edit_board", "block_panel-a", "block_panel-b")
   )
 
-  # The authored grid geometry (the a/b tab group, its active tab, sizes) is not
-  # asserted here: it round-trips through the client dockview restore, which is
-  # non-deterministic -- the grid mirror can commit an intermediate separate-
-  # leaves frame. The serialize / deserialize of the grid is covered directly in
-  # test-utils-serdes.R; the client leg awaits the dockviewR settled-state work.
+  # Grid geometry survives deserialization, not just membership: the analysis
+  # view restores its authored a/b tab group with b fronted (a is the hidden
+  # back tab), so only b reads as visible.
+  expect_setequal(visible_block_ids(active_view_grid(restored)), "b")
 
   # Import the saved file. Restoring reloads the session: the probe, wiped by
   # the reload, both waits for and proves the reload fired.
@@ -327,16 +333,18 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   # The reload restores Analysis as the active view, so again only its two
   # cards are built (c stays deferred with the off-screen Overview view).
   wait_dock_loaded(app, n_blocks = 2)
+  wait_active_block_tabs(app, "analysis", "block_panel-b")
 
   # The deserialize + reconcile + re-render rebuilds the dock-owned view
   # structure and the blocks identically.
   expect_identical(read_dock_state(app), before)
 
-  # Re-exporting after the reload reproduces the stored view structure (nav,
-  # membership, active view) byte-for-byte -- proving the stage / reload cycle
-  # preserved it and that the fixture re-importing its own (colliding) view ids
-  # does not drop them. The grid is excluded from the byte compare for the same
-  # reason as above: a client-rendered, mirror-committed slot.
+  # The restored board carries the per-view grid forward, not just the nav and
+  # blocks: re-exporting after the reload reproduces the stored geometry (the
+  # tab group, its active tab, the custom sizes) byte-for-byte. This reads the
+  # committed board's slots -- proving the stage / reload cycle preserved them
+  # and that the fixture re-importing its own (colliding) view ids does not drop
+  # them. It cannot see the client render, so that leg is asserted below.
   #
   # get_download can transiently fail after the reload -- the link's href is
   # filled only once outputs bind, and the download endpoint may briefly not
@@ -345,7 +353,19 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   ser2 <- jsonlite::fromJSON(path2, simplifyDataFrame = FALSE,
                              simplifyMatrix = FALSE)
 
+  expect_identical(
+    drop_focus(ser2[["payload"]][["grids"]]),
+    drop_focus(ser[["payload"]][["grids"]])
+  )
   expect_identical(ser2[["payload"]][["views"]], ser[["payload"]][["views"]])
+
+  # Client leg: the byte checks read the stored slots, so they cannot observe
+  # whether the dockview client actually applied the grid. Assert one rendered
+  # DOM fact -- the analysis view's a/b tab group restores with `b` as the front
+  # tab (its authored active tab, not `a` the first). The post-import settle
+  # wait above already held for exactly this state, so a client-side
+  # restore_layout failure or a collapse to separate leaves surfaces there.
+  expect_identical(active_block_panel_tabs(app, "analysis"), "block_panel-b")
 })
 
 test_that("deleting a block via its card menu drops the panel and its link", {

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -341,10 +341,16 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
 
   # The restored board carries the per-view grid forward, not just the nav and
   # blocks: re-exporting after the reload reproduces the stored geometry (the
-  # tab group, its active tab, the custom sizes) byte-for-byte. This reads the
-  # committed board's slots -- proving the stage / reload cycle preserved them
-  # and that the fixture re-importing its own (colliding) view ids does not drop
-  # them. It cannot see the client render, so that leg is asserted below.
+  # tab group, its active tab, the sizes). This reads the committed board's
+  # slots -- proving the stage / reload cycle preserved them and that the
+  # fixture re-importing its own (colliding) view ids does not drop them. It
+  # cannot see the client render, so that leg is asserted below.
+  #
+  # Structure and membership match exactly; the sizes match within
+  # `grid_size_tol()`. Under the restore latch the stored grid tracks the ratios
+  # dockview renders -- a post-restore select echoes them -- which jitter
+  # sub-tolerance run to run, so the byte-exact form the blanket server-skip
+  # allowed no longer holds. It returns with the dockViewR restore tag.
   #
   # get_download can transiently fail after the reload -- the link's href is
   # filled only once outputs bind, and the download endpoint may briefly not
@@ -353,9 +359,15 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   ser2 <- jsonlite::fromJSON(path2, simplifyDataFrame = FALSE,
                              simplifyMatrix = FALSE)
 
-  expect_identical(
-    drop_focus(ser2[["payload"]][["grids"]]),
-    drop_focus(ser[["payload"]][["grids"]])
+  expect_true(
+    isTRUE(
+      all.equal(
+        drop_focus(ser2[["payload"]][["grids"]]),
+        drop_focus(ser[["payload"]][["grids"]]),
+        tolerance = grid_size_tol(),
+        scale = 1
+      )
+    )
   )
   expect_identical(ser2[["payload"]][["views"]], ser[["payload"]][["views"]])
 

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -169,6 +169,68 @@ test_that("an rm verb shrinks membership; move / select leave it untouched", {
   expect_identical(board_views(selected), board_views(brd))
 })
 
+test_that("resize augments a size ref and stays a pure payload message", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = c("a", "b"))
+  )
+
+  # The wire form is a ref carrying `size`; augment canonicalizes it to the
+  # panel-keyed hint map, exactly as `move` / `add` do.
+  upd <- augment_board_update(
+    list(views = list(mod = list(
+      A = list(resize = list(blk("a", size = 0.3)))
+    ))),
+    brd
+  )
+  expect_identical(
+    upd$views$mod$A$resize, list(`block_panel-a` = list(size = 0.3))
+  )
+
+  # Like move / select, resize is client-owned geometry: the reducer writes
+  # nothing, so membership is untouched.
+  expect_identical(board_views(apply_board_update(brd, upd)), board_views(brd))
+})
+
+test_that("resize rejects a non-member, a missing size, and a bad ratio", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = c("a", "b"))
+  )
+
+  expect_error(
+    validate_board_update(
+      list(views = list(mod = list(
+        A = list(resize = list(`block_panel-c` = list(size = 0.3)))
+      ))),
+      brd
+    ),
+    class = "dock_views_mod_resize_unknown"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(views = list(mod = list(
+        A = list(resize = list(`block_panel-a` = list()))
+      ))),
+      brd
+    ),
+    class = "dock_views_mod_resize_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(views = list(mod = list(
+        A = list(resize = list(`block_panel-a` = list(size = 1.5)))
+      ))),
+      brd
+    ),
+    class = "dock_views_mod_hint_invalid"
+  )
+})
+
 test_that("a grid in views$mod is rejected at the update boundary", {
 
   brd <- new_dock_board(


### PR DESCRIPTION
## Summary

Now that #306 and dockViewR#86 (released as dockViewR 0.4.0) have landed, this rebases onto `main` and builds on the released chain: the gesture-settled `_state` emission, the first-class `move_panel`, and the `set_size` proxy.

### Settled `_state`: drop the bridge, gate the mirror on a restore latch

- `board-server.R` — `observe_grid_echo()` reads `dock$layout()` directly (the 250 ms debounce bridge is gone) and commits every settled echo that differs from what is stored, **except** the one the initial restore provokes. `manage_dock` raises a one-shot `restoring` latch around its single `restore_layout()` call; the mirror consumes it on the next echo and skips exactly that one. A restore replays the composed layout we already hold (dockViewR coalesces it into one settled echo through its buffered `onDidLayoutChange`), so committing it would overwrite the stored grid with a pruned copy or, mid-load, persist a transient frame — the bug #327 describes.
- **Not** a blanket `_state-source == "server"` skip. dockViewR raises its server flag around *every* proxy op — `add-panel`, `move-panel`, `set-size`, `restore-state`, … — so a skip keyed on the tag also drops the settled echo of a programmatic move / resize / add, and their geometry never persists (the `resize` verb below would be inert on save). The latch is owned by blockr.dock, which knows the one op — restore — whose echo is a redundant replay; every other server op's echo is new truth and commits. (A finer-grained provenance tag in dockViewR that distinguishes restore from other ops would let the mirror lean on the tag again; that is a separate upstream change.)
- `DESCRIPTION` — bump the floor to `dockViewR (>= 0.4.0)` for `move_panel` + `set_size`. dockViewR#86 merged to main, so the `@85-move-panel` branch pin is dropped; the bare `cynkra/dockViewR` remote is an interim until cynkra's r-universe rebuilds 0.4.0 (still 0.3.0), then it drops too.
- `dock-grid.R` — `all.equal.dock_grid` drops the transient `focus` marker before comparing. The stored grid carries no focus while the client's echo always does (the active group), which otherwise reads as a spurious geometry difference (the e2e `roundtrip_stable` sentinel caught exactly this). This matches the serdes `drop_focus`; a regression test covers it.
- `utils-dock.R` / `utils-serve.R` — freshen the two "debounced … echo" comments to "settled".
- `test-grid-mirror.R` / `test-model-interleaving.R` — cover the latch: a raised latch skips one echo and a later echo (a real drag, or a server move / resize) commits; the reproduced mirror asserts the restore echo never overwrites the authored grid, then a latch-down echo commits.

### First-class move: surgical `move_panel`

- `panel-ops.R` — `op_move_panel()` relocates the panel in one step via dockViewR's `move_panel(id, position)` (through a new `move_dock_panel()` helper) instead of decomposing into remove + add-with-hint; `hint_to_position()` already produces the `referencePanel` / `direction` vocabulary it consumes. The card rides along (dockview's `moveTo` keeps the panel's content), and the resulting settled echo is committed by the grid mirror — which is what persists the panel's new position.
- `test-panel-ops.R` — assert the single surgical relocation and its idempotency.

### New `resize` verb (#320)

- `dock-view.R` / `panel-ops.R` / `utils-dock.R` — `views$mod` gains a `resize` verb: `resize = list(blk("a", size = 0.3))` sizes a panel's group along its splitview axis through dockViewR's `set_size` (now on the 0.4.0 floor). It mirrors `move` — a placement verb accepting only the `size` hint, resolved through `resolve_placement_verb` and validated (member, ratio in `(0, 1)`). `op_resize_panel()` / `resize_dock_panel()` deliver to the live dock and write nothing to the board directly; the settled echo the resize provokes is committed by the grid mirror, which is what persists the new ratio. #319 had left `resize` rejected as an unknown verb pending the `set_size` proxy.

### Restore the #233 serdes e2e round-trip's grid legs

Reverts the #289 narrowing (`1a03b17`), which dropped the grid-geometry and client-render legs of `test-utils-serve.R`'s Export/Import round-trip because they were flaky against exactly the transient-frame commits this PR removes. With the settled chain plus the restore latch, a restore no longer commits a separate-leaves grid, so the legs are reliable again (dock#327): the fronted-tab `visible_block_ids(active_view_grid(restored))`, the grid round-trip across the reload, the `active_block_panel_tabs(app, "analysis")` client-render assertion, and the `wait_active_block_tabs` / `drop_focus` helpers.

The grid round-trip compares within `grid_size_tol()` rather than byte-for-byte. Under the one-shot restore latch a post-restore `select-panel` echoes the client's rendered sizes, so the stored grid tracks those (jittering sub-tolerance run to run) rather than pinning at the authored value the old blanket server-skip preserved. Structure and membership stay byte-exact; only the sizes are tolerance-compared, the same equality the mirror itself commits on. Byte-exact geometry returns once dockViewR distinguishes a restore in `_state-source` and the mirror can skip the whole restore burst — tracked in #343 (upstream cynkra/dockViewR#89).

Fixes #301
Fixes #320
Fixes #327
