### PR TITLE
Thread served plugins to the deferred card-build path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # blockr.dock (development version)
 
+* Off-screen views' block cards -- built on first visit rather than at
+  startup (#272) -- are now built with the plugin set passed to `serve()`,
+  not the board default (#331). `ensure_block_ui()` re-derived the edit /
+  control UI from `board_plugins()`, which omits any custom `ctrl_block`,
+  so a block's control toggle (the AI "sparkle" when the served plugin is
+  `blockr.ai::ai_ctrl_block`) showed on the initially-active view but was
+  absent on every other view's cards. The served plugin set now rides
+  `active_dock` alongside the visibility channel, so the deferred build --
+  the view switch and the add-panel path -- sees the served `ctrl_block`.
+
 * At startup the board now builds only the active view's dockView;
   off-screen views' docks are created on first visit rather than all up
   front (#304), mirroring the card deferral below. Building every view's

--- a/R/block-ui.R
+++ b/R/block-ui.R
@@ -200,15 +200,16 @@ build_block_ui <- function(id, x, blocks, visibility, ..., edit_ui,
 }
 
 # build_block_ui for callers that hold the board but not the plugins (the view
-# switch, the add-panel modal), deriving edit / ctrl UI the way board_ui does.
+# switch, the add-panel modal). Takes the served plugin set, since
+# board_plugins(x) is only the board default and drops any served ctrl_block;
+# serve() threads the real set via active_dock, falling back to that default.
 ensure_block_ui <- function(id, x, blocks, visibility,
+                            plugins = board_plugins(x),
                             session = get_session()) {
 
   if (all(names(blocks) %in% built_cards(visibility))) {
     return(invisible(character()))
   }
-
-  plugins <- board_plugins(x)
 
   build_block_ui(
     id,

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -11,6 +11,10 @@
 #'   two reactiveVal environments (`required`, `visible`) the dock writes to
 #'   gate off-screen blocks.
 #' @param ... Extension server arguments.
+#' @param plugins Served board plugins. Core threads these to its own block
+#'   server but not to callbacks, so `blockr_app_server.dock_board()` captures
+#'   and forwards them here; stashed on `active_dock` so the deferred card-build
+#'   paths see the served ctrl / edit UI. Defaults to the board default set.
 #' @param session Shiny session.
 #'
 #' @return List with `dock`, `actions`, `view_data`, and extension
@@ -18,6 +22,7 @@
 #'
 #' @noRd
 board_server_callback <- function(board, update, visibility, ...,
+                                  plugins = board_plugins(isolate(board$board)),
                                   session = get_session()) {
   initial_board <- isolate(board$board)
 
@@ -56,6 +61,11 @@ board_server_callback <- function(board, update, visibility, ...,
   # the dock handle every card-touching path receives (view switch, panel-op
   # apply, core insert / remove) -- so they read and write the one channel.
   active_dock$visibility <- visibility
+
+  # The served plugin set rides the same handle so those deferred card-build
+  # paths build with the ctrl / edit UI serve() installed, not board_plugins()'s
+  # default (which carries no served ctrl_block).
+  active_dock$plugins <- plugins
 
   switch_view_observer(session, update, client_active)
   add_view_observer(client_views, session, board, update)
@@ -412,6 +422,7 @@ show_view_ui <- function(view_id, docks) {
 # the result in `docks` under the view id. `active` stamps the active CSS
 # class at insert so the initially-shown view needs no switch round-trip.
 create_view <- function(v_id, layout, board, update, session, docks, visibility,
+                        plugins = board_plugins(isolate(board$board)),
                         blocks = NULL, extensions = NULL, active = FALSE) {
 
   ns <- session$ns
@@ -437,7 +448,7 @@ create_view <- function(v_id, layout, board, update, session, docks, visibility,
   )
 
   docks[[v_id]] <- manage_dock(
-    v_id, board, update, visibility,
+    v_id, board, update, visibility, plugins,
     layout = layout,
     blocks = blocks,
     extensions = extensions
@@ -552,6 +563,7 @@ reconcile_views <- function(board, update, docks, active_dock,
       session,
       docks,
       isolate(active_dock$visibility),
+      isolate(active_dock$plugins),
       blocks = board_blocks(brd),
       extensions = dock_extensions(brd),
       active = is.null(isolate(client_active()))
@@ -591,6 +603,7 @@ manage_dock <- function(
   board,
   update,
   visibility,
+  plugins = board_plugins(isolate(board$board)),
   layout = NULL,
   blocks = NULL,
   extensions = NULL
@@ -625,7 +638,8 @@ manage_dock <- function(
       n_panels = n_panels,
       prev_active_group = prev_active_group,
       active_group_trail = active_group_trail,
-      visibility = visibility
+      visibility = visibility,
+      plugins = plugins
     )
 
     # Apply server-initiated panel ops to this view's live dock -- the sole

--- a/R/dock-view.R
+++ b/R/dock-view.R
@@ -1615,7 +1615,7 @@ switch_active_view <- function(active, docks, active_dock, client_active,
     ]
     ensure_block_ui(
       session$ns(NULL), brd, active_blocks, active_dock$visibility,
-      session = session
+      plugins = active_dock$plugins, session = session
     )
 
     show_view_ui(active, docks)

--- a/R/panel-ops.R
+++ b/R/panel-ops.R
@@ -95,7 +95,7 @@ op_add_panel <- function(pid, hint, dock, board, active = TRUE) {
       # inactive branch only wraps a panel (no card move), so it needs none.
       ensure_block_ui(
         dock_board_ns(dock)(NULL), board, block,
-        dock$visibility, session = dock$proxy$session
+        dock$visibility, plugins = dock$plugins, session = dock$proxy$session
       )
       show_block_panel(block, add_panel = pos, dock = dock)
     } else {

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -46,7 +46,16 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
 
 #' @export
 blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
-  board_server(id, x, plugins, options, callbacks = board_server_callback,
+
+  # Core threads `plugins` to its own block server but not to board callbacks,
+  # so capture them for the callback to stash on active_dock -- the deferred
+  # card-build paths need the served set, since board_plugins() drops any served
+  # ctrl_block.
+  callback <- function(...) {
+    board_server_callback(..., plugins = plugins)
+  }
+
+  board_server(id, x, plugins, options, callbacks = callback,
                callback_location = "start", ...)
 }
 

--- a/tests/testthat/test-block-ui.R
+++ b/tests/testthat/test-block-ui.R
@@ -253,6 +253,36 @@ test_that("ensure_block_ui derives the edit plugin from the board", {
   expect_identical(seen$edit_ui, board_plugins(board)[["edit_block"]])
 })
 
+test_that("ensure_block_ui builds the card with the served ctrl (#331)", {
+
+  # A served ctrl_block whose UI drops a recognizable marker. board_plugins()
+  # carries no ctrl_block, so the marker rides the deferred card only when the
+  # served set -- not the board default -- reaches the build.
+  card <- NULL
+  local_mocked_bindings(
+    insertUI = function(selector, where, ui, ...) {
+      card <<- c(card, list(as.character(ui)))
+      invisible()
+    }
+  )
+
+  board <- new_dock_board(blocks = c(a = new_dataset_block("iris")))
+  vis <- fake_visibility("a")
+
+  served <- custom_plugins(
+    ctrl_block(ui = function(id, x) htmltools::span(class = "ctrl-sentinel"))
+  )(board)
+
+  ensure_block_ui(
+    "board", board, board_blocks(board), vis,
+    plugins = served, session = MockShinySession$new()
+  )
+
+  expect_match(
+    paste(unlist(card), collapse = ""), "ctrl-sentinel", fixed = TRUE
+  )
+})
+
 test_that("remove_block_ui removes the card, leaving the slot to core", {
 
   removed <- character()

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1331,3 +1331,91 @@ test_that("New view modal confirm submits an add-and-activate delta", {
     }
   )
 })
+
+test_that("board_server_callback stashes served plugins on the dock (#331)", {
+
+  board_rv <- board_args(blocks = c(a = new_dataset_block()))
+
+  served <- custom_plugins(ctrl_block())(isolate(board_rv$board))
+
+  with_mock_session(
+    {
+      res <- board_server_callback(
+        board_rv,
+        update = reactiveVal(),
+        visibility = fake_visibility("a"),
+        plugins = served
+      )
+
+      # The deferred card-build paths read the served set off this handle, so
+      # its ctrl_block -- absent from board_plugins() -- must survive here.
+      expect_true("ctrl_block" %in% names(res[["dock"]]$plugins))
+      expect_identical(res[["dock"]]$plugins, served)
+    }
+  )
+})
+
+test_that("manage_dock carries the served plugins on its view dock (#331)", {
+
+  board_rv <- board_args(blocks = c(a = new_dataset_block()))
+  served <- custom_plugins(ctrl_block())(isolate(board_rv$board))
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  res <- with_mock_context(ms, {
+    manage_dock(
+      "dock_main", board_rv, update = reactiveVal(),
+      visibility = fake_visibility("a"), plugins = served
+    )
+  })
+
+  ms$flushReact()
+
+  expect_identical(res$plugins, served)
+})
+
+test_that("switch_active_view first-visit card uses served ctrl (#331)", {
+
+  # The issue's repro: a block living only in an off-screen view has its card
+  # built on first visit, by switch_active_view. It must build with the served
+  # ctrl plugin (dropped by board_plugins()), so the control toggle is present.
+  card <- NULL
+  local_mocked_bindings(
+    insertUI = function(selector, where, ui, ...) {
+      card <<- c(card, list(as.character(ui)))
+      invisible()
+    },
+    hide_view_ui = function(...) invisible(),
+    show_view_ui = function(...) invisible(),
+    update_active_dock = function(...) invisible()
+  )
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars")),
+    grids  = list(one = dock_grid("a"), two = dock_grid("b"))
+  )
+
+  served <- custom_plugins(
+    ctrl_block(ui = function(id, x) htmltools::span(class = "ctrl-sentinel"))
+  )(brd)
+
+  docks <- list(two = list(layout = function() NULL))
+  active_dock <- list(
+    visibility = fake_visibility(c("a", "b")),
+    plugins = served
+  )
+  session <- list(
+    ns = NS("board"),
+    sendCustomMessage = function(...) invisible(),
+    sendInputMessage = function(...) invisible()
+  )
+
+  switch_active_view(
+    "two", docks, active_dock, reactiveVal("one"), brd, session
+  )
+
+  expect_match(
+    paste(unlist(card), collapse = ""), "ctrl-sentinel", fixed = TRUE
+  )
+})

--- a/tests/testthat/test-panel-ops.R
+++ b/tests/testthat/test-panel-ops.R
@@ -89,6 +89,44 @@ test_that("op_add_panel routes an extension panel and skips an unknown one", {
   expect_null(seen)
 })
 
+test_that("op_add_panel builds an off-screen card with served ctrl (#331)", {
+
+  # A block that lived only in an off-screen view has no card yet; op_add_panel
+  # builds it before the show. It must build with the served ctrl plugin (which
+  # board_plugins() drops), so the control toggle is present -- a served
+  # ctrl_block whose UI drops a marker proves it rode through.
+  card <- NULL
+  local_mocked_bindings(
+    insertUI = function(selector, where, ui, ...) {
+      card <<- c(card, list(as.character(ui)))
+      invisible()
+    },
+    show_block_panel = function(...) invisible()
+  )
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block("iris")))
+
+  served <- custom_plugins(
+    ctrl_block(ui = function(id, x) htmltools::span(class = "ctrl-sentinel"))
+  )(brd)
+
+  dock <- list(
+    proxy = list(session = MockShinySession$new()),
+    board_ns = NS("board"),
+    live_panels = shiny::reactiveVal(character()),
+    layout = function() NULL,
+    prev_active_group = shiny::reactiveVal(NULL),
+    visibility = fake_visibility("a"),
+    plugins = served
+  )
+
+  op_add_panel("block_panel-a", list(), dock, brd)
+
+  expect_match(
+    paste(unlist(card), collapse = ""), "ctrl-sentinel", fixed = TRUE
+  )
+})
+
 test_that("op_remove_panel removes a live panel, skips an absent one", {
 
   removed <- NULL


### PR DESCRIPTION
## Summary

- Off-screen views' block cards are built on first visit (the #272 deferral). `ensure_block_ui()` re-derived the plugin set from `board_plugins()`, which omits any served `ctrl_block`, so a block's control toggle — blockr.ai's AI "sparkle" — showed on the initially-active view but was absent on every other view's cards. This is view-based, not block-type-based.
- The served plugin set now rides `active_dock` alongside the `visibility` channel and threads through `create_view` → `manage_dock`, so both deferred build paths (the view switch and the add-panel modal) build cards with the plugins `serve()` installed. `blockr_app_server.dock_board()` captures the served set that blockr.core hands to its own block server but withholds from board callbacks.
- Regression coverage sits at the shared funnel (`ensure_block_ui`) and both caller paths (`switch_active_view`, `op_add_panel`), asserting the rendered card carries the served ctrl toggle; two plumbing tests lock the `active_dock` stash and the `manage_dock` threading.

Fixes #331
