### PR TITLE
Name variadic input slots from the link menu and block browser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # blockr.dock (development version)
 
+* The "Connect ..." sidebar and the block browser's append / prepend forms
+  now let a link into a variadic block carry a name: an optional "Input
+  name" field appears for variadic targets (leave it blank for a positional
+  slot). A supplied name must be unique among the target's inputs, per
+  blockr.core's name-or-position model.
+
 * `resolve_free_input()` now resolves a variadic link target to an empty
   (positional) slot instead of a generated `"1"`, `"2"`, ... name, aligning
   the "Connect ..." sidebar with blockr.core's name-or-position variadic

--- a/R/sidebar-block.R
+++ b/R/sidebar-block.R
@@ -142,6 +142,24 @@ validate_block_spec <- function(spec, board, target, session) {
       "link", session
     )
   }
+
+  # A prepend into a variadic target may carry a user-supplied slot name;
+  # core rejects two identically named inputs on one block. Appended
+  # blocks are new, so their first input never collides.
+  if (target_mode(target) == "prepend") {
+    name <- spec$target_input
+    if (!is.null(name) && nzchar(name)) {
+      links <- safe_board_links(board)
+      if (name %in% links[links$to == target$id]$input) {
+        notify(
+          "This input name is already used on the target block.",
+          type = "warning", session = session
+        )
+        req(FALSE)
+      }
+    }
+  }
+
   invisible(TRUE)
 }
 
