### PR TITLE
Pad the save snapshot to all board blocks in serialize_board.dock_board

### DIFF
--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -14,6 +14,23 @@ serialize_board.dock_board <- function(x, blocks, id = NULL, dock,
     reval_if
   )
 
+  # Deferred construction (core's needed-slot gate, background_construction_delay)
+  # leaves off-screen blocks unbuilt, so `blocks` only carries the constructed
+  # ones -- a PARTIAL snapshot. blockr_ser.blocks asserts one entry per board
+  # block (`length(blocks) == length(x)`), so a partial snapshot aborts the whole
+  # save with "length(blocks) == length(x) is not TRUE". Pad to every board block
+  # keyed by id, exactly like core's serialize_board.board does: an unbuilt block
+  # maps to NULL, which blockr_ser.block serializes from its constructor scope
+  # (its restored state is preserved, not blanked).
+  bid <- board_block_ids(x)
+  blocks <- set_names(
+    lapply(bid, function(i) {
+      st <- state[[i]]
+      if (is.null(st)) NULL else c(st, visible = list(visibility[[i]]))
+    }),
+    bid
+  )
+
   opts <- lapply(
     set_names(nm = names(as_board_options(x))),
     get_board_option_or_null,
@@ -30,7 +47,7 @@ serialize_board.dock_board <- function(x, blocks, id = NULL, dock,
       list(
         x,
         board_id = id,
-        blocks = Map(c, state, visible = lapply(visibility, list)),
+        blocks = blocks,
         options = opts,
         extensions = lapply(
           list(...),


### PR DESCRIPTION
Fixes BristolMyersSquibb/blockr.core#279.

Under deferred construction (core's needed-slot eval gate + `blockr.background_construction_delay = Inf`), off-screen views' block cards are only built on first visit. `serialize_board.dock_board` built the save snapshot from **only the constructed blocks**, but `blockr_ser.blocks` asserts one entry per board block (`length(blocks) == length(x)`) — so "Save as new workflow" on a board with unbuilt blocks aborted with `length(blocks) == length(x) is not TRUE`.

This pads the snapshot to every `board_block_ids(x)`, mirroring core's `serialize_board.board`: an unbuilt block maps to `NULL` and serializes from its constructor scope, so its restored state is **preserved, not blanked**.

**Verified** on a 28-block board (`Adept1_study.json`) with only 5 built: partial save succeeds, and each unbuilt block round-trips byte-identically to a fully static serialization. Also OK with all built / none built (static path).

---
Stacked on `301-drop-bridge-debounce` (#303) — the deferred-construction path that exposes this. Retarget to `main` once BristolMyersSquibb/blockr.dock#303 lands. Sibling lazy-view bug (control toggle missing on off-screen cards) is tracked separately in BristolMyersSquibb/blockr.dock#331.
