### PR TITLE
Route show_panel through the update channel instead of a dock arg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* A dock extension opens a panel with `show_panel(id, board, update)`, which
+  now emits the request on the board `update` channel instead of taking a live
+  `dock` handle; the dock realizes it against the active view internally.
+  Retiring the `dock` handle from the extension surface had left `blockr.dag`
+  -- which opens a block's panel on node click -- with no way to reach it,
+  breaking node-click-to-open-panel on every board with a DAG extension.
+  Routing the request through `update` restores that path while keeping the
+  dock internal (#308).
+
 * Renaming a block no longer crashes a board where that block is absent
   from some view -- a block placed in only one of several views, or
   parked in the offcanvas with no panel at all. The per-view rename

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -102,9 +102,11 @@ board_server_callback <- function(board, update, visible, ...,
   # both -- they are consumed on each side (serialization and the edit-block
   # plugin read the returned pair). The gaps are deliberate: `dock`
   # (active_dock) is returned for core's block insert / remove plugin but
-  # withheld from extensions, which read layout via `view_data`; `board` /
-  # `update` are core's own inputs, not echoed back; the peer env stays
-  # internal (core gets the resolved `ext_res`).
+  # withheld from extensions -- they read layout via `view_data` and open
+  # panels via `show_panel()`, which routes the request through `update` to the
+  # show_panel observer rather than handing out the dock; `board` / `update`
+  # are core's own inputs, not echoed back; the peer env stays internal (core
+  # gets the resolved `ext_res`).
   ext_res <- lapply(
     exts,
     extension_server,
@@ -124,6 +126,18 @@ board_server_callback <- function(board, update, visible, ...,
   observeEvent(
     update()$extensions$mod,
     apply_extensions_mod(update()$extensions$mod, ext_res)
+  )
+
+  # A dock extension opens a panel by emitting `views$show_panel` on the update
+  # channel (via the exported show_panel()); it is realized here, where the
+  # active_dock mirror is in scope, so the extension never handles the dock.
+  observeEvent(
+    update()$views$show_panel,
+    {
+      panel <- update()$views$show_panel
+
+      open_panel(panel$id, isolate(board$board), active_dock, panel$type)
+    }
   )
 
   register_actions(actions, triggers, board, update, ext_res)

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -102,18 +102,23 @@ determine_panel_pos <- function(dock) {
 #' UI utilities
 #'
 #' Exported utilities for manipulating dock panels (i.e. displaying panels).
+#' Called from a dock extension, `show_panel()` requests that a panel be
+#' opened (or focused, if already open) in the active view. It emits the
+#' request on the board `update` channel; the dock realizes it against the
+#' active view internally, so an extension supplies only the object `id`, the
+#' `board` and its `update` handle -- never the dock itself.
 #'
 #' @param id Object ID
 #' @param board Board object
-#' @param dock Object available as `dock` in extensions
-#' @param type Either "block" or "extensions", depending on what kind of panel
+#' @param update Board update signal, as received by an extension server
+#' @param type Either "block" or "extension", depending on what kind of panel
 #'   should be shown
 #'
 #' @return `NULL`, invisibly
 #'
 #' @rdname panel
 #' @export
-show_panel <- function(id, board, dock, type = c("block", "extension")) {
+show_panel <- function(id, board, update, type = c("block", "extension")) {
 
   stopifnot(is_string(id))
 
@@ -123,6 +128,19 @@ show_panel <- function(id, board, dock, type = c("block", "extension")) {
     stopifnot(id %in% board_block_ids(board))
   } else {
     stopifnot(id %in% dock_ext_ids(board))
+  }
+
+  update(list(views = list(show_panel = list(id = id, type = type))))
+
+  invisible()
+}
+
+open_panel <- function(id, board, dock, type = c("block", "extension")) {
+
+  type <- match.arg(type)
+
+  if (is.null(dock$proxy)) {
+    return(invisible())
   }
 
   panels <- dock_panel_ids(dock$proxy)

--- a/man/panel.Rd
+++ b/man/panel.Rd
@@ -4,16 +4,16 @@
 \alias{show_panel}
 \title{UI utilities}
 \usage{
-show_panel(id, board, dock, type = c("block", "extension"))
+show_panel(id, board, update, type = c("block", "extension"))
 }
 \arguments{
 \item{id}{Object ID}
 
 \item{board}{Board object}
 
-\item{dock}{Object available as \code{dock} in extensions}
+\item{update}{Board update signal, as received by an extension server}
 
-\item{type}{Either "block" or "extensions", depending on what kind of panel
+\item{type}{Either "block" or "extension", depending on what kind of panel
 should be shown}
 }
 \value{
@@ -21,4 +21,9 @@ should be shown}
 }
 \description{
 Exported utilities for manipulating dock panels (i.e. displaying panels).
+Called from a dock extension, \code{show_panel()} requests that a panel be
+opened (or focused, if already open) in the active view. It emits the
+request on the board \code{update} channel; the dock realizes it against the
+active view internally, so an extension supplies only the object \code{id}, the
+\code{board} and its \code{update} handle -- never the dock itself.
 }

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1044,3 +1044,37 @@ test_that("New view modal confirm submits an add-and-activate delta", {
     }
   )
 })
+
+test_that("views$show_panel realizes against the active dock (#308)", {
+
+  captured <- NULL
+
+  local_mocked_bindings(
+    open_panel = function(id, board, dock, type) {
+      captured <<- list(id = id, type = type)
+      invisible()
+    }
+  )
+
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block()),
+    layouts = list(Page = list("a"))
+  )
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  upd <- reactiveVal()
+  with_mock_context(
+    ms,
+    board_server_callback(board_rv, update = upd, visible = reactiveVal())
+  )
+  ms$flushReact()
+
+  isolate(
+    upd(list(views = list(show_panel = list(id = "a", type = "block"))))
+  )
+  ms$flushReact()
+
+  expect_identical(captured, list(id = "a", type = "block"))
+})

--- a/tests/testthat/test-utils-ui.R
+++ b/tests/testthat/test-utils-ui.R
@@ -33,3 +33,25 @@ test_that("determine_panel_pos places freely before the dock initialises", {
     list(direction = "right")
   )
 })
+
+test_that("show_panel() emits a views$show_panel intent on update", {
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+
+  captured <- NULL
+  update <- function(x) captured <<- x
+
+  show_panel("a", brd, update)
+
+  expect_identical(
+    captured,
+    list(views = list(show_panel = list(id = "a", type = "block")))
+  )
+})
+
+test_that("show_panel() rejects an id absent from the board", {
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+
+  expect_error(show_panel("missing", brd, function(x) NULL))
+})


### PR DESCRIPTION
## Summary

- `show_panel()` no longer takes a live `dock` handle. It emits a `views$show_panel` request on the board `update` channel, and a `board_server_callback()` observer realizes it against the internal `active_dock` (the old body, relocated to `open_panel()`). The dock handle stays internal.
- #265 retired the active-view dock handle from the extension server surface, but the exported `show_panel()` still dereferenced `dock$proxy` — so `blockr.dag`'s node-select observer, calling `show_panel(id, board, dock)`, broke with `argument "dock" is missing`, killing node-click-to-open-panel on every board with a DAG extension.
- Routing through `update` restores a supported panel-open path without re-exposing the dock: extensions read layout via `view_data` and open panels via `show_panel()`, both without the handle. No `blockr.core` change is required — core validates only `blocks`/`links`/`stacks` update slots and passes dock-owned ones through.

Migration for extension authors (breaking):

| before | after |
| --- | --- |
| `show_panel(id, board, dock)` | `show_panel(id, board, update)` |

The paired consumer change is in `blockr.dag` (drops its `dock` formal and calls `show_panel(id, board$board, update)`); this PR is pinned as its `blockr.dock` remote until it lands.

Fixes #308