### PR TITLE
Defer app$stop() so a failing e2e assertion can't leak the server

### DIFF
--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -73,6 +73,7 @@ test_that("edit board extension links blocks (e2e)", {
     seed = 42,
     load_timeout = 30 * 1000
   )
+  withr::defer(app$stop())
 
   set_in(app, "new_link_id", "ab")
   click(app, "add_link")
@@ -91,8 +92,6 @@ test_that("edit board extension links blocks (e2e)", {
   expect_identical(field(app, "ab_from"), "a")
   expect_identical(field(app, "ab_to"), "b")
   expect_identical(field(app, "ab_input"), "data")
-
-  app$stop()
 })
 
 test_that("adding a second block keeps both block panels (#196)", {
@@ -127,8 +126,6 @@ test_that("adding a second block keeps both block panels (#196)", {
   # only the extension (#196). Both block tabs must survive.
   add_block("head_block", "b")
   expect_identical(block_panel_tabs(app), c("block_panel-a", "block_panel-b"))
-
-  app$stop()
 })
 
 test_that("edit board extension stacks (e2e)", {
@@ -141,6 +138,7 @@ test_that("edit board extension stacks (e2e)", {
     seed = 42,
     load_timeout = 30 * 1000
   )
+  withr::defer(app$stop())
 
   set_in(app, "new_stack_id", "grp")
   click(app, "add_stack")
@@ -177,8 +175,6 @@ test_that("edit board extension stacks (e2e)", {
   app$wait_for_idle()
 
   expect_null(field(app, "grp_name"))
-
-  app$stop()
 })
 
 test_that("multi-view nav renders one labelled entry per view (#189)", {


### PR DESCRIPTION
## Summary

- Three e2e tests in `test-utils-serve.R` stopped their `AppDriver` with a bare trailing `app$stop()`. When an earlier `expect_*` throws, that line never runs, leaking the Shiny server and chromote session — the "address already in use" startup contention that ejects PRs from the merge queue.
- Move those teardowns to `withr::defer(app$stop())` right after `AppDriver$new`, so every AppDriver test releases its server unconditionally even when an assertion fails. This also drops a redundant explicit `app$stop()` that the "keeps both block panels" test already deferred.
- Net effect: all 14 AppDriver tests now tear down via `withr::defer` (previously 11), and no bare `app$stop()` remains. Test-hygiene only — no runtime code or assertions changed.

This is the first "Suggested directions" item in #205 (switch every e2e test to `withr::defer(app$stop())`). It intentionally does **not** close the issue: #205 stays open to track the temporary upstream `shinytest2` pin, which drops once rstudio/shiny#4400 lands.

Part of #205
