### PR TITLE
Defer off-screen dockViews and client-confirm the render mark

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # blockr.dock (development version)
 
+* At startup the board now builds only the active view's dockView;
+  off-screen views' docks are created on first visit rather than all up
+  front (#304), mirroring the card deferral below. Building every view's
+  dockView left the active group pointing at an off-screen view during the
+  startup restore burst, transiently dropping the visible view's blocks and
+  starving first paint. `reconcile_views()` now builds only the active
+  view's dock and defers the rest; a view without a live dock contributes
+  its board-stored grid to `view_data()` rather than blocking it.
+
+* A view's `visible`-axis mark -- the client-confirmed paint blockr.core's
+  background-construction gate waits for -- now fires on dockViewR's
+  `_restored` echo rather than at the tail of the server-side restore loop
+  (#304). It thus tracks the client actually applying the restore, so the
+  gate holds background construction until the visible view is on screen
+  instead of releasing it while the client is still settling.
+
 * At startup the board now builds only the active view's block cards;
   off-screen views' cards are built on first visit rather than all up
   front (#272). `board_ui()` rendered an edit card for every block across

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -89,11 +89,11 @@ board_server_callback <- function(board, update, visibility, ...,
   report_visible_observer(visibility, client_active, docks)
 
   # `view_data` is the live all-views layout, split into a `dock_views` +
-  # `dock_grids` pair. It is NULL until every view has reported its layout once
-  # (the all-or-nothing in live_view_data), so consumers req() it. A view's
-  # live arrangement is read on demand here; it no longer folds back into the
-  # board's slots.
-  view_data <- live_view_data(client_views, docks, client_active)
+  # `dock_grids` pair. Each view is live where its dock has reported, else its
+  # board-stored grid, so a deferred off-screen view is represented without
+  # blocking (see live_view_data). A view's live arrangement is read on demand
+  # here; it no longer folds back into the board's slots.
+  view_data <- live_view_data(client_views, docks, board, client_active)
 
   # Each extension can read the others' server results through the
   # `extensions` environment: one active binding per id, each resolving to
@@ -217,9 +217,10 @@ report_visible_observer <- function(visibility, client_active, docks) {
 
   # Owns the required axis: over the built cards, the active view's front panels
   # go required TRUE and everything else built FALSE. It leaves the visible axis
-  # alone -- the per-view arrange observer writes it once the client has painted
-  # (mark_cards_rendered), so the two touch disjoint slots. `req(layout())`
-  # waits for the client's report (NULL before then).
+  # alone -- the per-view `_restored` observer writes it once the client
+  # confirms it painted the view (mark_cards_rendered), so the two touch
+  # disjoint slots.
+  # `req(layout())` waits for the client's report (NULL before then).
   on_screen <- reactive({
     active <- req(client_active())
     dock <- req(docks[[active]])
@@ -284,21 +285,24 @@ observe_grid_echo <- function(id, dock, board, commit_grid) {
   )
 }
 
-# Returns NULL while any view is still pending — its dock not yet created by
-# reconcile, or its dockview layout not yet reported — so downstream observers
-# `req()` past the initial flush. Reading `docks[[v_id]]` (a reactiveValues)
-# takes a dependency on each view's entry, so this re-evaluates when reconcile
-# creates the dock — whatever the init flush order — rather than stranding on
-# the empty-`docks` early return. The active view comes from `client_active`,
-# not `client_views`. The live all-views layout is returned split into a
-# `dock_views` (membership + names + active) and a `dock_grids` (geometry) --
-# the same shape the board stores.
-live_view_data <- function(client_views, docks, client_active) {
+# The live all-views layout, split into a `dock_views` (membership + names +
+# active) and a `dock_grids` (geometry) pair -- the same shape the board stores.
+# Each view contributes its live dockview grid once its dock has reported, and
+# its board-stored grid otherwise, so an off-screen view whose dock is deferred
+# (never created this session, #304) is represented by what it would restore to
+# rather than blocking every consumer on a layout that never arrives. Reading
+# `docks[[v_id]]` (a reactiveValues) takes a dependency on each view's entry, so
+# a view upgrades from stored to live when reconcile creates its dock and it
+# reports -- whatever the flush order. NULL now only stands for a view briefly
+# in the nav model but not yet on the board (a sub-flush removal transient),
+# which consumers `req()` past. The active view comes from `client_active`, not
+# `client_views`.
+live_view_data <- function(client_views, docks, board, client_active) {
   reactive({
 
     state <- client_views()
 
-    grids <- lapply(names(state), live_view_grid, docks = docks)
+    grids <- lapply(names(state), live_view_grid, docks = docks, board = board)
 
     if (any(lgl_ply(grids, is.null))) {
       return(NULL)
@@ -320,21 +324,28 @@ live_view_data <- function(client_views, docks, client_active) {
   })
 }
 
-live_view_grid <- function(v_id, docks) {
+# A view's live grid once its dock has reported, else its board-stored grid
+# (composed from the view's membership and grid slot) -- the #304 fallback that
+# keeps a deferred off-screen view from blocking view_data. NULL only when the
+# view is not on the board.
+live_view_grid <- function(v_id, docks, board) {
 
   dk <- docks[[v_id]]
 
-  if (is.null(dk)) {
+  if (!is.null(dk)) {
+    ly <- dk$layout()
+    if (!is.null(ly)) {
+      return(as_dock_grid(as_dock_layout(ly)))
+    }
+  }
+
+  views <- board_views(board$board)
+
+  if (!(v_id %in% names(views))) {
     return(NULL)
   }
 
-  ly <- dk$layout()
-
-  if (is.null(ly)) {
-    return(NULL)
-  }
-
-  as_dock_grid(as_dock_layout(ly))
+  as_dock_grid(view_grid(views[[v_id]], board_grids(board$board)[[v_id]]))
 }
 
 live_view_membership <- function(grid, view) {
@@ -446,11 +457,14 @@ remove_view <- function(v_id, session, docks) {
   invisible()
 }
 
-# Make the live dock session match the committed board's view set:
-# instantiate added views, tear down removed ones, relabel renamed ones, and
-# switch to the active view. The board owns which views exist, their names and
-# the active one; a view's per-view arrangement is client-owned, read live via
-# view_data() and never folded back into the board, so reconcile never
+# Make the live dock session match the committed board's view set. The nav model
+# (`client_views`) tracks every view -- added, removed, renamed -- but only the
+# active view's dock is instantiated; off-screen views are deferred and their
+# dock built on first visit, when a later reconcile finds them active (#304).
+# This mirrors board_ui's card deferral: the nav lists every view, the heavy
+# per-view machinery follows the user. The board owns which views exist, their
+# names and the active one; a view's per-view arrangement is client-owned, read
+# live via view_data() and never folded back into the board, so reconcile never
 # pushes a layout to its live dock. Takes the reactive board handle (not a
 # snapshot) so the live list reaches manage_dock, whose interaction observers
 # read board$board after the fact (#194); the committed board is snapshotted
@@ -472,46 +486,26 @@ reconcile_views <- function(board, update, docks, active_dock,
   state <- isolate(client_views())
   have <- names(docks)
   shown <- names(state)
-  visibility <- isolate(active_dock$visibility)
 
-  for (v in setdiff(want, have)) {
-
-    create_view(
-      v,
-      view_grid(views[[v]], if (is.null(grids)) NULL else grids[[v]]),
-      board,
-      update,
-      session,
-      docks,
-      visibility,
-      blocks = board_blocks(brd),
-      extensions = dock_extensions(brd),
-      active = identical(v, server_active)
-    )
-
-    state[[v]] <- bare_view(views[[v]])
-  }
-
-  # Add a nav item only for views the nav doesn't already show. `board_ui`
-  # renders every seeded view statically, so this set is empty on init;
-  # gating on `docks` (also empty on init) instead re-adds each as a
+  # Nav + client_views model: every view, built or deferred. `board_ui` seeds
+  # the nav statically, so `shown` already lists every view on init and this add
+  # loop is empty then; keying it on `docks` instead re-adds each as a
   # blank-labelled duplicate (#189). Label from the container `view_names()`,
   # which resolves whether the name sits on the layout or is derived from id.
   for (v in setdiff(want, shown)) {
+    state[[v]] <- bare_view(views[[v]])
     session$sendInputMessage(
       "view_nav",
       list(add = list(id = v, name = labels[[v]]))
     )
   }
 
-  for (v in setdiff(have, want)) {
-
-    remove_view(v, session, docks)
+  for (v in setdiff(shown, want)) {
     session$sendInputMessage("view_nav", list(remove = v))
     state[[v]] <- NULL
   }
 
-  for (v in intersect(want, have)) {
+  for (v in intersect(want, shown)) {
 
     new_nm <- view_name(views[[v]])
 
@@ -522,6 +516,36 @@ reconcile_views <- function(board, update, docks, active_dock,
         list(rename = list(id = v, to = new_nm))
       )
     }
+  }
+
+  # Dock lifecycle: tear down docks whose view the board dropped, then build the
+  # active view's dock if it is not up yet -- deferring every other view to the
+  # reconcile its first visit triggers. `active` stamps the active CSS class at
+  # insert only at startup (no view shown yet) so the first paint needs no
+  # switch; a mid-session first visit is activated by switch_active_view below.
+  for (v in setdiff(have, want)) {
+    remove_view(v, session, docks)
+  }
+
+  if (!is.null(server_active) && !(server_active %in% names(docks))) {
+
+    active_grid <- view_grid(
+      views[[server_active]],
+      if (is.null(grids)) NULL else grids[[server_active]]
+    )
+
+    create_view(
+      server_active,
+      active_grid,
+      board,
+      update,
+      session,
+      docks,
+      isolate(active_dock$visibility),
+      blocks = board_blocks(brd),
+      extensions = dock_extensions(brd),
+      active = is.null(isolate(client_active()))
+    )
   }
 
   client_views(state)
@@ -654,12 +678,21 @@ manage_dock <- function(
             )
           }
         }
-
-        # Every card the layout calls for is now moved into its panel: the view
-        # is arranged. Write this view id into its on-screen blocks' visible
-        # slot -- the client-confirmed paint core's construction gate waits for.
-        mark_cards_rendered(visibility, visible_block_ids(init_layout), id)
       },
+      once = TRUE
+    )
+
+    # The view is arranged only once the client confirms it. dockViewR fires
+    # `_restored` (event priority) after applying the restore, and the client
+    # flushes it back only after running the card moves batched with that push
+    # -- so it stands for the visible view being on screen, not merely
+    # dispatched. Writing each on-screen block's `visible` slot here, off that
+    # client-confirmed signal rather than the tail of the server-side restore
+    # loop, gives core the paint its background-construction gate waits for
+    # (#304).
+    observeEvent(
+      input[[dock_input("restored")]],
+      mark_cards_rendered(visibility, visible_block_ids(init_layout), id),
       once = TRUE
     )
 

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -345,38 +345,59 @@ test_that("rename skips views without the block's panel (#116)", {
   expect_identical(renamed, as.character(as_block_panel_id("a")))
 })
 
-test_that("live_view_data is NULL while any view layout is uninitialized", {
+test_that("live_view_data uses a view's stored grid until it reports (#304)", {
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
 
-  layouts <- with_mock_context(ms, {
-    list(A = reactiveVal(NULL), B = reactiveVal(NULL))
-  })
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = "a", B = "b")
+  )
 
   res <- with_mock_context(ms, {
-    client_views <- reactiveVal(
-      reconstruct_dock_views(list(A = dock_view(), B = dock_view()))
-    )
+    board <- reactiveValues(board = brd)
+    client_views <- reactiveVal(seed_view_state(board_views(brd)))
     ids <- names(client_views())
+    layouts <- list(A = reactiveVal(NULL), B = reactiveVal(NULL))
     docks <- reactiveValues()
     docks[[ids[[1L]]]] <- list(layout = layouts$A)
     docks[[ids[[2L]]]] <- list(layout = layouts$B)
     client_active <- reactiveVal(ids[[1L]])
-    list(vd = live_view_data(client_views, docks, client_active))
+    list(
+      vd = live_view_data(client_views, docks, board, client_active),
+      layouts = layouts,
+      ids = ids
+    )
   })
 
-  expect_null(isolate(res$vd()))
+  # Neither dock has reported a live layout, so every view falls back to its
+  # board-stored grid: view_data is populated (no all-or-nothing block) rather
+  # than NULL.
+  vd0 <- isolate(res$vd())
+  expect_named(vd0, c("views", "grids"))
+  expect_s3_class(vd0$views, "dock_views")
+  expect_identical(unname(view_names(vd0$views)), c("A", "B"))
+  expect_identical(
+    layout_panel_ids(vd0$grids[[res$ids[[1L]]]]), "block_panel-a"
+  )
+  expect_identical(
+    layout_panel_ids(vd0$grids[[res$ids[[2L]]]]), "block_panel-b"
+  )
+  expect_identical(active_name(vd0$views), "A")
 
-  with_mock_context(ms, layouts$A(list(grid = list(), panels = list())))
-  expect_null(isolate(res$vd()))
+  # A view reporting a live layout upgrades to it; the other stays stored.
+  g <- as_dock_grid(dock_grid("block_panel-b", "block_panel-a"))
+  reported <- list(grid = grid_to_tree(g), activeGroup = "1")
+  with_mock_context(ms, res$layouts$A(reported))
 
-  with_mock_context(ms, layouts$B(list(grid = list(), panels = list())))
-
-  lys <- isolate(res$vd())
-  expect_named(lys, c("views", "grids"))
-  expect_s3_class(lys$views, "dock_views")
-  expect_identical(unname(view_names(lys$views)), c("A", "B"))
-  expect_identical(active_name(lys$views), "A")
+  vd1 <- isolate(res$vd())
+  expect_identical(
+    layout_panel_ids(vd1$grids[[res$ids[[1L]]]]),
+    c("block_panel-b", "block_panel-a")
+  )
+  expect_identical(
+    layout_panel_ids(vd1$grids[[res$ids[[2L]]]]), "block_panel-b"
+  )
 })
 
 test_that("live_view_data re-evaluates once docks are populated (#243)", {
@@ -392,31 +413,46 @@ test_that("live_view_data re-evaluates once docks are populated (#243)", {
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())
 
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = c("a", "b"))
+  )
+
   res <- with_mock_context(ms, {
-    client_views <- reactiveVal(reconstruct_dock_views(list(A = dock_view())))
+    board <- reactiveValues(board = brd)
+    client_views <- reactiveVal(seed_view_state(board_views(brd)))
     docks <- reactiveValues()
     client_active <- reactiveVal(NULL)
     list(
-      vd = live_view_data(client_views, docks, client_active),
+      vd = live_view_data(client_views, docks, board, client_active),
       docks = docks,
       view = names(client_views())[[1L]]
     )
   })
 
-  # First read with empty docks: NULL, but the absent-key read has subscribed.
-  expect_null(isolate(res$vd()))
+  # First read with empty docks: the view falls back to its stored grid (seeded
+  # order), and the absent-key read has subscribed.
+  vd0 <- isolate(res$vd())
+  expect_named(vd0, c("views", "grids"))
+  expect_identical(
+    layout_panel_ids(vd0$grids[[res$view]]),
+    c("block_panel-a", "block_panel-b")
+  )
 
-  # Mimic reconcile creating the dock: the reactiveValues write alone
-  # re-triggers live_view_data.
+  # Mimic reconcile creating the dock and the client reporting a reordered live
+  # layout: the reactiveValues write re-triggers live_view_data, upgrading from
+  # stored to the live order.
+  g <- as_dock_grid(dock_grid("block_panel-b", "block_panel-a"))
   layout <- with_mock_context(
-    ms, reactiveVal(list(grid = list(), panels = list()))
+    ms, reactiveVal(list(grid = grid_to_tree(g), activeGroup = "1"))
   )
   with_mock_context(ms, res$docks[[res$view]] <- list(layout = layout))
 
-  lys <- isolate(res$vd())
-
-  expect_named(lys, c("views", "grids"))
-  expect_identical(unname(view_names(lys$views)), "A")
+  vd1 <- isolate(res$vd())
+  expect_identical(
+    layout_panel_ids(vd1$grids[[res$view]]),
+    c("block_panel-b", "block_panel-a")
+  )
 })
 
 test_that("view_data() tracks a reported layout despite flush order (#243)", {
@@ -444,8 +480,14 @@ test_that("view_data() tracks a reported layout despite flush order (#243)", {
     )
   )
 
-  # Force the first read before reconcile runs: docks empty, so NULL.
-  expect_null(isolate(res$view_data()))
+  # Before reconcile runs the dock is not up, so view_data falls back to Page's
+  # board-stored grid (seeded order) rather than blocking.
+  vd0 <- isolate(res$view_data())
+  expect_named(vd0, c("views", "grids"))
+  expect_identical(
+    layout_panel_ids(vd0$grids[["Page"]]),
+    c("block_panel-a", "block_panel-b")
+  )
 
   ms$flushReact()
 
@@ -466,6 +508,137 @@ test_that("view_data() tracks a reported layout despite flush order (#243)", {
     layout_panel_ids(vd$grids[["Page"]]),
     c("block_panel-b", "block_panel-a")
   )
+})
+
+test_that("reconcile builds only the active view's dock (#304)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  brd <- new_dock_board(
+    blocks = c(
+      a = new_dataset_block(), b = new_head_block(), c = new_head_block()
+    ),
+    views = list(A = "a", B = "b", C = "c"),
+    active = "B"
+  )
+  active_id <- active_view(board_views(brd))
+
+  created <- character()
+  flags <- list()
+
+  # Stand in for create_view: record which views are built (and the no-flash
+  # `active` stamp) without the DOM / module machinery.
+  stub_create <- function(v_id, layout, board, update, session, docks,
+                          visibility, ..., active = FALSE) {
+    created <<- c(created, v_id)
+    flags[[v_id]] <<- active
+    docks[[v_id]] <- list(layout = function() NULL)
+  }
+
+  docks <- with_mock_context(ms, reactiveValues())
+  client_views <- with_mock_context(
+    ms, reactiveVal(seed_view_state(board_views(brd)))
+  )
+  client_active <- with_mock_context(ms, reactiveVal(NULL))
+  active_dock <- with_mock_context(
+    ms, reactiveValues(visibility = fake_visibility(board_block_ids(brd)))
+  )
+  update <- with_mock_context(ms, reactiveVal())
+  session <- list(
+    ns = identity,
+    sendInputMessage = function(...) invisible(),
+    sendCustomMessage = function(...) invisible()
+  )
+
+  reconcile <- function(board_obj) {
+    with_mocked_bindings(
+      with_mock_context(
+        ms,
+        reconcile_views(
+          board_obj, update, docks, active_dock, client_active, client_views,
+          session
+        )
+      ),
+      create_view = stub_create,
+      # Mimic the client acknowledging the switch so a later reconcile sees the
+      # new active view.
+      switch_active_view = function(active, ...) client_active(active),
+      .package = "blockr.dock"
+    )
+  }
+
+  board_obj <- with_mock_context(ms, reactiveValues(board = brd))
+  reconcile(board_obj)
+
+  # Only the active view's dock is built; the other two are deferred. It is
+  # stamped active at insert (no view shown yet) so the first paint needs no
+  # switch round-trip.
+  expect_identical(created, active_id)
+  expect_identical(with_mock_context(ms, names(docks)), active_id)
+  expect_true(flags[[active_id]])
+
+  # Visiting a deferred view (the board makes it active) builds its dock on
+  # demand -- inactive, since switch_active_view activates it.
+  visited <- setdiff(names(board_views(brd)), active_id)[[1L]]
+  board_obj$board <- apply_views_active(visited, brd)
+  reconcile(board_obj)
+
+  expect_setequal(with_mock_context(ms, names(docks)), c(active_id, visited))
+  expect_false(flags[[visited]])
+})
+
+test_that("rendered is reported only on client-confirmed restore (#304)", {
+
+  # The active view's blocks go `required` (on screen) through the server-side
+  # restore loop, but their `visible` slot -- the client-confirmed paint core's
+  # gate waits for -- is written only on the client's `_restored` echo, not the
+  # loop tail.
+  local_mocked_bindings(
+    restore_layout = function(...) invisible(),
+    show_block_panel = function(...) invisible(),
+    show_ext_panel = function(...) invisible(),
+    .package = "blockr.dock"
+  )
+
+  # Separate leaves so both a and b front their own group (both on screen);
+  # the default grid would tab them together, hiding b as a back tab.
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    grids = list(Page = dock_grid("a", "b"))
+  )
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  vis <- with_mock_context(ms, fake_visibility(board_rv))
+  with_mock_context(
+    ms,
+    board_server_callback(board_rv, update = reactiveVal(), visibility = vis)
+  )
+  ms$flushReact()
+
+  # The client reports its live layout and that the dock initialized: the
+  # restore loop runs, placing a and b on screen (required TRUE), but nothing
+  # has confirmed the paint, so their visible slots stay NA.
+  g <- as_dock_grid(dock_grid("block_panel-a", "block_panel-b"))
+  reported <- list(grid = grid_to_tree(g), activeGroup = "1")
+  do.call(ms$setInputs, set_names(list(reported), "Page-dock_state"))
+  do.call(ms$setInputs, set_names(list(TRUE), "Page-dock_initialized"))
+  ms$flushReact()
+
+  expect_identical(isolate(vis$required[["a"]]()), TRUE)
+  expect_identical(isolate(vis$required[["b"]]()), TRUE)
+  expect_true(is.na(isolate(vis$visible[["a"]]())))
+  expect_true(is.na(isolate(vis$visible[["b"]]())))
+
+  # The client acknowledges the restore -- now the blocks are painted, their
+  # visible slot carrying the active view id.
+  do.call(ms$setInputs, set_names(list(TRUE), "Page-dock_restored"))
+  ms$flushReact()
+
+  page <- with_mock_context(ms, vid(board_rv$board, "Page"))
+  expect_identical(isolate(vis$visible[["a"]]()), page)
+  expect_identical(isolate(vis$visible[["b"]]()), page)
 })
 
 test_that("visible_block_ids returns the front-tab block of each group", {

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -473,13 +473,16 @@ test_that("view lifecycle: switch, rename, remove a view (#232)", {
     sprintf("#my_board-view_nav .blockr-view-item[data-view-id=\"%s\"]", id)
   }
 
-  # First is active on load: its dock alone carries blockr-view-dock-active.
+  # First is active on load, and off-screen views' docks are deferred (#304),
+  # so only its dock is built -- carrying blockr-view-dock-active. Second's dock
+  # materialises on first visit (below).
   docks <- read_view_docks(app)
-  expect_setequal(docks$id, c(first, second))
-  expect_identical(docks$id[docks$active], first)
+  expect_identical(docks$id, first)
+  expect_true(docks$active)
 
   # Switch active view: clicking the Second nav item reports its id to
-  # `view_nav`; the reconcile swaps which dock is active.
+  # `view_nav`; the reconcile builds Second's deferred dock on this first visit
+  # and swaps which dock is active.
   app$run_js(
     paste0("document.querySelector('", item_sel(second), "').click()")
   )
@@ -488,7 +491,9 @@ test_that("view lifecycle: switch, rename, remove a view (#232)", {
   nav <- read_view_nav(app)
   expect_identical(nav$label[nav$active], "Second")
 
+  # Second's dock is now built and active; First's stays around, inactive.
   docks <- read_view_docks(app)
+  expect_setequal(docks$id, c(first, second))
   expect_identical(docks$id[docks$active], second)
 
   # Rename the active view through the pencil: it swaps the label span for an


### PR DESCRIPTION
## Summary

Promotes the two coupled defects profiled in #289 (comment 4902313632) to their fix. On a many-view board (cdex scale: 99 blocks, 12 views) the visible view painted dead-last at startup once the #293 stack removed the churn that had been accidentally re-establishing visibility early.

- **Defer off-screen views' dockViews.** `reconcile_views()` now builds only the active view's dock; every other view's dock is created on first visit, when a later reconcile finds it active — mirroring #289's card deferral. Initialising every view's dockView at startup left the dock active group pointing at an off-screen view (the transient 0/99 visibility drop), which suspended the two blocks the user was looking at.
- **Report `rendered` from the client, not the server loop.** The per-view `initialized` flag now flips on dockViewR's `_restored` echo — the client confirming it applied the restore and the card moves batched with it — rather than at the tail of the server-side `show_block_panel()` loop. Core's render gate (#257/#259) then releases background block construction only once the visible view is actually on screen, instead of before, where it monopolised the single R process for ~2 minutes while the client's settle events queued behind it.
- **`view_data()` no longer blocks on a never-reporting view.** The old all-or-nothing NULL (every view must report a live layout once) can't hold when off-screen docks are never created. A view without a live dock now contributes its board-stored arrangement — what it would restore to — and upgrades to live once its dock reports. Serialization reads the stored slots directly since #273, so nothing downstream regresses.

Also corrects two tests that were already failing on the #289 tip (`the visibility seed reads the active view's open tabs`, `... falls back to all members when unexpressed`): they still asserted the old flat `visible()` id-set after `de19288` moved that channel to the named `required`/`rendered` status. Independent of this change — they fail on `272-defer-offscreen-cards` without it.

New regression tests cover both halves, each verified to fail on the unfixed code. The cdex-scale acceptance (visible view paints before background construction; no 0/99 transient) and the browser-render behaviour stay CI / real-app territory: the dock e2e layer does not render dockview locally, and workflow CI is dormant while the branch is stacked.

Stacked on #289 (`272-defer-offscreen-cards`). Retarget to `main` once the stack lands.

Fixes #304
