### PR TITLE
Migrate view teardown to shiny session$destroy()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rmarkdown
 Remotes:
     nbenn/shinytest2@wait-for-app-serving,
-    BristolMyersSquibb/blockr.core@202-session-destroy
+    BristolMyersSquibb/blockr.core
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Roxygen: list(markdown = TRUE)
 Imports:
     blockr.core (>= 0.1.4),
     bsicons,
-    shiny,
+    shiny (>= 1.14.0),
     shinyjs,
     bslib,
     glue,
@@ -45,7 +45,7 @@ Suggests:
     rmarkdown
 Remotes:
     nbenn/shinytest2@wait-for-app-serving,
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core@202-session-destroy
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -456,7 +456,7 @@ remove_view <- function(v_id, session, docks) {
   }
 
   hide_view_ui(v_id, docks)
-  destroy_module(v_id, session = session)
+  session$destroy(v_id)
   removeUI(
     selector = paste0("#", session$ns(as_view_handle_id(v_id))),
     immediate = TRUE,

--- a/R/dock-layout.R
+++ b/R/dock-layout.R
@@ -154,11 +154,12 @@ as_dock_view.dock_layout <- function(x, ...) {
 # `{root, orientation}` wrapper. Inverse of `tree_to_grid()`.
 grid_to_tree <- function(grid) {
 
-  gid <- 0L
+  counter <- new.env(parent = emptyenv())
+  counter$n <- 0L
 
   next_id <- function() {
-    gid <<- gid + 1L
-    as.character(gid)
+    counter$n <- counter$n + 1L
+    as.character(counter$n)
   }
 
   to_tree <- function(node, size) {


### PR DESCRIPTION
## Summary

- blockr.core removed the exported `destroy_module()` in favour of shiny 1.14.0's public, scoped `session$destroy(id)` (BristolMyersSquibb/blockr.core#202, merged). `remove_view()` is our only caller — it tears down a deleted view's `manage_dock(v_id, …)` module (a `moduleServer` of per-view observers watching `update()`), so it moves to `session$destroy(v_id)`, the same all-components teardown.
- Bump `shiny (>= 1.14.0)`.
- `blockr.core#202` is now on `main`, so `Remotes` resolves `blockr.core` from `main`. A branch pin (`@202-session-destroy`) carried the coordination while core was unmerged; it was dropped in the final commit once core landed.

A second commit is unrelated housekeeping to unblock `ci/lint`: lintr 3.4.0 (released 2026-07-16) tightened `assignment_linter` to flag a `<<-` whose target lives only inside its closure. `grid_to_tree()`'s id counter was the one such case in the package; it switches to an explicit environment (the linter's recommended form), behaviour unchanged. Pre-existing and independent of the teardown migration.

Fixes #333
