### PR TITLE
Skip block rename in views that lack the block's panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # blockr.dock (development version)
 
+* Renaming a block no longer crashes a board where that block is absent
+  from some view -- a block placed in only one of several views, or
+  parked in the offcanvas with no panel at all. The per-view rename
+  observer fires for every view; it now skips the ones whose dock does
+  not hold the renamed block instead of pushing the new title to a panel
+  that view lacks, which reached dockView with an unknown id and threw
+  client-side (#116).
+
 * A board's per-view layout is now split into two independent slots: a
   `dock_views` collection of structure objects (each view's ordered
   panel-id set, name and id, plus the active view), read with

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -658,9 +658,17 @@ manage_dock <- function(
             next
           }
 
-          new_name <- delta[["block_name"]]
           blk_panel_id <- as_block_panel_id(blk_id)
 
+          # This observer fires for every view; skip the docks that do not hold
+          # this block. live_panels() is the authoritative server-side
+          # membership set -- pushing a title to a panel absent from this dock
+          # reaches dockView with an unknown id and throws client-side.
+          if (!as.character(blk_panel_id) %in% live_panels()) {
+            next
+          }
+
+          new_name <- delta[["block_name"]]
           old_title <- get_dock_panel(blk_panel_id, dock$proxy)$title
 
           if (identical(new_name, old_title)) {

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -258,6 +258,66 @@ test_that("renaming a block refreshes the dock panel title (#193)", {
   expect_identical(title_set, "Renamed")
 })
 
+test_that("rename skips views without the block's panel (#116)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  # A board whose single view holds only `a`; `b` is parked with no panel in
+  # this view's dock. The per-view rename observer fires for every view, so it
+  # must skip the ones that do not hold the renamed block -- pushing a title to
+  # an absent panel reaches dockView with an unknown id and throws client-side.
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars")),
+    layouts = list(v1 = dock_layout("a", name = "V1"))
+  )
+  upd <- reactiveVal()
+
+  with_mock_context(ms, {
+    manage_dock(
+      "dock_main", board_rv, update = upd,
+      layout = board_layouts(board_rv$board)[["v1"]]
+    )
+  })
+
+  ms$flushReact()
+
+  renamed <- character()
+
+  rename <- function(blk_id, name) {
+    with_mocked_bindings(
+      with_mocked_bindings(
+        {
+          with_mock_context(ms, {
+            upd(list(blocks = list(mod = set_names(
+              list(list(block_name = name)), blk_id
+            ))))
+          })
+          ms$flushReact()
+        },
+        set_panel_title = function(proxy, id, title, ...) {
+          renamed <<- c(renamed, as.character(id))
+          invisible(proxy)
+        },
+        .package = "dockViewR"
+      ),
+      get_dock_panel = function(id, ...) {
+        if (identical(as.character(id), as.character(as_block_panel_id("a")))) {
+          list(title = "iris")
+        } else {
+          NULL
+        }
+      }
+    )
+  }
+
+  rename("b", "Renamed b")
+  expect_identical(renamed, character())
+
+  rename("a", "Renamed a")
+  expect_identical(renamed, as.character(as_block_panel_id("a")))
+})
+
 test_that("live_view_data is NULL while any view layout is uninitialized", {
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())


### PR DESCRIPTION
## Summary

- The per-view rename observer fires for *every* view and pushed the renamed block's new title to its own dock unconditionally. For a view whose dock doesn't hold that block, `get_dock_panel()` returns `NULL` and the title push then reached dockView with an unknown panel id, throwing `TypeError: Cannot read properties of undefined (reading 'api')` client-side. Before #202 made the comparison `NULL`-safe, the same absence surfaced as the `argument is of length zero` server error this issue was filed under — same root cause, moved symptom.
- Root fix: gate the push on `live_panels()`, the authoritative server-side panel-membership set the module already maintains, so a view updates only panels it actually holds. This is the one observer in `manage_dock` that reacts to a board-global signal rather than its own dock's client events, so it's the only place that can target a panel the view lacks — `set_panel_title` has no other call site.
- Regression test drives the observer for a two-block board whose single view holds only one block: renaming the parked block must not reach `set_panel_title` (it does on unfixed code — the crash), while renaming the held block still relabels its panel.

Supersedes #117, which guarded the pre-#202 `new_name == old_title` line that no longer exists on `main` (as noted in the issue thread). This gates on the authoritative membership set rather than inferring presence from the browser-echoed dock state.

Fixes #116
