### PR TITLE
Add panel placement ops to the action registry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,7 @@ Collate:
     'action-class.R'
     'action-block.R'
     'action-link.R'
+    'action-panel.R'
     'action-stack.R'
     'action-ui.R'
     'action-utils.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # blockr.dock (development version)
 
+* Panel placement is now available as ops through the action registry, so
+  an extension or API caller can add a panel to a live view at a chosen
+  position, remove one, or select one -- the same paths the add-panel
+  modal and a tab drag already drive. The add op carries a dockView
+  position hint (`referenceGroup` / `referencePanel` plus a `within` /
+  `left` / `right` / `above` / `below` direction), consumed once at
+  insertion and never stored. Like a user gesture, the op writes nothing
+  to the board: the view's membership fold and the settled grid mirror
+  capture the result afterwards, so a server-initiated placement is
+  indistinguishable from a hand-arranged one. Resize (needs the
+  `set_size` dock proxy) and a first-class move join the family once
+  their dockViewR floors land; a move meanwhile decomposes into
+  remove-then-add (#316).
+
 * The block status badge is now derived in one exported helper,
   `block_status_badge()`, and reused by blockr.dag, so the dock card icon
   and the DAG node badge always render the same status, colour and

--- a/R/action-class.R
+++ b/R/action-class.R
@@ -89,7 +89,10 @@ board_actions.dock_board <- function(x, ...) {
     remove_link_action,
     add_stack_action,
     edit_stack_action,
-    remove_stack_action
+    remove_stack_action,
+    add_panel_action,
+    remove_panel_action,
+    select_panel_action
   )
 }
 

--- a/R/action-panel.R
+++ b/R/action-panel.R
@@ -1,0 +1,140 @@
+# Panel placement ops: add (with a position hint), remove and select a panel
+# in a live view, driven through the action registry so an extension or API
+# caller can place panels the way the add-panel modal and a tab drag already
+# do. Unlike every other board action these write nothing to the board: the op
+# mutates the live dock only, and the view's membership fold plus the settled
+# grid mirror capture the result afterwards -- a server-initiated placement is
+# indistinguishable, to the board, from the user having dragged the panels
+# there. A position hint rides the op, is consumed once at insertion and is
+# never stored. `dock` is the active view's dock; `docks` resolves a named
+# target view, defaulting to the active one.
+
+add_panel_action <- function(trigger, board, update, dock, docks = NULL, ...) {
+  new_action(
+    function(input, output, session) {
+
+      observeEvent(
+        trigger(),
+        {
+          op <- trigger()
+
+          add_dock_panel(
+            op[["panel"]],
+            board$board,
+            resolve_op_dock(dock, docks, op[["view"]]),
+            position = op[["position"]]
+          )
+        }
+      )
+
+      NULL
+    },
+    id = "add_panel_action"
+  )
+}
+
+remove_panel_action <- function(trigger, board, update, dock, docks = NULL,
+                                ...) {
+  new_action(
+    function(input, output, session) {
+
+      observeEvent(
+        trigger(),
+        {
+          op <- trigger()
+
+          remove_dock_panel(
+            op[["panel"]],
+            resolve_op_dock(dock, docks, op[["view"]])
+          )
+        }
+      )
+
+      NULL
+    },
+    id = "remove_panel_action"
+  )
+}
+
+select_panel_action <- function(trigger, board, update, dock, docks = NULL,
+                                ...) {
+  new_action(
+    function(input, output, session) {
+
+      observeEvent(
+        trigger(),
+        {
+          op <- trigger()
+
+          select_dock_panel(
+            op[["panel"]],
+            resolve_op_dock(dock, docks, op[["view"]])
+          )
+        }
+      )
+
+      NULL
+    },
+    id = "select_panel_action"
+  )
+}
+
+resolve_op_dock <- function(active, docks, view = NULL) {
+
+  if (is.null(view) || is.null(docks) || !view %in% names(docks)) {
+    return(active)
+  }
+
+  docks[[view]]
+}
+
+add_dock_panel <- function(pid, board, dock, position = NULL) {
+
+  pid <- as_dock_panel_id(pid)
+
+  if (is.null(position)) {
+    position <- determine_panel_pos(dock)
+  }
+
+  if (is_block_panel_id(pid)) {
+    show_block_panel(
+      board_blocks(board)[as_obj_id(pid)],
+      add_panel = position,
+      dock = dock
+    )
+  } else {
+    show_ext_panel(
+      as.list(dock_extensions(board))[[as_obj_id(pid)]],
+      add_panel = position,
+      dock = dock
+    )
+  }
+
+  invisible(NULL)
+}
+
+remove_dock_panel <- function(pid, dock) {
+
+  pid <- as_dock_panel_id(pid)
+
+  if (is_block_panel_id(pid)) {
+    hide_block_panel(pid, rm_panel = TRUE, dock = dock)
+  } else {
+    hide_ext_panel(pid, rm_panel = TRUE, dock = dock)
+  }
+
+  invisible(NULL)
+}
+
+select_dock_panel <- function(pid, dock) {
+
+  pid <- as_dock_panel_id(pid)
+
+  if (is_block_panel_id(pid)) {
+    show_block_panel(pid, add_panel = FALSE, dock = dock)
+  } else {
+    show_ext_panel(pid, add_panel = FALSE, dock = dock)
+  }
+
+  invisible(NULL)
+}

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -126,7 +126,10 @@ board_server_callback <- function(board, update, visible, ...,
     apply_extensions_mod(update()$extensions$mod, ext_res)
   )
 
