### PR TITLE
Resolve variadic link inputs to a positional slot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # blockr.dock (development version)
 
+* `resolve_free_input()` now resolves a variadic link target to an empty
+  (positional) slot instead of a generated `"1"`, `"2"`, ... name, aligning
+  the "Connect ..." sidebar with blockr.core's name-or-position variadic
+  model (and with blockr.ui's link menu). An integer input name is treated
+  by core as a *named* argument, and downstream consumers such as
+  blockr.io's Download/Export blocks name files and Excel sheets by the
+  link input verbatim, which surfaced as `1.csv` / `2.csv` exports.
+
 * At startup the board now builds only the active view's dockView;
   off-screen views' docks are created on first visit rather than all up
   front (#304), mirroring the card deferral below. Building every view's

--- a/R/sidebar-link.R
+++ b/R/sidebar-link.R
@@ -76,22 +76,14 @@ link_commit_value <- function(spec, board) {
 
 # Pick the target's input slot for a new link, mirroring blockr.dock's
 # `block_input_select(mode = "inputs")` with only blockr.core primitives:
-# the first free named input, or - for a variadic target - a freshly
-# generated numeric slot.
+# the first free named input, or - for a variadic target - an empty
+# (positional) slot, per core's name-or-position input model.
 resolve_free_input <- function(block, block_id, links) {
   curr <- links[links$to == block_id]$input
   free <- setdiff(block_inputs(block), curr)
 
   if (is.na(block_arity(block))) {
-    num <- suppressWarnings(as.integer(curr))
-    num <- num[!is.na(num)]
-    slot <- if (!length(num)) {
-      "1"
-    } else {
-      mis <- setdiff(seq_len(max(num)), num)
-      as.character(if (length(mis)) min(mis) else max(num) + 1L)
-    }
-    free <- c(free, slot)
+    free <- c(free, "")
   }
 
   free[1L]

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -110,6 +110,54 @@ test_that("add link action: OUTGOING commit honours an explicit port", {
   )
 })
 
+test_that("add link action: variadic target resolves to a positional slot", {
+  local_mocked_sidebar()
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), r = new_rbind_block())
+    ),
+    board_id = "my_board"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_link_action(
+          trigger = reactive("a"),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # Variadic target renders no port picker, so block_input arrives
+      # NULL; core's name-or-position model treats an integer name as a
+      # *named* argument, so the resolved slot must be positional ("").
+      commit_menu(session, source = "a", target = "r", link_id = "ar")
+
+      expect_added_link(
+        r_update(), id = "ar", from = "a", to = "r", input = ""
+      )
+    }
+  )
+})
+
+test_that("resolve_free_input gives a variadic target a positional slot", {
+  blocks <- board_blocks(
+    new_board(c(a = new_dataset_block("iris"), r = new_rbind_block()))
+  )
+
+  expect_identical(resolve_free_input(blocks[["r"]], "r", links()), "")
+
+  # A variadic target already carrying a positional link resolves to
+  # another positional slot, never a generated integer name.
+  wired <- links(id = "ar", from = "a", to = "r", input = "1")
+  expect_identical(resolve_free_input(blocks[["r"]], "r", wired), "")
+})
+
 test_that("add link action: INCOMING commit targets the anchor", {
   local_mocked_sidebar()
   # Anchor `h` (head) has a free input; the INCOMING section offers `a`


### PR DESCRIPTION
## Symptom

Multi-input Download/Export via the "Connect ..." sidebar produces files named `1.csv`, `2.csv` (and Excel sheets `1`, `2`) instead of meaningful names. Reported for the ALLM QC dashboard.

## Cause

blockr.core's name-or-position variadic model treats an integer input name as a *named* argument, so `resolve_free_input()`'s generated `"1"`, `"2"`, ... quietly named what should be positional, and blockr.io names download files/sheets by the link input verbatim.

blockr.ui fixed this on Jul 1 (`2945271`, #20), but the Jul 13 CRAN vendoring (`4bf6b57`) copied a pre-fix ui tree, silently reverting it in the dock copy. That fix was the only post-Jul-1 change to the five vendored files, so nothing else was lost.

## Change

- `resolve_free_input()` emits an empty (positional) slot for variadic targets, byte-for-byte the ui fix. Covers the link-menu commit and both sidebar-block auto-link call sites.
- Unit tests: sidebar commit resolves a variadic target to `""`; a target already carrying a positional link never gets a generated integer name.

## Verification

Live board (2 datasets -> Download, positional links): CSV ZIP entries `data_1.csv` + `data_2.csv`, Excel sheets `data_1`, `data_2` (fallback names from the companion blockr.io PR cynkra/blockr.io: fill positional slot names). Full suite: 7280 passed, 0 failed.

## Note for review

This restores *correct* (positional) slots but not *meaningful* names: those need either a settable name field in the link menu (user-named slots are legit in core's model) or new core surface exposing slot origins — positional slots reach the block server with hidden synthetic keys, so the upstream block id is not available to blockr.io. Decision pending with @christoph.