@@ -262,7 +280,12 @@ resolve_target <- function(board, target) {
   # from, so the panel is rendered context-free (the consumer supplies
   # the "Append from X" context via the sidebar title).
   if (is.null(target) || is.null(target$id)) {
-    return(list(subtitle = NULL, inputs = character(), attrs = list()))
+    return(
+      list(
+        subtitle = NULL, inputs = character(), attrs = list(),
+        variadic = FALSE
+      )
+    )
   }
 
   blk <- board_block(board, target$id)
@@ -280,6 +303,7 @@ resolve_target <- function(board, target) {
 
   inputs <- character()
   attrs <- list()
+  variadic <- FALSE
   if (target$mode == "prepend" && !is.null(blk)) {
     # Filter out slots already taken by incoming links to the target,
     # so the user is never offered a port they can't actually use.
@@ -288,14 +312,15 @@ resolve_target <- function(board, target) {
       taken_inputs(board, target$id)
     )
     arity <- block_arity(blk)
-    if (is.na(arity)) {
+    variadic <- is.na(arity)
+    if (variadic) {
       attrs <- list(`data-target-arity` = "inf")
     } else if (is.numeric(arity) && length(arity) == 1L) {
       attrs <- list(`data-target-arity` = as.character(arity))
     }
   }
 
-  list(subtitle = subtitle, inputs = inputs, attrs = attrs)
+  list(subtitle = subtitle, inputs = inputs, attrs = attrs, variadic = variadic)
 }
 
 browser_panel <- function(ns, metas, mode, tgt) {
@@ -330,7 +355,9 @@ browser_panel <- function(ns, metas, mode, tgt) {
           lapply(names(groups), function(cat) {
             category_section(
               cat, groups[[cat]],
-              function(m) browser_block_card(m, ns, mode, tgt$inputs)
+              function(m) {
+                browser_block_card(m, ns, mode, tgt$inputs, tgt$variadic)
+              }
             )
           })
         ),
@@ -358,7 +385,8 @@ category_section <- function(category, entries, card_fn) {
   )
 }
 
-browser_block_card <- function(meta, ns, mode, target_inputs) {
+browser_block_card <- function(meta, ns, mode, target_inputs,
+                               target_variadic = FALSE) {
   tags$div(
     class = "blockr-block-browser-card",
     `data-block-type` = meta$type,
@@ -408,14 +436,15 @@ browser_block_card <- function(meta, ns, mode, target_inputs) {
         meta$description
       )
     },
-    card_advanced(meta, ns, mode, target_inputs)
+    card_advanced(meta, ns, mode, target_inputs, target_variadic)
   )
 }
 
 # Render only the fields the flow needs (mode is fixed per render, so
 # there is no need to render every field and hide the inapplicable ones
 # via CSS). `htmltools` drops the NULL children for the omitted fields.
-card_advanced <- function(meta, ns, mode, target_inputs) {
+card_advanced <- function(meta, ns, mode, target_inputs,
+                          target_variadic = FALSE) {
   field_id <- function(suffix) ns(paste0(meta$type, "_", suffix))
   show_link <- mode %in% c("append", "prepend")
   # Only ask the user to pick a slot when there is an actual choice
@@ -423,6 +452,14 @@ card_advanced <- function(meta, ns, mode, target_inputs) {
   # forced; the dock falls back to `block_inputs(blk)[1L]`.
   show_block_input <- mode == "append" && length(meta$inputs) > 1L
   show_target_input <- mode == "prepend" && length(target_inputs) > 1L
+
+  # A variadic end has no fixed ports to pick from: offer an optional
+  # name instead (blank commits a positional slot). The field carries
+  # the mode's slot class so the browser JS reports it verbatim.
+  name_variadic <- (mode == "append" && isTRUE(meta$variadic)) ||
+    (mode == "prepend" && isTRUE(target_variadic))
+  name_suffix <- if (mode == "append") "block-input" else "target-input"
+  name_id_suffix <- if (mode == "append") "block_input" else "target_input"
   add_label <- switch(mode,
     add = "Add",
     append = "Append",
@@ -470,6 +507,15 @@ card_advanced <- function(meta, ns, mode, target_inputs) {
         id = field_id("target_input"),
         label = "Target input port",
         options = target_inputs
+      )
+    },
+    if (name_variadic) {
+      field_text(
+        class_suffix = name_suffix,
+        id = field_id(name_id_suffix),
+        label = "Input name (optional)",
+        value = "",
+        placeholder = "leave blank for an unnamed input"
       )
     },
     tags$button(

--- a/R/sidebar-link.R
+++ b/R/sidebar-link.R
@@ -100,6 +100,21 @@ validate_link_spec <- function(spec, board, session) {
     )
     req(FALSE)
   }
+
+  # core rejects two identically named inputs on one block, so a
+  # user-supplied variadic slot name has to be free on the target.
+  name <- spec$block_input
+  if (!is.null(name) && nzchar(name)) {
+    links <- board_links(board)
+    if (name %in% links[links$to == spec$target]$input) {
+      notify(
+        "This input name is already used on the target block.",
+        type = "warning", session = session
+      )
+      req(FALSE)
+    }
+  }
+
   invisible(TRUE)
 }
 
@@ -354,7 +369,8 @@ link_card_meta <- function(blk_id, blocks, registry, anchor, direction,
     package = entry_attr(entry, "package", "local"),
     description = entry_attr(entry, "description", ""),
     target_id = target_id,
-    target_inputs = free_inputs[[target_id]] %||% character()
+    target_inputs = free_inputs[[target_id]] %||% character(),
+    target_variadic = is.na(block_arity(blocks[[target_id]]))
   )
 }
 
@@ -443,6 +459,15 @@ link_card_advanced <- function(meta, ns, board) {
         id = card_ns("block_input"),
         label = "Block input port",
         options = meta$target_inputs
+      )
+    },
+    if (meta$target_variadic) {
+      field_text(
+        class_suffix = "input-name",
+        id = card_ns("input_name"),
+        label = "Input name (optional)",
+        value = "",
+        placeholder = "leave blank for an unnamed input"
       )
     },
     tags$button(

--- a/inst/assets/js/sidebar-link.js
+++ b/inst/assets/js/sidebar-link.js
@@ -43,9 +43,11 @@
       source: direction === "outgoing" ? anchor : other,
       target: direction === "outgoing" ? other : anchor,
       link_id: getFieldValue(card, "blockr-block-browser-field-link-id"),
-      block_input: getFieldValue(
-        card, "blockr-block-browser-field-block-input"
-      ),
+      // Finite targets render a port <select>; variadic targets render a
+      // free-text name field instead. Only one is present per card.
+      block_input:
+        getFieldValue(card, "blockr-block-browser-field-block-input") ||
+        getFieldValue(card, "blockr-block-browser-field-input-name"),
       nonce: ++commitSeq
     };
     return spec;

--- a/tests/testthat/test-action-block.R
+++ b/tests/testthat/test-action-block.R
@@ -267,6 +267,169 @@ test_that("prepend block action: target_input picks the link slot", {
   )
 })
 
+test_that("append block action: a name field names the variadic slot", {
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(a = new_dataset_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL)
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        append_block_action(
+          trigger = reactive("a"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # Appending a variadic rbind: the name field arrives as block_input
+      # and names the new block's fresh slot.
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "rbind_block", id = "r1", title = NULL,
+        link_id = "lnk1", block_input = "controls", nonce = 1
+      ))
+
+      df <- as.data.frame(r_update()$links$add)
+      expect_identical(df$to, "r1")
+      expect_identical(df$input, "controls")
+    }
+  )
+})
+
+test_that("prepend block action: a name field names the target slot", {
+  r_board <- reactiveValues(
+    board = new_board(blocks = c(r = new_rbind_block())),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL)
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        prepend_block_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # Prepending a source into a variadic target: target_input carries
+      # the typed name for the target's fresh slot.
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "dataset_block", id = "d1", title = NULL,
+        link_id = "lnk1", target_input = "controls", nonce = 1
+      ))
+
+      df <- as.data.frame(r_update()$links$add)
+      expect_identical(df$to, "r")
+      expect_identical(df$input, "controls")
+    }
+  )
+})
+
+test_that("prepend block action: a duplicate target name is rejected", {
+  r_board <- reactiveValues(
+    board = new_board(
+      blocks = c(a = new_dataset_block(), r = new_rbind_block()),
+      links = links(id = "ar", from = "a", to = "r", input = "controls")
+    ),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL)
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        prepend_block_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      session$setInputs(`browser-commit` = commit_spec(
+        type = "dataset_block", id = "d1", title = NULL,
+        link_id = "lnk1", target_input = "controls", nonce = 1
+      ))
+
+      expect_identical(r_update(), list())
+    }
+  )
+})
+
+test_that("block browser renders a name field for variadic ends", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), r = new_rbind_block(),
+      m = new_merge_block())
+  )
+  by_class <- function(tok) {
+    sprintf(
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]", tok
+    )
+  }
+  field_input <- function(html, block_type, cls) {
+    doc <- xml2::read_html(html)
+    card <- xml2::xml_find_first(
+      doc,
+      paste0(
+        by_class("blockr-block-browser-card"),
+        "[@data-block-type='", block_type, "']"
+      )
+    )
+    xml2::xml_find_first(card, paste0(".", by_class(cls), "//input"))
+  }
+
+  # Append a variadic rbind -> block-input becomes a free-text name field;
+  # a finite merge keeps its port <select> (no text input).
+  append_html <- as.character(block_browser_ui("b", board, append_to("a")))
+  rbind_name <- field_input(
+    append_html, "rbind_block", "blockr-block-browser-field-block-input"
+  )
+  expect_false(is.na(rbind_name))
+  expect_identical(
+    xml2::xml_attr(rbind_name, "placeholder"),
+    "leave blank for an unnamed input"
+  )
+  expect_true(
+    is.na(
+      field_input(
+        append_html, "merge_block", "blockr-block-browser-field-block-input"
+      )
+    )
+  )
+
+  # Prepend into a variadic target -> target-input becomes a name field.
+  prepend_html <- as.character(block_browser_ui("b", board, prepend_to("r")))
+  expect_false(
+    is.na(
+      field_input(
+        prepend_html, "dataset_block",
+        "blockr-block-browser-field-target-input"
+      )
+    )
+  )
+})
+
 test_that("prepend: NULL target_input falls back to only slot", {
   # head_block has arity 1 (input "data"); the browser hides the
   # target_input picker, so spec$target_input arrives as NULL. The

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -152,10 +152,136 @@ test_that("resolve_free_input gives a variadic target a positional slot", {
 
   expect_identical(resolve_free_input(blocks[["r"]], "r", links()), "")
 
-  # A variadic target already carrying a positional link resolves to
-  # another positional slot, never a generated integer name.
-  wired <- links(id = "ar", from = "a", to = "r", input = "1")
-  expect_identical(resolve_free_input(blocks[["r"]], "r", wired), "")
+  # A variadic target already carrying a positional ("") link still
+  # resolves to another positional slot.
+  positional <- links(id = "ar", from = "a", to = "r", input = "")
+  expect_identical(resolve_free_input(blocks[["r"]], "r", positional), "")
+
+  # A legacy integer-named link never makes the resolver generate another
+  # integer name; the fresh slot is positional.
+  named <- links(id = "ar", from = "a", to = "r", input = "1")
+  expect_identical(resolve_free_input(blocks[["r"]], "r", named), "")
+})
+
+test_that("add link action: variadic target honours a user-supplied name", {
+  local_mocked_sidebar()
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), r = new_rbind_block())
+    ),
+    board_id = "my_board"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_link_action(
+          trigger = reactive("a"),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # The variadic name field carries a typed slot name through as
+      # block_input, so the link is created as a named argument.
+      commit_menu(
+        session, source = "a", target = "r", link_id = "ar",
+        block_input = "controls"
+      )
+
+      expect_added_link(
+        r_update(), id = "ar", from = "a", to = "r", input = "controls"
+      )
+    }
+  )
+})
+
+test_that("add link action: a duplicate variadic input name is rejected", {
+  local_mocked_sidebar()
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+        r = new_rbind_block()),
+      links = links(id = "br", from = "b", to = "r", input = "controls")
+    ),
+    board_id = "my_board"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_link_action(
+          trigger = reactive("a"),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # `r` already carries a "controls" input from `b`; core forbids a
+      # second identically named input, so the menu rejects the commit.
+      commit_menu(
+        session, source = "a", target = "r", link_id = "ar",
+        block_input = "controls"
+      )
+
+      expect_identical(r_update(), list())
+    }
+  )
+})
+
+test_that("link menu renders a name field only for variadic targets", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), r = new_rbind_block(),
+      m = new_merge_block())
+  )
+
+  doc <- xml2::read_html(as.character(link_menu_ui("mid", board, "a")))
+  by_class <- function(tok) {
+    sprintf(
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]", tok
+    )
+  }
+  card <- function(id) {
+    xml2::xml_find_first(
+      doc,
+      paste0(by_class("blockr-link-menu-card"), "[@data-block-type='", id, "']")
+    )
+  }
+  has_field <- function(node, tok) {
+    length(xml2::xml_find_all(node, paste0(".", by_class(tok)))) > 0L
+  }
+
+  expect_true(
+    has_field(card("r"), "blockr-block-browser-field-input-name")
+  )
+  expect_false(
+    has_field(card("r"), "blockr-block-browser-field-block-input")
+  )
+  expect_false(
+    has_field(card("m"), "blockr-block-browser-field-input-name")
+  )
+  expect_true(
+    has_field(card("m"), "blockr-block-browser-field-block-input")
+  )
+
+  placeholder <- xml2::xml_attr(
+    xml2::xml_find_first(
+      card("r"),
+      paste0(
+        ".", by_class("blockr-block-browser-field-input-name"), "//input"
+      )
+    ),
+    "placeholder"
+  )
+  expect_identical(placeholder, "leave blank for an unnamed input")
 })
 
 test_that("add link action: INCOMING commit targets the anchor", {


### PR DESCRIPTION
## Summary

- Linking into a variadic block always created an unnamed positional slot with no way to name it. The "Connect" link menu and the block browser's append / prepend forms now show an optional "Input name" field for variadic ends -- blank keeps the slot positional, a value names it.
- The typed name is validated for uniqueness against the target's existing inputs, since blockr.core forbids two identically named inputs on one block.
- Dock-only: the commit path already honoured a supplied slot name, so this is the field, the link-menu JS that reports it, and the two menus' server-side validation -- no blockr.core change. The core-provenance alternative floated in the issue (auto-naming export files by source block) is intentionally not pursued.
- Also folds in the #335 review cleanups: corrects a test comment that labelled a named `"1"` input as "positional", and adds coverage for a variadic target that already carries a positional slot.

Fixes #337
