### PR TITLE
Skip the grid-echo layout mirror on a locked board

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -734,11 +734,22 @@ manage_dock <- function(
     # observer below. dockViewR emits one settled `_state` per gesture (a
     # gesture's layout mutations coalesce onto a microtask), so a re-echo after
     # quiescence canonicalises identically and writes nothing.
-    commit_grid <- function(grid) {
-      update(list(views = list(grid = set_names(list(grid), id))))
-    }
+    #
+    # A locked board takes no geometry write-back: `commit_grid` rides the
+    # `update()` gate blockr.core rejects while locked, and dockViewR echoes
+    # `_state` on every view visit, so a live mirror would commit-then-reject
+    # each visit. Skip wiring it -- locking is a static deploy option, decided
+    # once here. Do NOT extend this to the render path: report_visible_observer
+    # also reacts to `dock$layout()`, but it writes the visibility channel (what
+    # paints the front tab), not the board, and must stay live when locked.
+    if (!is_dock_locked()) {
 
-    observe_grid_echo(id, dock, board, commit_grid)
+      commit_grid <- function(grid) {
+        update(list(views = list(grid = set_names(list(grid), id))))
+      }
+
+      observe_grid_echo(id, dock, board, commit_grid)
+    }
 
     if (get_log_level() >= debug_log_level) {
       observeEvent(

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -13,6 +13,19 @@ retry_download <- function(app, output, .attempts = 6L) {
   stop(res)
 }
 
+# Every e2e AppDriver goes through here so the chromote command timeout is
+# hardened in one place. A loaded CI runner (Windows especially) can take longer
+# than chromote's 10s default to bind the app's port, so AppDriver's first
+# `Page.navigate` times out at init (rstudio/shinytest2#448). The chromote
+# session inherits its command timeout from the default chromote object, so
+# raise that before the session is spawned -- via `default_chromote_object()`,
+# the same object AppDriver draws its session from.
+new_app_driver <- function(...) {
+  chrome <- chromote::default_chromote_object()
+  chrome$default_timeout <- 60
+  shinytest2::AppDriver$new(...)
+}
+
 board_args <- function(...) {
   generate_plugin_args(
     new_dock_board(...),

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1604,3 +1604,60 @@ test_that("a locked board freezes every block once it reports (#127)", {
     }
   )
 })
+
+test_that("the grid-echo mirror is wired only when unlocked (#339)", {
+
+  board_rv <- board_args(blocks = c(a = new_dataset_block()))
+
+  echo_wired <- 0L
+  local_mocked_bindings(
+    observe_grid_echo = function(...) {
+      echo_wired <<- echo_wired + 1L
+      invisible()
+    }
+  )
+
+  wire_mirror <- function() {
+    ms <- new_mock_session()
+    with_mock_context(ms, {
+      manage_dock("dock_main", board_rv, visibility = fake_visibility("a"),
+                  update = reactiveVal())
+    })
+    ms$flushReact()
+    if (!ms$isClosed()) ms$close()
+  }
+
+  echo_wired <- 0L
+  withr::with_options(list(blockr.locked = NULL), wire_mirror())
+  expect_identical(echo_wired, 1L)
+
+  # Locked: the futile geometry write-back is skipped, so the mirror is never
+  # wired -- no commit-then-reject per view visit.
+  echo_wired <- 0L
+  withr::with_options(list(blockr.locked = TRUE), wire_mirror())
+  expect_identical(echo_wired, 0L)
+})
+
+test_that("a locked board still wires the render path (#339)", {
+
+  board_rv <- board_args(blocks = c(a = new_dataset_block()))
+
+  render_wired <- 0L
+  local_mocked_bindings(
+    report_visible_observer = function(...) {
+      render_wired <<- render_wired + 1L
+      invisible()
+    }
+  )
+
+  withr::local_options(blockr.locked = TRUE)
+
+  with_mock_session({
+    board_server_callback(board_rv, update = reactiveVal(),
+                          visibility = fake_visibility("a"))
+  })
+
+  # The grid mirror is gated when locked, but the visible-axis writer that
+  # paints the front tab must not be -- gating it would blank a locked board.
+  expect_identical(render_wired, 1L)
+})

--- a/tests/testthat/test-commit-sentinel.R
+++ b/tests/testthat/test-commit-sentinel.R
@@ -10,7 +10,7 @@ test_that("a settled gesture commits a bounded amount, quiescence adds none", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "empty", "app.R", package = "blockr.dock"),
     name = "commit-sentinel",
     seed = 42,
@@ -56,7 +56,7 @@ test_that("the authored layout round-trips to its stored form", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "sized-grid", "app.R", package = "blockr.dock"),
     name = "roundtrip-sentinel",
     seed = 42,

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -66,7 +66,7 @@ test_that("dock app renders a block added via the extension (#191)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "empty", "app.R", package = "blockr.dock"),
     name = "dock",
     seed = 42,
@@ -101,7 +101,7 @@ test_that("edit board extension links blocks (e2e)", {
   # A board pre-seeded with a source and a transform block so the test drives
   # only link operations -- adding blocks would deactivate the extension panel
   # and race shinytest2. The same bare fixture serves the stacks test below.
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "edit-add", "app.R", package = "blockr.dock"),
     name = "edit-link",
     seed = 42,
@@ -132,7 +132,7 @@ test_that("adding a second block keeps both block panels (#196)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "empty", "app.R", package = "blockr.dock"),
     name = "panel-visibility",
     seed = 42,
@@ -166,7 +166,7 @@ test_that("edit board extension stacks (e2e)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "edit-add", "app.R", package = "blockr.dock"),
     name = "edit-stacks",
     seed = 42,
@@ -215,7 +215,7 @@ test_that("multi-view nav renders one labelled entry per view (#189)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "multi-view", "app.R", package = "blockr.dock"),
     name = "multi-view",
     seed = 42,
@@ -259,7 +259,7 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "serdes", "app.R", package = "blockr.dock"),
     name = "serdes",
     seed = 42,
@@ -352,7 +352,7 @@ test_that("deleting a block via its card menu drops the panel and its link", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "edit-board", "app.R", package = "blockr.dock"),
     name = "remove-block",
     seed = 42,
@@ -387,7 +387,7 @@ test_that("removing a link via the edit extension updates the board", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "edit-board", "app.R", package = "blockr.dock"),
     name = "remove-link",
     seed = 42,
@@ -418,7 +418,7 @@ test_that("removing a stack via the edit extension updates the board", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "edit-board", "app.R", package = "blockr.dock"),
     name = "remove-stack",
     seed = 42,
@@ -449,7 +449,7 @@ test_that("view lifecycle: switch, rename, remove a view (#232)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "multi-view", "app.R", package = "blockr.dock"),
     name = "view-lifecycle",
     seed = 42,
@@ -549,7 +549,7 @@ test_that("dock panel move updates layout state and serialization (#234)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "edit-board", "app.R", package = "blockr.dock"),
     name = "layout-edit",
     seed = 42,
@@ -648,7 +648,7 @@ test_that("locked board hides block actions, shows lock indicator (#236)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "locked-dock", "app.R", package = "blockr.dock"),
     name = "locked-board",
     seed = 42,
@@ -695,7 +695,7 @@ test_that("single-page board renders one auto-named view (#236)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "single-page", "app.R", package = "blockr.dock"),
     name = "single-page",
     seed = 42,
@@ -725,7 +725,7 @@ test_that("busy pulse tracks real work, not layout bookkeeping (#285)", {
 
   skip_on_cran()
 
-  app <- shinytest2::AppDriver$new(
+  app <- new_app_driver(
     system.file("examples", "multi-view", "app.R", package = "blockr.dock"),
     name = "busy-pulse",
     seed = 42,


### PR DESCRIPTION
## Summary

The grid-echo layout mirror commits view geometry through `update()`, which blockr.core's gate rejects on a locked board — and dockViewR echoes `_state` on every view visit, so the mirror ran a futile commit-then-reject each time. Since locking is a static deploy option (`blockr.locked`), the mirror is now simply not wired when locked, decided once at `manage_dock` time rather than gated per fire.

The render path is deliberately left live: `report_visible_observer` reacts to the same `dock$layout()` echo but writes blockr.core's visibility channel (what paints the front tab), not the board — gating it would blank a locked board. A comment and a regression test both pin that distinction, since it's the easy thing for a later "locked observers" cleanup to get wrong.

The idle user-input mutation observers (view add / remove / rename, `action-block` / `action-link` / `action-stack`) are intentionally left alone: their controls are already hidden when locked (`views_can_crud()` is `!is_dock_locked()`), so they never fire and gating them would buy nothing.

Fixes #339
