### PR TITLE
Add server-initiated view relayout via a views$relayout slice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # blockr.dock (development version)
 
+* Server code can now re-lay-out an existing view in one authored command,
+  through a new `relayout` slice on the `views` update channel (#312). The
+  slice carries a fused `dock_layout()` per view id; the update lifecycle
+  splits it into that view's membership and stored grid, and the live dock
+  is teleported to the new arrangement with a single push. This is the
+  server-to-client geometry path of the structure/grid split (#293) --
+  membership introduced by a relayout is validated against the board's
+  blocks, and it is a discrete command rather than a continuous sync, so
+  one relayout yields bounded board commits and then quiescence. A view
+  whose dock is deferred or not yet created applies the new arrangement
+  when it first renders.
+
 * A board's per-view layout is now split into two independent slots: a
   `dock_views` collection of structure objects (each view's ordered
   panel-id set, name and id, plus the active view), read with

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -508,6 +508,47 @@ reconcile_views <- function(board, update, docks, active_dock,
   invisible()
 }
 
+# Push a whole-view layout onto a live dock: restore the dockview geometry,
+# then re-home each panel's block / extension card into its group. The caller
+# must have parked the current cards in the offcanvas first (as the initial
+# render does), so the dockview rebuild does not tear live UI down with the old
+# panels. Shared by the initial restore and the server-authored relayout.
+push_dock_layout <- function(layout, dock, blocks, extensions) {
+
+  restore_layout(layout, dock$proxy, blocks = blocks, extensions = extensions)
+
+  for (pid in as_dock_panel_id(layout)) {
+    if (is_block_panel_id(pid)) {
+      show_block_panel(pid, add_panel = FALSE, dock = dock)
+    } else if (is_ext_panel_id(pid)) {
+      show_ext_panel(pid, add_panel = FALSE, dock = dock)
+    } else {
+      blockr_abort(
+        "Unknown panel type {class(pid)}.",
+        class = "dock_panel_invalid"
+      )
+    }
+  }
+
+  invisible()
+}
+
+# Park every one of a dock's live cards back in the offcanvas without touching
+# the dockview panels -- the offcanvas-first state a restore needs so the
+# rebuild cannot take the block / extension UI down with the old panels.
+park_dock_cards <- function(panel_ids, dock) {
+
+  for (pid in lapply(panel_ids, as_dock_panel_id)) {
+    if (is_block_panel_id(pid)) {
+      hide_block_panel(pid, rm_panel = FALSE, dock = dock)
+    } else if (is_ext_panel_id(pid)) {
+      hide_ext_panel(pid, rm_panel = FALSE, dock = dock)
+    }
+  }
+
+  invisible()
+}
+
 #' Run a single dockViewR instance as a Shiny module.
 #'
 #' Sets up the dock view, restores an initial layout, and handles panel
@@ -613,24 +654,36 @@ manage_dock <- function(
 
     observeEvent(
       req(input[[dock_input("initialized")]]),
-      {
-        restore_layout(init_layout, dock$proxy,
-                       blocks = init_blocks, extensions = init_exts)
-
-        for (pid in as_dock_panel_id(init_layout)) {
-          if (is_block_panel_id(pid)) {
-            show_block_panel(pid, add_panel = FALSE, dock = dock)
-          } else if (is_ext_panel_id(pid)) {
-            show_ext_panel(pid, add_panel = FALSE, dock = dock)
-          } else {
-            blockr_abort(
-              "Unknown panel type {class(pid)}.",
-              class = "dock_panel_invalid"
-            )
-          }
-        }
-      },
+      push_dock_layout(init_layout, dock, init_blocks, init_exts),
       once = TRUE
+    )
+
+    # Deliver a server-authored re-layout to this view's live dock: a one-shot
+    # push of the new arrangement (the assistant's `modify_view` command),
+    # driven off the update channel exactly as the panel-title observer below
+    # consumes `update()$blocks$mod`. The lifecycle has already written this
+    # view's membership and grid; here the client is teleported to match. Cards
+    # are parked in the offcanvas first so the dockview rebuild keeps the block
+    # UI alive, then re-homed by the push -- the arrangement the re-layout drops
+    # a member from simply leaves that card parked. A view whose dock is
+    # deferred or not yet created gets no push: it applies the slots when it
+    # first renders.
+    observeEvent(
+      update()$views$relayout[[id]],
+      {
+        relayout <- update()$views$relayout[[id]]
+
+        park_dock_cards(isolate(live_panels()), dock)
+
+        push_dock_layout(
+          relayout, dock,
+          board_blocks(board$board),
+          dock_extensions(board$board)
+        )
+
+        live_panels(as.character(layout_panel_ids(relayout)))
+      },
+      ignoreInit = TRUE
     )
 
     observeEvent(

--- a/R/dock-board.R
+++ b/R/dock-board.R
@@ -310,7 +310,7 @@ augment_board_update.dock_board <- function(upd, board, ...,
 
   upd <- NextMethod()
 
-  if (length(upd$views$add)) {
+  if (length(upd$views$add) || length(upd$views$relayout)) {
     upd$views <- resolve_views_layouts(upd$views, board, upd)
   }
 
@@ -385,6 +385,10 @@ apply_board_update.dock_board <- function(board, upd, ...) {
 
   if (length(upd$views$add)) {
     board <- apply_views_add(upd$views$add, board)
+  }
+
+  if (length(upd$views$relayout)) {
+    board <- apply_views_relayout(upd$views$relayout, board)
   }
 
   if (length(upd$views$mod)) {

--- a/R/views-delta.R
+++ b/R/views-delta.R
@@ -1,9 +1,11 @@
-# Resolve bare IDs in a submitted `add` layout to canonical
+# Resolve bare IDs in a submitted `add` / `relayout` layout to canonical
 # block_panel-/ext_panel- form (as `initialise_layout()` does at
 # construction). Uses the pre-rm block set (current + blocks$add) so a
 # layout referencing a to-be-removed block still resolves;
 # `merge_views_mod()` drops it before the post-state checks. `mod` no longer
 # carries geometry -- it is a membership set of already-canonical panel ids.
+# Resolution is idempotent on already-canonical ids, so an assistant that
+# stages a fused layout of `block_panel-` ids passes through untouched.
 resolve_views_layouts <- function(views, board, upd) {
 
   current_blocks <- board_blocks(board)
@@ -33,6 +35,10 @@ resolve_views_layouts <- function(views, board, upd) {
 
   if (length(views$add)) {
     views$add <- lapply(views$add, resolve_one)
+  }
+
+  if (length(views$relayout)) {
+    views$relayout <- lapply(views$relayout, resolve_one)
   }
 
   views
@@ -124,7 +130,7 @@ validate_views_delta <- function(views, board, upd) {
   }
 
   unknown_keys <- setdiff(
-    names(views), c("add", "mod", "rm", "active", "rename", "grid")
+    names(views), c("add", "mod", "rm", "active", "rename", "grid", "relayout")
   )
   if (length(unknown_keys)) {
     blockr_abort(
@@ -137,6 +143,7 @@ validate_views_delta <- function(views, board, upd) {
   mod_ids <- names(views$mod) %||% character()
   rm_ids <- views$rm %||% character()
   rename_ids <- names(views$rename) %||% character()
+  relayout_ids <- names(views$relayout) %||% character()
   active <- views$active
 
   add_unnamed <- length(views$add) &&
@@ -155,6 +162,16 @@ validate_views_delta <- function(views, board, upd) {
   if (mod_unnamed) {
     blockr_abort(
       "All entries of `views$mod` must carry a view id.",
+      class = "dock_views_delta_unnamed"
+    )
+  }
+
+  relayout_unnamed <- length(views$relayout) &&
+    (is.null(names(views$relayout)) || any(!nzchar(relayout_ids)))
+
+  if (relayout_unnamed) {
+    blockr_abort(
+      "All entries of `views$relayout` must carry a view id.",
       class = "dock_views_delta_unnamed"
     )
   }
@@ -204,6 +221,43 @@ validate_views_delta <- function(views, board, upd) {
     )
   }
 
+  # `relayout` is the authored full-view write (membership + geometry), so a
+  # view id may not also travel on another per-view slice in the same delta:
+  # `rm` would remove what it re-lays-out, `add` is for a view that does not
+  # exist yet, and `mod` would contradict the membership `relayout` writes.
+  relayout_in_rm <- intersect(relayout_ids, rm_ids)
+  if (length(relayout_in_rm)) {
+    blockr_abort(
+      paste(
+        "View{?s} {relayout_in_rm} cannot appear in both `views$relayout`",
+        "and `views$rm`."
+      ),
+      class = "dock_views_delta_relayout_rm_clash"
+    )
+  }
+
+  relayout_in_add <- intersect(relayout_ids, add_ids)
+  if (length(relayout_in_add)) {
+    blockr_abort(
+      paste(
+        "View{?s} {relayout_in_add} cannot appear in both `views$relayout`",
+        "and `views$add`; a new view's layout goes in `add`."
+      ),
+      class = "dock_views_delta_relayout_add_clash"
+    )
+  }
+
+  relayout_in_mod <- intersect(relayout_ids, mod_ids)
+  if (length(relayout_in_mod)) {
+    blockr_abort(
+      paste(
+        "View{?s} {relayout_in_mod} cannot appear in both `views$relayout`",
+        "and `views$mod`; `relayout` already writes membership."
+      ),
+      class = "dock_views_delta_relayout_mod_clash"
+    )
+  }
+
   current_views <- names(board_views(board))
   unknown_mod <- setdiff(mod_ids, current_views)
   if (length(unknown_mod)) {
@@ -238,6 +292,17 @@ validate_views_delta <- function(views, board, upd) {
         "the board."
       ),
       class = "dock_views_delta_arrange_unknown"
+    )
+  }
+
+  unknown_relayout <- setdiff(relayout_ids, current_views)
+  if (length(unknown_relayout)) {
+    blockr_abort(
+      paste(
+        "View{?s} {unknown_relayout} in `views$relayout` do not exist on",
+        "the board."
+      ),
+      class = "dock_views_delta_relayout_unknown"
     )
   }
 
@@ -295,6 +360,18 @@ validate_views_delta <- function(views, board, upd) {
     }
 
     validate_layout_panel_refs(views$add[[v]], ok_panels, v)
+  }
+
+  for (v in relayout_ids) {
+
+    if (!is_dock_layout(views$relayout[[v]])) {
+      blockr_abort(
+        "`views$relayout${v}` must be a `dock_layout`.",
+        class = "dock_views_delta_layout_invalid"
+      )
+    }
+
+    validate_layout_panel_refs(views$relayout[[v]], ok_panels, v)
   }
 
   for (v in mod_ids) {
@@ -489,6 +566,32 @@ apply_views_add <- function(add_views, board) {
     ly <- add_views[[v]]
 
     views[[v]] <- new_dock_view(layout_panel_ids(ly), view_name(ly))
+    arr[[v]] <- grid_from_layout(ly)
+  }
+
+  board_views(board) <- views
+  board_grids(board) <- new_dock_grids(arr)
+
+  board
+}
+
+# Apply a server-authored re-layout: the one write the lifecycle makes to both
+# an existing view's slots at once. The fused layout splits the same way an add
+# does -- membership record plus stored grid -- but the view already exists, so
+# the display name is a property of the view record, untouched here (a rename
+# travels on its own slice). `manage_dock` delivers the geometry to the live
+# dock with a one-shot push; a deferred or not-yet-created dock needs none,
+# picking the slots up when it first renders.
+apply_views_relayout <- function(relayout, board) {
+
+  views <- board_views(board)
+  arr <- as.list(board_grids(board) %||% list())
+
+  for (v in names(relayout)) {
+
+    ly <- relayout[[v]]
+
+    views[[v]] <- new_dock_view(layout_panel_ids(ly), view_name(views[[v]]))
     arr[[v]] <- grid_from_layout(ly)
   }
 

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -258,6 +258,74 @@ test_that("renaming a block refreshes the dock panel title (#193)", {
   expect_identical(title_set, "Renamed")
 })
 
+test_that("a relayout pushes the authored layout to the live dock (#312)", {
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  # The single view holds block `a`; `b` is on the board but unplaced. A
+  # relayout to {a, b} exercises the membership-growing path.
+  board_rv <- board_args(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = dock_layout("a")
+  )
+  upd <- reactiveVal()
+
+  dock <- with_mock_context(ms, {
+    manage_dock("dock_main", board_rv, update = upd)
+  })
+
+  ms$flushReact()
+
+  pushed <- NULL
+  parked <- character()
+
+  # A bare `update` reactiveVal bypasses augment (tested in test-views-delta),
+  # so the payload carries canonical panel ids keyed by the module id. Mock the
+  # DOM-touching push / show / hide so the observer's control flow is what is
+  # asserted, not the (headless) dockview render.
+  with_mocked_bindings(
+    {
+      with_mock_context(ms, {
+        upd(
+          list(
+            views = list(
+              relayout = setNames(
+                list(dock_layout("block_panel-a", "block_panel-b")),
+                "dock_main"
+              )
+            )
+          )
+        )
+      })
+      ms$flushReact()
+    },
+    restore_layout = function(layout, proxy, ...) {
+      pushed <<- as.character(layout_panel_ids(layout))
+      invisible(NULL)
+    },
+    show_block_panel = function(...) invisible(NULL),
+    hide_block_panel = function(id, ...) {
+      parked <<- c(parked, as.character(id))
+      invisible(NULL)
+    },
+    .package = "blockr.dock"
+  )
+
+  # The authored layout is pushed once, carrying both members.
+  expect_setequal(pushed, c("block_panel-a", "block_panel-b"))
+
+  # The live card was parked in the offcanvas before the restore, so the
+  # rebuild cannot tear it down.
+  expect_true("block_panel-a" %in% parked)
+
+  # live_panels now tracks the authored membership.
+  expect_setequal(
+    isolate(dock$live_panels()),
+    c("block_panel-a", "block_panel-b")
+  )
+})
+
 test_that("live_view_data is NULL while any view layout is uninitialized", {
   ms <- new_mock_session()
   withr::defer(if (!ms$isClosed()) ms$close())

--- a/tests/testthat/test-model-interleaving.R
+++ b/tests/testthat/test-model-interleaving.R
@@ -248,6 +248,39 @@ model_remove <- function(st) {
   list(st = st, commit = res$commit)
 }
 
+# The server-authored re-layout (the modify_view command): membership and
+# geometry are written together in one board commit, then the client teleports
+# to the authored layout -- the one-shot push. Reproduced from
+# apply_views_relayout plus the delivery observer so the "one relayout ->
+# bounded commits + quiescence" bound is checkable under interleaving. The
+# pending echo is the push's ack; delivered next it matches the stored grid and
+# commits nothing.
+model_relayout <- function(st) {
+
+  pool <- model_panels()
+  k <- sample.int(min(4L, length(pool)), 1L)
+  authored <- client_layout(sample(pool, k), sizes = runif(k, 0.1, 1))
+
+  before_members <- model_members(st)
+  before_stored <- model_stored(st)
+
+  st$board <- apply_board_update(
+    st$board,
+    list(views = list(relayout = set_names(list(authored), "V")))
+  )
+
+  st$client$rendered <- model_members(st)
+  st$client$arr <- authored
+  st$client$pending <- authored
+
+  changed <- !setequal(before_members, model_members(st)) ||
+    !isTRUE(
+      all.equal(before_stored, model_stored(st), tolerance = grid_size_tol())
+    )
+
+  list(st = st, commit = as.integer(changed))
+}
+
 test_that("a stale echo's ghost is pruned by compose, never rendered", {
 
   st <- model_new()
@@ -320,6 +353,41 @@ test_that("a settled gesture commits once; a re-echo commits nothing", {
   expect_identical(model_deliver_echo(st)$commit, 0L)
 })
 
+test_that("a relayout writes both slots and its ack echo converges", {
+
+  st <- model_new()
+
+  # The server authors a new arrangement: drop c, a two-pane split of {b, a}.
+  authored <- client_layout(
+    as.character(as_block_panel_id(c("b", "a"))), sizes = c(0.4, 0.6)
+  )
+
+  st$board <- apply_board_update(
+    st$board,
+    list(views = list(relayout = set_names(list(authored), "V")))
+  )
+
+  # One commit writes both membership and geometry to the authored layout.
+  expect_setequal(
+    model_members(st), as.character(as_block_panel_id(c("a", "b")))
+  )
+  expect_setequal(
+    model_shown(st), as.character(as_block_panel_id(c("a", "b")))
+  )
+  expect_no_error(validate_board(st$board))
+
+  # The one-shot push's ack: the client echoes the authored layout, matching
+  # the stored grid within tolerance -> no convergence commit, and it holds as
+  # a fixed point.
+  st$client$rendered <- model_members(st)
+  st$client$arr <- authored
+  st$client$pending <- authored
+  expect_identical(model_deliver_echo(st)$commit, 0L)
+
+  st$client$pending <- authored
+  expect_identical(model_deliver_echo(st)$commit, 0L)
+})
+
 test_that("restore rebuilds without resurrecting a pruned ghost", {
 
   st <- model_new()
@@ -372,8 +440,8 @@ test_that("restore rebuilds a view whose membership emptied under a ghost", {
 
 test_that("seeded interleavings hold the invariants and converge", {
 
-  events <- c("gesture", "echo", "add", "remove", "restore")
-  probs <- c(0.30, 0.30, 0.16, 0.16, 0.08)
+  events <- c("gesture", "echo", "add", "remove", "restore", "relayout")
+  probs <- c(0.26, 0.26, 0.14, 0.14, 0.08, 0.12)
 
   for (seed in seq_len(40L)) {
 
@@ -390,7 +458,8 @@ test_that("seeded interleavings hold the invariants and converge", {
         echo = model_deliver_echo(st),
         add = model_add(st),
         remove = model_remove(st),
-        restore = list(st = model_restore(st), commit = 0L)
+        restore = list(st = model_restore(st), commit = 0L),
+        relayout = model_relayout(st)
       )
 
       st <- res$st

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -787,3 +787,224 @@ test_that("apply_views_rm is a pure board transform", {
   expect_silent(out <- apply_views_rm(vid(brd, "B"), brd))
   expect_identical(unname(view_names(board_layouts(out))), "A")
 })
+
+test_that("apply_views_relayout rewrites a view's membership and geometry", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(A = list("a"))
+  )
+
+  # A single-panel view is re-laid-out to a two-panel arrangement: the new
+  # member folds into membership and the authored geometry lands in the grid
+  # slot -- both slots written by one authored command.
+  upd <- augment_board_update(
+    list(
+      views = list(
+        relayout = list(A = dock_layout("a", "b", sizes = c(0.3, 0.7)))
+      )
+    ),
+    brd
+  )
+
+  out <- apply_board_update(brd, upd)
+  aid <- vid(brd, "A")
+
+  expect_setequal(
+    view_members(board_views(out)[[aid]]),
+    c("block_panel-a", "block_panel-b")
+  )
+  expect_setequal(
+    layout_panel_ids(board_grids(out)[[aid]]),
+    c("block_panel-a", "block_panel-b")
+  )
+  expect_identical(active_name(out), "A")
+})
+
+test_that("relayout flows through apply_board_update on an existing view", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(A = list("a", "b"), B = list("b"))
+  )
+
+  # Reorder A to a single-panel {a}, addressing the view by id.
+  out <- apply_board_update(
+    brd,
+    augment_board_update(
+      list(
+        views = list(relayout = setNames(list(dock_layout("a")), vid(brd, "A")))
+      ),
+      brd
+    )
+  )
+
+  expect_identical(
+    layout_panel_ids(board_layouts(out)[[vid(brd, "A")]]),
+    "block_panel-a"
+  )
+  # A sibling view and the active marker are untouched.
+  expect_identical(
+    layout_panel_ids(board_layouts(out)[[vid(brd, "B")]]),
+    "block_panel-b"
+  )
+  expect_identical(active_name(out), "A")
+})
+
+test_that("relayout preserves the view's display name, never renames", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(v1 = dock_layout("a", name = "Analysis"))
+  )
+
+  # Even a name carried on the fused layout is ignored: the display name lives
+  # on the view record and only `rename` writes it.
+  out <- apply_board_update(
+    brd,
+    augment_board_update(
+      list(
+        views = list(
+          relayout = setNames(
+            list(dock_layout("a", "b", name = "Ignored")), "v1"
+          )
+        )
+      ),
+      brd
+    )
+  )
+
+  expect_identical(view_name(board_views(out)[["v1"]]), "Analysis")
+})
+
+test_that("augment resolves bare ids in a relayout layout and is idempotent", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(A = list("a"))
+  )
+  aid <- vid(brd, "A")
+
+  once <- augment_board_update(
+    list(views = list(relayout = setNames(list(dock_layout("a", "b")), aid))),
+    brd
+  )
+
+  expect_setequal(
+    layout_panel_ids(once$views$relayout[[aid]]),
+    c("block_panel-a", "block_panel-b")
+  )
+
+  # The lifecycle re-runs augment to a fixed point, so a second pass over an
+  # already-resolved relayout must be a no-op.
+  twice <- augment_board_update(once, brd)
+  expect_identical(once, twice)
+})
+
+test_that("relayout membership is validated against the board's blocks", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    layouts = list(A = list("a"))
+  )
+
+  expect_error(
+    augment_board_update(
+      list(
+        views = list(
+          relayout = setNames(list(dock_layout("ghost")), vid(brd, "A"))
+        )
+      ),
+      brd
+    ),
+    class = "dock_views_delta_panel_ref_invalid"
+  )
+})
+
+test_that("validate_views_delta rejects relayout on an unknown view", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    layouts = list(A = list("a"))
+  )
+
+  expect_error(
+    augment_board_update(
+      list(views = list(relayout = list(Ghost = dock_layout("a")))),
+      brd
+    ),
+    class = "dock_views_delta_relayout_unknown"
+  )
+})
+
+test_that("validate_views_delta rejects relayout clashing with rm/add/mod", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    layouts = list(A = list("a"), B = list("a"))
+  )
+  aid <- vid(brd, "A")
+
+  expect_error(
+    validate_views_delta(
+      list(relayout = setNames(list(dock_layout("a")), aid), rm = aid),
+      brd,
+      list()
+    ),
+    class = "dock_views_delta_relayout_rm_clash"
+  )
+
+  expect_error(
+    validate_views_delta(
+      list(
+        relayout = setNames(list(dock_layout("a")), "C"),
+        add = setNames(list(dock_layout("a")), "C")
+      ),
+      brd,
+      list()
+    ),
+    class = "dock_views_delta_relayout_add_clash"
+  )
+
+  expect_error(
+    validate_views_delta(
+      list(
+        relayout = setNames(list(dock_layout("a")), aid),
+        mod = setNames(list("block_panel-a"), aid)
+      ),
+      brd,
+      list()
+    ),
+    class = "dock_views_delta_relayout_mod_clash"
+  )
+})
+
+test_that("a serialize after a relayout reflects the new arrangement", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    layouts = list(A = list("a"))
+  )
+
+  out <- apply_board_update(
+    brd,
+    augment_board_update(
+      list(
+        views = list(
+          relayout = list(A = dock_layout("a", "b", sizes = c(0.25, 0.75)))
+        )
+      ),
+      brd
+    )
+  )
+
+  des <- blockr_deser(blockr_ser(out))
+  aid <- vid(des, "A")
+
+  expect_setequal(
+    layout_panel_ids(board_layouts(des)[[aid]]),
+    c("block_panel-a", "block_panel-b")
+  )
+  # The authored two-pane split survives as a stored grid, not the default.
+  expect_false(is.null(board_grids(des)[[aid]]))
+})


### PR DESCRIPTION
## Summary

- Adds a `relayout` slice to the `views` update channel: a fused `dock_layout()` per view id, resolved and split at augment into that view's membership and stored grid, then written to both board slots in one commit by `apply_views_relayout()`. Membership a relayout introduces is validated against the board's blocks, and a view id may not also travel on `add` / `mod` / `rm` in the same delta.
- Delivers the geometry to the live dock as a one-shot push: `manage_dock` observes `update()$views$relayout[[id]]` (the event pattern the panel-title observer already uses for `update()$blocks$mod`) and, after parking the live cards back in the offcanvas, restores the new arrangement and re-homes each card — through an extracted `push_dock_layout()` it now shares with the initial render. A view whose dock is deferred or not yet created gets no push; it applies the slots when it first renders.
- It is a discrete teleport command, not a continuous sync, so one relayout yields bounded board commits and then quiescence. That property is pinned in the #296 model harness as a new `relayout` event across the seeded interleavings plus a dedicated convergence test.
- Stacked on #300 (`295-restore-rebuild`), whose machinery predates the #298 cast rework, so the decompose uses `grid_from_layout()` exactly as `apply_views_add()` does; it adapts to `as_dock_view()` / `as_dock_grid()` when the stack restacks onto the newer #298. CI gates on `branches: main`, so this stays dormant until the stack lands.
- Follow-up, separate PR in blockr.assistant: migrate the `modify_view` tool from `views$mod` (now rejected by the membership-only validation) to `views$relayout`, payload unchanged.

This is the server-to-client geometry path — the last unbuilt piece of the ownership design (#293).

Fixes #312