-  register_actions(actions, triggers, board, update, ext_res)
+  register_actions(
+    actions, triggers, board, update,
+    c(ext_res, list(dock = active_dock, docks = docks))
+  )
 
   # Returned to core, spread into every plugin's args (see the two-bundle note
   # above): `dock` for block placement, `view_data` for serialization, `actions`
@@ -612,16 +615,7 @@ manage_dock <- function(
                        blocks = init_blocks, extensions = init_exts)
 
         for (pid in as_dock_panel_id(as_dock_grid(init_layout))) {
-          if (is_block_panel_id(pid)) {
-            show_block_panel(pid, add_panel = FALSE, dock = dock)
-          } else if (is_ext_panel_id(pid)) {
-            show_ext_panel(pid, add_panel = FALSE, dock = dock)
-          } else {
-            blockr_abort(
-              "Unknown panel type {class(pid)}.",
-              class = "dock_panel_invalid"
-            )
-          }
+          select_dock_panel(pid, dock)
         }
       },
       once = TRUE
@@ -629,22 +623,7 @@ manage_dock <- function(
 
     observeEvent(
       input[[dock_input("panel-to-remove")]],
-      {
-        pid <- as_dock_panel_id(
-          input[[dock_input("panel-to-remove")]]
-        )
-
-        if (is_block_panel_id(pid)) {
-          hide_block_panel(pid, rm_panel = TRUE, dock = dock)
-        } else if (is_ext_panel_id(pid)) {
-          hide_ext_panel(pid, rm_panel = TRUE, dock = dock)
-        } else {
-          blockr_abort(
-            "Unknown panel type {class(pid)}.",
-            class = "dock_panel_invalid"
-          )
-        }
-      }
+      remove_dock_panel(input[[dock_input("panel-to-remove")]], dock)
     )
 
     observeEvent(
@@ -678,26 +657,7 @@ manage_dock <- function(
         }
 
         for (pid in input$add_dock_panel) {
-          if (maybe_block_panel_id(pid)) {
-            show_block_panel(
-              board_blocks(board$board)[as_obj_id(new_block_panel_id(pid))],
-              add_panel = pos,
-              dock = dock
-            )
-          } else if (maybe_ext_panel_id(pid)) {
-            exts <- as.list(dock_extensions(board$board))
-
-            show_ext_panel(
-              exts[[as_obj_id(new_ext_panel_id(pid))]],
-              add_panel = pos,
-              dock = dock
-            )
-          } else {
-            blockr_abort(
-              "Unknown panel specification {pid}.",
-              class = "dock_panel_invalid"
-            )
-          }
+          add_dock_panel(pid, board$board, dock, position = pos)
         }
 
         removeModal()

--- a/tests/testthat/test-action-class.R
+++ b/tests/testthat/test-action-class.R
@@ -21,11 +21,11 @@ test_that("action ctor", {
   db_act <- board_actions(new_dock_board())
 
   expect_type(db_act, "list")
-  expect_length(db_act, 9L)
+  expect_length(db_act, 12L)
 
   trig <- action_triggers(db_act)
 
-  expect_length(trig, 9L)
+  expect_length(trig, 12L)
   expect_named(trig, chr_ply(db_act, action_id))
 
   expect_null(

--- a/tests/testthat/test-action-panel.R
+++ b/tests/testthat/test-action-panel.R
@@ -1,0 +1,306 @@
+# The panel ops share their dispatch with the add-panel modal and the
+# tab-close / restore paths (board-server.R), so these tests drive the
+# dispatch helpers directly (mocking the show / hide boundary) and then the
+# registry actions (asserting the op fires the dispatch and writes nothing to
+# the board -- the membership fold and grid mirror capture the result, tested
+# with the live dock elsewhere).
+
+test_that("add_dock_panel places a block panel with the caller's hint", {
+  captured <- NULL
+
+  local_mocked_bindings(
+    show_block_panel = function(block, add_panel, dock, ...) {
+      captured <<- list(block = block, add_panel = add_panel, dock = dock)
+      invisible(NULL)
+    },
+    show_ext_panel = function(...) stop("ext path taken")
+  )
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+  pos <- list(referenceGroup = "grp1", direction = "within")
+
+  add_dock_panel("block_panel-a", brd, dock = "DOCK", position = pos)
+
+  expect_identical(captured$add_panel, pos)
+  expect_identical(captured$dock, "DOCK")
+  expect_s3_class(captured$block, "blocks")
+  expect_named(captured$block, "a")
+})
+
+test_that("add_dock_panel places an extension panel", {
+  captured <- NULL
+
+  local_mocked_bindings(
+    show_block_panel = function(...) stop("block path taken"),
+    show_ext_panel = function(ext, add_panel, dock, ...) {
+      captured <<- list(ext = ext, add_panel = add_panel)
+      invisible(NULL)
+    }
+  )
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    extensions = new_edit_board_extension()
+  )
+
+  add_dock_panel("ext_panel-edit_board_extension", brd, dock = "DOCK",
+                 position = TRUE)
+
+  expect_true(captured$add_panel)
+  expect_true(is_dock_extension(captured$ext))
+})
+
+test_that("add_dock_panel defaults the position via determine_panel_pos", {
+  captured <- NULL
+
+  local_mocked_bindings(
+    determine_panel_pos = function(dock) list(direction = "right"),
+    show_block_panel = function(block, add_panel, dock, ...) {
+      captured <<- add_panel
+      invisible(NULL)
+    },
+    show_ext_panel = function(...) stop("ext path taken")
+  )
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+
+  add_dock_panel("block_panel-a", brd, dock = "DOCK")
+
+  expect_identical(captured, list(direction = "right"))
+})
+
+test_that("remove_dock_panel hides a block or extension panel", {
+  seen <- NULL
+
+  local_mocked_bindings(
+    hide_block_panel = function(id, rm_panel, dock, ...) {
+      seen <<- list(kind = "block", id = id, rm_panel = rm_panel, dock = dock)
+      invisible(NULL)
+    },
+    hide_ext_panel = function(id, rm_panel, dock, ...) {
+      seen <<- list(kind = "ext", id = id, rm_panel = rm_panel)
+      invisible(NULL)
+    }
+  )
+
+  remove_dock_panel("block_panel-a", dock = "DOCK")
+
+  expect_identical(seen$kind, "block")
+  expect_true(seen$rm_panel)
+  expect_true(is_block_panel_id(seen$id))
+  expect_identical(seen$dock, "DOCK")
+
+  remove_dock_panel("ext_panel-foo", dock = "DOCK")
+
+  expect_identical(seen$kind, "ext")
+  expect_true(is_ext_panel_id(seen$id))
+})
+
+test_that("select_dock_panel activates a panel without adding or removing", {
+  seen <- NULL
+
+  local_mocked_bindings(
+    show_block_panel = function(block, add_panel, dock, ...) {
+      seen <<- list(kind = "block", add_panel = add_panel)
+      invisible(NULL)
+    },
+    show_ext_panel = function(ext, add_panel, dock, ...) {
+      seen <<- list(kind = "ext", add_panel = add_panel)
+      invisible(NULL)
+    }
+  )
+
+  select_dock_panel("block_panel-a", dock = "DOCK")
+
+  expect_identical(seen$kind, "block")
+  expect_false(seen$add_panel)
+
+  select_dock_panel("ext_panel-foo", dock = "DOCK")
+
+  expect_identical(seen$kind, "ext")
+  expect_false(seen$add_panel)
+})
+
+test_that("the dispatch rejects an unrecognised panel id", {
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+
+  expect_error(
+    add_dock_panel("gibberish-1", brd, dock = "DOCK", position = TRUE),
+    class = "invalid_dock_panel_id_coercion"
+  )
+  expect_error(
+    remove_dock_panel("gibberish-1", dock = "DOCK"),
+    class = "invalid_dock_panel_id_coercion"
+  )
+  expect_error(
+    select_dock_panel("gibberish-1", dock = "DOCK"),
+    class = "invalid_dock_panel_id_coercion"
+  )
+})
+
+test_that("resolve_op_dock resolves a named view or falls back to active", {
+  active <- list(tag = "active")
+  v1 <- list(tag = "v1")
+  docks <- list(view_1 = v1, view_2 = list(tag = "v2"))
+
+  expect_identical(resolve_op_dock(active, docks, "view_1"), v1)
+  expect_identical(resolve_op_dock(active, docks, NULL), active)
+  expect_identical(resolve_op_dock(active, docks, "gone"), active)
+  expect_identical(resolve_op_dock(active, NULL, "view_1"), active)
+})
+
+test_that("the panel ops are registered on the board", {
+  ids <- chr_ply(board_actions(new_dock_board()), action_id)
+
+  expect_true(
+    all(c("add_panel_action", "remove_panel_action", "select_panel_action")
+        %in% ids)
+  )
+})
+
+test_that("add_panel_action places the panel and writes nothing to the board", {
+  captured <- NULL
+
+  local_mocked_bindings(
+    show_block_panel = function(block, add_panel, dock, ...) {
+      captured <<- list(add_panel = add_panel, dock = dock)
+      invisible(NULL)
+    }
+  )
+
+  r_board <- reactiveValues(
+    board = new_dock_board(blocks = c(a = new_dataset_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  op <- list(
+    panel = "block_panel-a",
+    position = list(referenceGroup = "g", direction = "within")
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_panel_action(
+          trigger = reactive(op), board = r_board, update = r_update,
+          dock = "DOCK", docks = NULL
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      expect_identical(captured$add_panel, op$position)
+      expect_identical(captured$dock, "DOCK")
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("remove_panel_action hides the panel and writes nothing", {
+  captured <- NULL
+
+  local_mocked_bindings(
+    hide_block_panel = function(id, rm_panel, dock, ...) {
+      captured <<- list(rm_panel = rm_panel, dock = dock)
+      invisible(NULL)
+    }
+  )
+
+  r_board <- reactiveValues(
+    board = new_dock_board(blocks = c(a = new_dataset_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        remove_panel_action(
+          trigger = reactive(list(panel = "block_panel-a")),
+          board = r_board, update = r_update, dock = "DOCK", docks = NULL
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      expect_true(captured$rm_panel)
+      expect_identical(captured$dock, "DOCK")
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("select_panel_action activates the panel and writes nothing", {
+  captured <- NULL
+
+  local_mocked_bindings(
+    show_block_panel = function(block, add_panel, dock, ...) {
+      captured <<- list(add_panel = add_panel)
+      invisible(NULL)
+    }
+  )
+
+  r_board <- reactiveValues(
+    board = new_dock_board(blocks = c(a = new_dataset_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        select_panel_action(
+          trigger = reactive(list(panel = "block_panel-a")),
+          board = r_board, update = r_update, dock = "DOCK", docks = NULL
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      expect_false(captured$add_panel)
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("a panel op with a view id targets that view's dock", {
+  captured <- NULL
+
+  local_mocked_bindings(
+    show_block_panel = function(block, add_panel, dock, ...) {
+      captured <<- dock
+      invisible(NULL)
+    }
+  )
+
+  r_board <- reactiveValues(
+    board = new_dock_board(blocks = c(a = new_dataset_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  op <- list(panel = "block_panel-a", position = TRUE, view = "view_2")
+
+  testServer(
+    function(id, ...) {
+      docks <- reactiveValues(view_1 = "DOCK1", view_2 = "DOCK2")
+      moduleServer(
+        id,
+        add_panel_action(
+          trigger = reactive(op), board = r_board, update = r_update,
+          dock = "ACTIVE", docks = docks
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      expect_identical(captured, "DOCK2")
+    }
+  )
+})


### PR DESCRIPTION
## Summary

- Adds `add_panel_action`, `remove_panel_action` and `select_panel_action` to the board's action registry, so an extension or API caller can place a panel in a live view at a stated dockView position, remove one, or activate one -- the same paths the add-panel modal and a tab drag already drive. Each is fired as `actions[["add_panel_action"]](list(panel = , position = , view = ))`; `position` is a dockView hint (`referenceGroup` / `referencePanel` plus a `within` / `left` / `right` / `above` / `below` direction) and `view` defaults to the active view.
- The ops write nothing to the board. They mutate the live dock only, and the view's membership fold plus the settled grid mirror capture the result afterwards -- a server-initiated placement is indistinguishable, to the board, from a hand-arranged one, and the position hint is consumed once at insertion and never stored or serialized.
- The add-panel modal, the tab-close path and layout restore now share the same add / remove / select dispatch helpers the ops use, so a user gesture and a server op run one code path (no behaviour change to the existing paths).
- Built on `main`: add / remove / select need only mechanisms already there (`show_block_panel(add_panel = <position>)`, the hide path, `select_block_panel`). Resize (`set_size`) joins the family once #303 lands its dockViewR floor; a first-class move awaits cynkra/dockViewR#85 and meanwhile decomposes into remove-then-add.

Fixes #316