### PR TITLE
Resolve grid panel ids element-wise, matching view members

### DIFF
--- a/R/dock-grid.R
+++ b/R/dock-grid.R
@@ -687,19 +687,18 @@ default_layout <- function(blocks, extensions) {
   )
 }
 
-# Rewrite a grid's bare leaf ids to canonical panel ids via `id_map`. Only
-# fully-bare grids are rewritten (see `resolve_panel_ids()`); a name clash
-# between an extension and a block falls back to a default two-group grid.
+# Rewrite a grid's bare leaf ids to canonical panel ids via `id_map`, per
+# element (like `resolve_panel_ids()`): a bare key is mapped and an
+# already-canonical panel id passes through, so a `blk()` / `ext()` ref can sit
+# beside a bare id in the same grid. A name clash between an extension and a
+# block is ambiguous, so bare resolution falls back to a default two-group grid.
 resolve_grid <- function(grid, id_map) {
 
   grid <- as_dock_grid(grid)
 
   panel_ids <- layout_panel_ids(grid)
 
-  bare <- length(panel_ids) && all(panel_ids %in% names(id_map)) &&
-    any(!panel_ids %in% id_map)
-
-  if (!bare) {
+  if (!any(panel_ids %in% names(id_map))) {
     return(grid)
   }
 
@@ -730,7 +729,9 @@ clash_default_grid <- function(id_map) {
 
 rewrite_grid_leaves <- function(grid, id_map) {
 
-  rename1 <- function(id) coal(id_map[[id]], id, fail_all = FALSE)
+  rename1 <- function(id) {
+    if (length(id) == 1L && id %in% names(id_map)) id_map[[id]] else id
+  }
 
   rewrite_node <- function(node) {
 

--- a/tests/testthat/test-layout-class.R
+++ b/tests/testthat/test-layout-class.R
@@ -137,6 +137,41 @@ test_that("as_dock_layout materialises grid + panels on demand", {
   expect_identical(payload$panels[["block_panel-a"]][["title"]], "Dataset")
 })
 
+test_that("resolve_grid resolves bare ids mixed with a pre-resolved ref", {
+
+  blks <- c(a = new_dataset_block(), b = new_head_block())
+  exts <- list(edit = new_edit_board_extension())
+  id_map <- panel_id_map(blks, exts)
+
+  mixed <- resolve_grid(dock_grid("a", "b", ext("edit")), id_map)
+
+  expect_identical(
+    layout_panel_ids(mixed),
+    c("block_panel-a", "block_panel-b", "ext_panel-edit")
+  )
+
+  expect_identical(mixed, resolve_grid(dock_grid("a", "b", "edit"), id_map))
+  expect_identical(
+    mixed,
+    resolve_grid(dock_grid(blk("a"), blk("b"), ext("edit")), id_map)
+  )
+})
+
+test_that("a grid mixing bare ids with a ref keeps every member on the board", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    extensions = list(edit = new_edit_board_extension()),
+    views = list(Setup = c("a", "b", "edit")),
+    grids = list(Setup = dock_grid("a", "b", ext("edit")))
+  )
+
+  expect_setequal(
+    layout_panel_ids(board_grids(brd)[["Setup"]]),
+    c("block_panel-a", "block_panel-b", "ext_panel-edit")
+  )
+})
+
 test_that("sizes propagate to grid children and nested branches", {
 
   grid <- dock_grid("a", "b", sizes = c(0.3, 0.7))


### PR DESCRIPTION
## Summary

- `resolve_grid()` rewrote bare leaf ids to canonical panel ids only when *every* id in the grid was a map key, so a single pre-resolved `blk()` / `ext()` ref (e.g. `dock_grid("data", "cdisc", ext("dag"))`) left the sibling bare members unresolved; `drop_unknown_members()` then pruned them and the view rendered empty with no diagnostic.
- Resolve per element instead — map a bare key, pass an already-canonical id through — so a ref sits beside a bare id and the mixed form resolves identically to the all-bare form. This mirrors `resolve_panel_ids()`, which views were migrated to in 94684e1 while grids were left on the old all-or-nothing gate.
- `rewrite_grid_leaves()`'s `rename1()` now tolerates a missing key; the old `coal(id_map[[id]], id)` threw on an already-canonical id (`[[` errors on an absent name), which per-element resolution now exercises.
- Regression tests assert the mixed / all-bare / fully-typed authoring forms resolve identically, and that a mixed grid keeps every member on a constructed board (both proven to fail before the fix).

Fixes #321
