### PR TITLE
Add edit_link_action to edit an existing link in a sidebar

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,4 +6,5 @@
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^\.claude
+^\.lintr$
 ^vignettes/mermaid/.*\.mmd$

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,1 @@
+exclusions: list("tests/testthat/*.R" = list(object_usage_linter = Inf))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* New `edit_link_action`: a sidebar editor for a single existing link. It can
+  rename the link's input (turning an unnamed positional slot into a named
+  one, or changing an existing name), switch the input slot on a finite
+  target, and redirect the link's source or target - under the same
+  acyclicity, eligibility and input-name uniqueness rules the "Connect ..."
+  menu enforces. The edit commits as a `links` `mod` delta, so the link id
+  survives (a remove-and-recreate would drop it). Surfaces such as
+  blockr.dag can trigger it for a selected edge.
+
 * The "Connect ..." sidebar and the block browser's append / prepend forms
   now let a link into a variadic block carry a name: an optional "Input
   name" field appears for variadic targets (leave it blank for a positional

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,9 @@
   one, or changing an existing name), switch the input slot on a finite
   target, and redirect the link's source or target - under the same
   acyclicity, eligibility and input-name uniqueness rules the "Connect ..."
-  menu enforces. The edit commits as a `links` `mod` delta, so the link id
-  survives (a remove-and-recreate would drop it). Surfaces such as
-  blockr.dag can trigger it for a selected edge.
+  menu enforces, with the block pickers rendered like the add-panel picker.
+  The link keeps its id across the edit. Surfaces such as blockr.dag can
+  trigger it for a selected edge.
 
 * The "Connect ..." sidebar and the block browser's append / prepend forms
   now let a link into a variadic block carry a name: an optional "Input

--- a/R/action-class.R
+++ b/R/action-class.R
@@ -86,6 +86,7 @@ board_actions.dock_board <- function(x, ...) {
     prepend_block_action,
     remove_block_action,
     add_link_action,
+    edit_link_action,
     remove_link_action,
     add_stack_action,
     edit_stack_action,

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -115,13 +115,13 @@ edit_link_action <- function(trigger, board, update, ...) {
           return()
         }
 
-        # `links$mod` deltas are applied via core's `update_link()`, which
-        # keeps the link id (a rm + add would drop it). An empty delta means
-        # the user confirmed without editing anything - nothing to apply.
-        delta <- committed()$delta
+        # The menu returns the edited link keyed by its (unchanged) id, or
+        # NULL when nothing changed. Commit it as a remove + re-add of that
+        # id in one update, which keeps the id and re-applies every field.
+        link <- committed()$link
 
-        if (length(delta)) {
-          update(list(links = list(mod = set_names(list(delta), id))))
+        if (!is.null(link)) {
+          update(list(links = list(rm = id, add = link)))
         }
 
         session$onFlushed(

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -61,6 +61,87 @@ add_link_action <- function(trigger, board, update, ...) {
   )
 }
 
+edit_link_action <- function(trigger, board, update, ...) {
+  new_action(
+    function(input, output, session) {
+
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
+
+      # The menu validates its own commit (block eligibility, acyclicity,
+      # input-name uniqueness) and returns only the fields that changed, so
+      # this handler is a thin adapter over a `links$mod` update.
+      committed <- edit_link_menu_server(
+        "menu",
+        board = reactive(board$board),
+        link_id = reactive(trigger())
+      )
+
+      menu_ui <- function() {
+        edit_link_menu_ui(
+          session$ns("menu"), board$board, link_id = trigger()
+        )
+      }
+
+      sidebar_title <- function() paste0("Edit link ", trigger())
+
+      observeEvent(trigger(), {
+        show_sidebar(
+          sidebar_id, title = sidebar_title(), ui = menu_ui()
+        )
+      })
+
+      # Close the sidebar the moment the edited link leaves the board
+      # (removed elsewhere): editing a link that no longer exists makes no
+      # sense, so don't wait for an "Update" click. Guarded on the sidebar
+      # being open and on an edit actually being in progress.
+      observeEvent(board$board, {
+        id <- trigger()
+        if (length(id) == 1L && !is.na(id) && nzchar(id) &&
+              !id %in% board_link_ids(board$board) &&
+              isTRUE(sidebar_state(sidebar_id)$open)) {
+          hide_sidebar(sidebar_id)
+        }
+      }, ignoreInit = TRUE)
+
+      observeEvent(committed(), {
+        id <- trigger()
+
+        # Safety net for a race (board change not yet observed when the user
+        # clicks): committing for a link that's gone would error, so bail and
+        # close unless `id` is still a present link.
+        if (!(length(id) == 1L && !is.na(id) && nzchar(id) &&
+                id %in% board_link_ids(board$board))) {
+          hide_sidebar(sidebar_id)
+          return()
+        }
+
+        # `links$mod` deltas are applied via core's `update_link()`, which
+        # keeps the link id (a rm + add would drop it). An empty delta means
+        # the user confirmed without editing anything - nothing to apply.
+        delta <- committed()$delta
+
+        if (length(delta)) {
+          update(list(links = list(mod = set_names(list(delta), id))))
+        }
+
+        session$onFlushed(
+          function() {
+            isolate(
+              keep_or_hide_sidebar(
+                sidebar_id, title = sidebar_title(), ui = menu_ui()
+              )
+            )
+          },
+          once = TRUE
+        )
+      })
+
+      NULL
+    },
+    id = "edit_link_action"
+  )
+}
+
 remove_link_action <- function(trigger, board, update, ...) {
   new_action(
     function(input, output, session) {

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -115,13 +115,13 @@ edit_link_action <- function(trigger, board, update, ...) {
           return()
         }
 
-        # The menu returns the edited link keyed by its (unchanged) id, or
-        # NULL when nothing changed. Commit it as a remove + re-add of that
-        # id in one update, which keeps the id and re-applies every field.
-        link <- committed()$link
+        # The menu returns just the changed fields (or an empty delta when
+        # nothing changed). Apply them as a `links$mod` on the unchanged id;
+        # core merges the delta onto the current link via `update_link()`.
+        delta <- committed()$delta
 
-        if (!is.null(link)) {
-          update(list(links = list(rm = id, add = link)))
+        if (length(delta)) {
+          update(list(links = list(mod = set_names(list(delta), id))))
         }
 
         session$onFlushed(

--- a/R/sidebar-link.R
+++ b/R/sidebar-link.R
@@ -494,10 +494,15 @@ seed_link_id <- function(board) {
 
 # The edit menu is the single-link counterpart to the connect menu: it
 # edits one existing link rather than offering a pool of new ones. `from`
-# and `to` are block pickers, the input port / name field re-renders for
+# and `to` are block pickers (the block-browser selectize, so they read
+# like the add-panel picker), the input port / name field re-renders for
 # the currently selected target, and the same eligibility, acyclicity and
 # uniqueness rules as `add_link_action` are enforced at commit. The commit
-# is a `links$mod` delta so the link id survives the edit.
+# removes and re-adds the link under the same id, so the id survives.
+#
+# The endpoints and input field are `uiOutput`s so the open sidebar tracks
+# the board live: a block renamed / added / removed elsewhere (e.g. while
+# the sidebar is pinned) refreshes the pickers, keeping the selection.
 
 edit_link_menu_ui <- function(id, board, link_id) {
   stopifnot(is.character(id), length(id) == 1L, nzchar(id))
@@ -511,10 +516,9 @@ edit_link_menu_ui <- function(id, board, link_id) {
       "This link is no longer on the board."
     )
   } else {
-    choices <- edit_link_block_choices(board_blocks(board))
     tagList(
-      selectInput(ns("from"), "Source block", choices, selected = row$from),
-      selectInput(ns("to"), "Target block", choices, selected = row$to),
+      css_block_selectize(),
+      uiOutput(ns("endpoints")),
       uiOutput(ns("input_field")),
       actionButton(
         ns("confirm"), "Update link",
@@ -538,13 +542,54 @@ edit_link_menu_server <- function(id, board, link_id) {
     id,
     function(input, output, session) {
 
+      # Authoritative source / target selection. Switching the edited link
+      # resets it to that link's committed endpoints - the persisted
+      # `input$from/to` still hold the previously edited link's pick until
+      # the client re-reports, so relying on them would leak one edit into
+      # the next (and mis-key the input control on a variadic vs finite
+      # target). Within an edit it tracks the user's picks.
+      sel <- reactiveValues(from = NULL, to = NULL)
+
+      observeEvent(link_id_fn(), {
+        row <- edit_link_row(isolate(board()), link_id_fn())
+        sel$from <- if (is.null(row)) NULL else row$from
+        sel$to <- if (is.null(row)) NULL else row$to
+      }, ignoreNULL = FALSE)
+
+      observeEvent(input$from, sel$from <- input$from, ignoreInit = TRUE)
+      observeEvent(input$to, sel$to <- input$to, ignoreInit = TRUE)
+
+      # Source / target pickers, seeded from the link's committed endpoints
+      # and re-rendered on the link switching or any board change - so a
+      # rename / add / remove elsewhere refreshes the options and labels
+      # while the sidebar stays open. The selectize is client-owned once
+      # rendered, so this does not depend on `sel` (which would re-init it
+      # on every pick).
+      output$endpoints <- renderUI({
+        lid <- link_id_fn()
+        req(length(lid) == 1L, !is.na(lid), nzchar(lid))
+        brd <- board()
+        row <- edit_link_row(brd, lid)
+        req(row)
+
+        ids <- board_block_ids(brd)
+        tagList(
+          edit_link_block_select(
+            session$ns("from"), "Source block", brd, ids, row$from
+          ),
+          edit_link_block_select(
+            session$ns("to"), "Target block", brd, ids, row$to
+          )
+        )
+      })
+
       output$input_field <- renderUI({
         lid <- link_id_fn()
         req(length(lid) == 1L, !is.na(lid), nzchar(lid))
         brd <- board()
         row <- edit_link_row(brd, lid)
         req(row)
-        edit_link_input_field(session$ns, brd, lid, input$to %||% row$to, row)
+        edit_link_input_field(session$ns, brd, lid, sel$to %||% row$to, row)
       })
 
       eventReactive(
@@ -555,10 +600,22 @@ edit_link_menu_server <- function(id, board, link_id) {
           brd <- board()
           req(lid %in% board_link_ids(brd))
 
-          spec <- gather_edit_link_spec(input, brd, lid)
+          spec <- gather_edit_link_spec(input, brd, lid, sel$from, sel$to)
           validate_edit_link_spec(spec, brd, lid, session)
 
-          list(delta = edit_link_delta(spec, brd, lid), nonce = input$confirm)
+          # An edit is committed as a remove + re-add under the *same* id,
+          # not a `links$mod` delta: the id survives and the full link is
+          # re-applied (mirroring the edit-board table's link edits). NULL
+          # when nothing changed, so the action issues no update.
+          link <- if (length(edit_link_delta(spec, brd, lid))) {
+            as_links(
+              set_names(
+                list(new_link(spec$from, spec$to, spec$input)), lid
+              )
+            )
+          }
+
+          list(link = link, nonce = input$confirm)
         },
         ignoreNULL = TRUE,
         ignoreInit = TRUE
@@ -609,10 +666,14 @@ edit_link_input_field <- function(ns, board, link_id, to_id, row) {
   )
 }
 
-gather_edit_link_spec <- function(input, board, link_id) {
+# `from` / `to` are the authoritative selections tracked by the server
+# (reset on a link switch); they fall back to the link's committed
+# endpoints when the pickers have not reported yet.
+gather_edit_link_spec <- function(input, board, link_id, from = NULL,
+                                  to = NULL) {
   row <- edit_link_row(board, link_id)
-  from <- input$from %||% row$from
-  to <- input$to %||% row$to
+  from <- from %||% row$from
+  to <- to %||% row$to
   to_blk <- board_blocks(board)[[to]]
 
   # An untouched field falls back to what the rendered control pre-selects
@@ -705,8 +766,8 @@ validate_edit_link_spec <- function(spec, board, link_id, session) {
   invisible(TRUE)
 }
 
-# The subset of `from` / `to` / `input` that actually changed, keyed for a
-# `links$mod` delta. Empty when the user confirmed without editing.
+# The subset of `from` / `to` / `input` that actually changed. Empty when
+# the user confirmed without editing (the commit is then skipped).
 edit_link_delta <- function(spec, board, link_id) {
   row <- edit_link_row(board, link_id)
   fields <- c("from", "to", "input")
@@ -741,14 +802,23 @@ links_without <- function(board, link_id) {
   lnks[setdiff(board_link_ids(board), link_id)]
 }
 
-edit_link_block_choices <- function(blocks) {
-  set_names(
-    names(blocks),
-    chr_mply(edit_link_block_label, names(blocks), as.list(blocks))
+# A single-select block picker rendered with the block-browser selectize
+# (icon, name, package badge, id) - the same look as the add-panel picker
+# - preselected to `selected`. `build_block_options()` /
+# `js_blk_selectize_render()` are the shared block-browser helpers.
+edit_link_block_select <- function(id, label, board, blk_ids, selected) {
+  selectizeInput(
+    id,
+    label = label,
+    choices = NULL,
+    options = list(
+      options = build_block_options(board, blk_ids),
+      items = list(selected),
+      maxItems = 1L,
+      valueField = "value",
+      labelField = "label",
+      searchField = c("label", "description", "searchtext"),
+      render = js_blk_selectize_render()
+    )
   )
-}
-
-edit_link_block_label <- function(id, blk) {
-  nm <- block_name(blk) %||% id
-  if (nzchar(nm) && !identical(nm, id)) paste0(nm, " (", id, ")") else id
 }

--- a/R/sidebar-link.R
+++ b/R/sidebar-link.R
@@ -489,3 +489,266 @@ seed_link_id <- function(board) {
   out <- seed_ids(board_link_ids(board), 1L)
   if (length(out) == 0L) "" else out
 }
+
+# ---- edit-link menu ----------------------------------------------------
+
+# The edit menu is the single-link counterpart to the connect menu: it
+# edits one existing link rather than offering a pool of new ones. `from`
+# and `to` are block pickers, the input port / name field re-renders for
+# the currently selected target, and the same eligibility, acyclicity and
+# uniqueness rules as `add_link_action` are enforced at commit. The commit
+# is a `links$mod` delta so the link id survives the edit.
+
+edit_link_menu_ui <- function(id, board, link_id) {
+  stopifnot(is.character(id), length(id) == 1L, nzchar(id))
+
+  ns <- NS(id)
+  row <- edit_link_row(board, link_id)
+
+  body <- if (is.null(row)) {
+    tags$p(
+      class = "blockr-block-browser-empty",
+      "This link is no longer on the board."
+    )
+  } else {
+    choices <- edit_link_block_choices(board_blocks(board))
+    tagList(
+      selectInput(ns("from"), "Source block", choices, selected = row$from),
+      selectInput(ns("to"), "Target block", choices, selected = row$to),
+      uiOutput(ns("input_field")),
+      actionButton(
+        ns("confirm"), "Update link",
+        class = "btn-primary blockr-link-edit-confirm"
+      )
+    )
+  }
+
+  htmltools::attachDependencies(
+    tags$div(class = "blockr-link-edit", body),
+    list(link_menu_dep())
+  )
+}
+
+edit_link_menu_server <- function(id, board, link_id) {
+  stopifnot(is.character(id), length(id) == 1L, nzchar(id))
+
+  link_id_fn <- as_accessor(link_id)
+
+  moduleServer(
+    id,
+    function(input, output, session) {
+
+      output$input_field <- renderUI({
+        lid <- link_id_fn()
+        req(length(lid) == 1L, !is.na(lid), nzchar(lid))
+        brd <- board()
+        row <- edit_link_row(brd, lid)
+        req(row)
+        edit_link_input_field(session$ns, brd, lid, input$to %||% row$to, row)
+      })
+
+      eventReactive(
+        input$confirm,
+        {
+          lid <- link_id_fn()
+          req(length(lid) == 1L, !is.na(lid), nzchar(lid))
+          brd <- board()
+          req(lid %in% board_link_ids(brd))
+
+          spec <- gather_edit_link_spec(input, brd, lid)
+          validate_edit_link_spec(spec, brd, lid, session)
+
+          list(delta = edit_link_delta(spec, brd, lid), nonce = input$confirm)
+        },
+        ignoreNULL = TRUE,
+        ignoreInit = TRUE
+      )
+    }
+  )
+}
+
+# The input slot control for the currently selected target: a free-text
+# name for a variadic target (pre-filled only when the target is
+# unchanged, since a fresh target has no current slot), else a port picker
+# over the target's free named inputs. The edited link is excluded from
+# the occupancy so its own slot reads as free.
+edit_link_input_field <- function(ns, board, link_id, to_id, row) {
+  to_blk <- board_blocks(board)[[to_id]]
+
+  if (is.null(to_blk)) {
+    return(NULL)
+  }
+
+  links_df <- as.data.frame(links_without(board, link_id))
+
+  if (is.na(block_arity(to_blk))) {
+    return(
+      textInput(
+        ns("input_name"),
+        "Input name (optional)",
+        value = default_variadic_name(to_id, row),
+        placeholder = "leave blank for an unnamed input"
+      )
+    )
+  }
+
+  free <- free_named_inputs(to_blk, to_id, links_df)
+
+  if (!length(free)) {
+    return(
+      tags$p(
+        class = "blockr-block-browser-empty",
+        "This target block has no free input port."
+      )
+    )
+  }
+
+  selectInput(
+    ns("input_port"), "Input port", free,
+    selected = default_finite_slot(free, to_id, row)
+  )
+}
+
+gather_edit_link_spec <- function(input, board, link_id) {
+  row <- edit_link_row(board, link_id)
+  from <- input$from %||% row$from
+  to <- input$to %||% row$to
+  to_blk <- board_blocks(board)[[to]]
+
+  # An untouched field falls back to what the rendered control pre-selects
+  # (the current slot when the target is unchanged), so a no-op confirm
+  # produces no delta - never a switch to a different free slot.
+  slot <- if (is.null(to_blk)) {
+    ""
+  } else if (is.na(block_arity(to_blk))) {
+    input$input_name %||% default_variadic_name(to, row)
+  } else {
+    free <- free_named_inputs(
+      to_blk, to, as.data.frame(links_without(board, link_id))
+    )
+    input$input_port %||% default_finite_slot(free, to, row)
+  }
+
+  list(
+    from = as.character(from),
+    to = as.character(to),
+    input = as.character(slot)
+  )
+}
+
+# The slot a target's input control defaults to: the link's current slot
+# when the target is unchanged (and still free), else the first free port
+# / an unnamed variadic slot. Shared by the renderer and the commit
+# gather so an untouched control and its server-side fallback agree.
+default_finite_slot <- function(free, to_id, row) {
+  if (identical(to_id, row$to) && row$input %in% free) row$input else free[1L]
+}
+
+default_variadic_name <- function(to_id, row) {
+  if (identical(to_id, row$to)) row$input else ""
+}
+
+# Reject a self-link, a redirect that closes a cycle, or an input slot
+# that is taken / out of range - mirroring the eligibility the connect
+# menu enforces up front by filtering. Each failure notifies and
+# `req(FALSE)`s, stopping the enclosing `eventReactive`.
+validate_edit_link_spec <- function(spec, board, link_id, session) {
+  blocks <- board_blocks(board)
+
+  if (!(spec$from %in% names(blocks) && spec$to %in% names(blocks))) {
+    notify(
+      "Please choose valid blocks to link.", type = "warning",
+      session = session
+    )
+    req(FALSE)
+  }
+
+  if (identical(spec$from, spec$to)) {
+    notify(
+      "A link's source and target must differ.", type = "warning",
+      session = session
+    )
+    req(FALSE)
+  }
+
+  links_df <- as.data.frame(links_without(board, link_id))
+
+  if (spec$from %in% descendants_of(spec$to, links_df)) {
+    notify(
+      "This would create a cycle.", type = "warning", session = session
+    )
+    req(FALSE)
+  }
+
+  to_blk <- blocks[[spec$to]]
+
+  if (is.na(block_arity(to_blk))) {
+    used <- links_df$input[links_df$to == spec$to]
+    if (nzchar(spec$input) && spec$input %in% used) {
+      notify(
+        "This input name is already used on the target block.",
+        type = "warning", session = session
+      )
+      req(FALSE)
+    }
+  } else {
+    free <- free_named_inputs(to_blk, spec$to, links_df)
+    if (!(nzchar(spec$input) && spec$input %in% free)) {
+      notify(
+        "Please choose a free input port on the target block.",
+        type = "warning", session = session
+      )
+      req(FALSE)
+    }
+  }
+
+  invisible(TRUE)
+}
+
+# The subset of `from` / `to` / `input` that actually changed, keyed for a
+# `links$mod` delta. Empty when the user confirmed without editing.
+edit_link_delta <- function(spec, board, link_id) {
+  row <- edit_link_row(board, link_id)
+  fields <- c("from", "to", "input")
+  unchanged <- lgl_mply(identical, spec[fields], row[fields])
+  spec[fields][!unchanged]
+}
+
+# The edited link's current fields as a plain list, or NULL when the id is
+# absent (removed elsewhere mid-edit).
+edit_link_row <- function(board, link_id) {
+  if (is.null(board) ||
+        !(length(link_id) == 1L && !is.na(link_id) && nzchar(link_id))) {
+    return(NULL)
+  }
+
+  df <- as.data.frame(board_links(board))
+  pos <- match(link_id, df$id)
+
+  if (is.na(pos)) {
+    return(NULL)
+  }
+
+  list(
+    from = as.character(df$from[pos]),
+    to = as.character(df$to[pos]),
+    input = as.character(df$input[pos])
+  )
+}
+
+links_without <- function(board, link_id) {
+  lnks <- board_links(board)
+  lnks[setdiff(board_link_ids(board), link_id)]
+}
+
+edit_link_block_choices <- function(blocks) {
+  set_names(
+    names(blocks),
+    chr_mply(edit_link_block_label, names(blocks), as.list(blocks))
+  )
+}
+
+edit_link_block_label <- function(id, blk) {
+  nm <- block_name(blk) %||% id
+  if (nzchar(nm) && !identical(nm, id)) paste0(nm, " (", id, ")") else id
+}

--- a/R/sidebar-link.R
+++ b/R/sidebar-link.R
@@ -603,19 +603,11 @@ edit_link_menu_server <- function(id, board, link_id) {
           spec <- gather_edit_link_spec(input, brd, lid, sel$from, sel$to)
           validate_edit_link_spec(spec, brd, lid, session)
 
-          # An edit is committed as a remove + re-add under the *same* id,
-          # not a `links$mod` delta: the id survives and the full link is
-          # re-applied (mirroring the edit-board table's link edits). NULL
-          # when nothing changed, so the action issues no update.
-          link <- if (length(edit_link_delta(spec, brd, lid))) {
-            as_links(
-              set_names(
-                list(new_link(spec$from, spec$to, spec$input)), lid
-              )
-            )
-          }
-
-          list(link = link, nonce = input$confirm)
+          # Return only the changed fields as a `links$mod` delta: the link
+          # keeps its id (and its untouched fields), which core merges via
+          # `update_link()`. Empty when nothing changed, so the action then
+          # issues no update.
+          list(delta = edit_link_delta(spec, brd, lid), nonce = input$confirm)
         },
         ignoreNULL = TRUE,
         ignoreInit = TRUE

--- a/R/sidebar-link.R
+++ b/R/sidebar-link.R
@@ -577,8 +577,12 @@ edit_link_menu_server <- function(id, board, link_id) {
           edit_link_block_select(
             session$ns("from"), "Source block", brd, ids, row$from
           ),
+          # Only blocks that can still receive a link (a free named input,
+          # or variadic arity) are offered as targets; the edited link's own
+          # slot is freed first, so its current target stays selectable.
           edit_link_block_select(
-            session$ns("to"), "Target block", brd, ids, row$to
+            session$ns("to"), "Target block", brd,
+            edit_link_target_ids(brd, lid), row$to
           )
         )
       })
@@ -792,6 +796,22 @@ edit_link_row <- function(board, link_id) {
 links_without <- function(board, link_id) {
   lnks <- board_links(board)
   lnks[setdiff(board_link_ids(board), link_id)]
+}
+
+# Block ids eligible as the link's target: those with input capacity (a
+# free named input, or variadic arity), computed with the edited link
+# removed so its current target - whose slot then frees up - stays in the
+# list. Reuses the connect menu's `has_input_capacity()`.
+edit_link_target_ids <- function(board, link_id) {
+  blocks <- board_blocks(board)
+  links_df <- as.data.frame(links_without(board, link_id))
+  ids <- names(blocks)
+  keep <- vapply(
+    ids,
+    function(id) has_input_capacity(blocks[[id]], id, links_df),
+    logical(1L)
+  )
+  ids[keep]
 }
 
 # A single-select block picker rendered with the block-browser selectize

--- a/inst/assets/css/sidebar-link.css
+++ b/inst/assets/css/sidebar-link.css
@@ -108,3 +108,28 @@
 .blockr-link-menu.is-empty .blockr-link-menu-direction {
   display: none;
 }
+
+/* ---- edit-link form ---------------------------------------------------
+   The single-link editor uses plain Shiny inputs (a source / target
+   picker and a re-rendered input-slot field) rather than the card grid,
+   so it only needs light layout: full-width controls, a spaced primary
+   action, and a visible empty-state (the shared notice class defaults to
+   display:none, shown here since the form has no .is-empty toggle). */
+.blockr-link-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.blockr-link-edit .shiny-input-container {
+  width: 100%;
+}
+
+.blockr-link-edit .blockr-block-browser-empty {
+  display: flex;
+}
+
+.blockr-link-edit-confirm {
+  margin-top: 12px;
+  align-self: flex-start;
+}

--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -35,6 +35,6 @@ local({
         force = TRUE
       )
     },
-    testthat::teardown_env()
+    teardown_env()
   )
 })

--- a/tests/testthat/test-action-class.R
+++ b/tests/testthat/test-action-class.R
@@ -21,11 +21,11 @@ test_that("action ctor", {
   db_act <- board_actions(new_dock_board())
 
   expect_type(db_act, "list")
-  expect_length(db_act, 9L)
+  expect_length(db_act, 10L)
 
   trig <- action_triggers(db_act)
 
-  expect_length(trig, 9L)
+  expect_length(trig, 10L)
   expect_named(trig, chr_ply(db_act, action_id))
 
   expect_null(

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -451,23 +451,33 @@ test_that("remove link action", {
 # the link's current value.
 edit_link_menu <- function(session, from = NULL, to = NULL,
                            input_port = NULL, input_name = NULL, confirm = 1L) {
-  vals <- list(`menu-confirm` = confirm)
+  vals <- list()
   if (!is.null(from)) vals[["menu-from"]] <- from
   if (!is.null(to)) vals[["menu-to"]] <- to
   if (!is.null(input_port)) vals[["menu-input_port"]] <- input_port
   if (!is.null(input_name)) vals[["menu-input_name"]] <- input_name
-  do.call(session$setInputs, vals)
+
+  # Set the pickers first and let the selection observers settle (the user
+  # picks, then clicks), then commit - mirroring the real two-step flow.
+  if (length(vals)) {
+    do.call(session$setInputs, vals)
+    session$flushReact()
+  }
+  session$setInputs(`menu-confirm` = confirm)
 }
 
-expect_link_mod <- function(upd, id, delta) {
-  testthat::expect_length(upd, 1L)
+# An edit is committed as a remove + re-add of the same id (not a
+# `links$mod` delta): the id survives and the full link is re-applied.
+expect_link_edit <- function(upd, id, from, to, input) {
   testthat::expect_named(upd, "links")
-  testthat::expect_named(upd$links, "mod")
-  testthat::expect_named(upd$links$mod, id)
-  # `mod` entries are partial-arg deltas (a named list of `new_link()`
-  # argument values), not a full `links` object.
-  testthat::expect_false(inherits(upd$links$mod, "links"))
-  testthat::expect_identical(upd$links$mod[[id]], delta)
+  testthat::expect_setequal(names(upd$links), c("rm", "add"))
+  testthat::expect_identical(upd$links$rm, id)
+  testthat::expect_s3_class(upd$links$add, "links")
+  df <- as.data.frame(upd$links$add)
+  testthat::expect_identical(df$id, id)
+  testthat::expect_identical(df$from, from)
+  testthat::expect_identical(df$to, to)
+  testthat::expect_identical(df$input, input)
 }
 
 edit_link_env <- function(links, board_id = "b") {
@@ -505,7 +515,7 @@ test_that("edit link action: redirecting the target commits a mod delta", {
       # Re-point a -> h onto the merge block's `y` port; from is untouched.
       edit_link_menu(session, to = "m", input_port = "y")
 
-      expect_link_mod(r_update(), "l1", list(to = "m", input = "y"))
+      expect_link_edit(r_update(), "l1", from = "a", to = "m", input = "y")
     }
   )
 })
@@ -528,7 +538,7 @@ test_that("edit link action: switching the input slot commits only input", {
       session$flushReact()
       edit_link_menu(session, input_port = "y")
 
-      expect_link_mod(r_update(), "l1", list(input = "y"))
+      expect_link_edit(r_update(), "l1", from = "a", to = "m", input = "y")
     }
   )
 })
@@ -552,7 +562,7 @@ test_that("edit link action: naming a variadic positional slot", {
       # The variadic target renders a name field; a blank slot becomes named.
       edit_link_menu(session, input_name = "left")
 
-      expect_link_mod(r_update(), "l1", list(input = "left"))
+      expect_link_edit(r_update(), "l1", from = "a", to = "r", input = "left")
     }
   )
 })
@@ -575,7 +585,7 @@ test_that("edit link action: redirecting the source commits only from", {
       session$flushReact()
       edit_link_menu(session, from = "b")
 
-      expect_link_mod(r_update(), "l1", list(from = "b"))
+      expect_link_edit(r_update(), "l1", from = "b", to = "h", input = "data")
     }
   )
 })
@@ -694,7 +704,7 @@ test_that("edit link action: removing the edited link closes the sidebar", {
   )
 })
 
-test_that("edit link menu renders source / target pickers and a confirm", {
+test_that("edit link menu ui holds the endpoint / input slots and confirm", {
   board <- new_board(
     c(a = new_dataset_block("iris"), m = new_merge_block()),
     links = links(l1 = new_link("a", "m", "x"))
@@ -705,9 +715,9 @@ test_that("edit link menu renders source / target pickers and a confirm", {
     xml2::xml_find_first(doc, paste0("//*[@id='mid-", suffix, "']"))
   }
 
-  expect_false(is.na(xml2::xml_attr(by_id("from"), "id")))
-  expect_false(is.na(xml2::xml_attr(by_id("to"), "id")))
-  # The port / name control is server-rendered into this uiOutput slot.
+  # From / to and the port / name control are server-rendered into these
+  # uiOutput slots (so a board change refreshes them live).
+  expect_false(is.na(xml2::xml_attr(by_id("endpoints"), "id")))
   expect_false(is.na(xml2::xml_attr(by_id("input_field"), "id")))
   confirm <- xml2::xml_find_first(
     doc,
@@ -717,6 +727,74 @@ test_that("edit link menu renders source / target pickers and a confirm", {
     )
   )
   expect_false(is.na(xml2::xml_attr(confirm, "class")))
+})
+
+test_that("edit link menu renders rich source / target pickers", {
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), m = new_merge_block()),
+      links = links(l1 = new_link("a", "m", "x"))
+    ),
+    board_id = "b"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(id, function(input, output, session) {
+        edit_link_menu_server(
+          "menu", board = reactive(r_board$board), link_id = reactive("l1")
+        )
+      })
+    },
+    {
+      session$flushReact()
+      ep <- as.character(output$`menu-endpoints`$html)
+      # Both pickers, rendered with the block-browser selectize (the
+      # add-panel look), not a bare <select>.
+      expect_true(grepl("menu-from", ep, fixed = TRUE))
+      expect_true(grepl("menu-to", ep, fixed = TRUE))
+      expect_true(grepl("selectize", ep))
+    }
+  )
+})
+
+test_that("edit link input field follows the switched link, not stale input", {
+  # Editing one link then another through the persistent menu module must
+  # not let the first link's target leak into the second: switching to a
+  # variadic-target link has to render the NAME control even though
+  # `input$to` still holds the previous (finite) target.
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), m = new_merge_block(),
+        r = new_rbind_block()),
+      links = links(l1 = new_link("a", "m", "x"), l2 = new_link("a", "r", ""))
+    ),
+    board_id = "b"
+  )
+  lid <- reactiveVal("l1")
+
+  testServer(
+    function(id, ...) {
+      moduleServer(id, function(input, output, session) {
+        edit_link_menu_server(
+          "menu", board = reactive(r_board$board), link_id = lid
+        )
+      })
+    },
+    {
+      session$flushReact()
+      session$setInputs(`menu-to` = "m")
+      session$flushReact()
+      port <- as.character(output$`menu-input_field`$html)
+      expect_true(grepl("menu-input_port", port, fixed = TRUE))
+
+      lid("l2")
+      session$flushReact()
+      name <- as.character(output$`menu-input_field`$html)
+      expect_true(grepl("menu-input_name", name, fixed = TRUE))
+      expect_false(grepl("menu-input_port", name, fixed = TRUE))
+    }
+  )
 })
 
 test_that("edit link menu ui is empty for an unknown link", {

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -18,7 +18,7 @@ commit_menu <- function(session, source, target, link_id,
 }
 
 local_mocked_sidebar <- function(env = parent.frame()) {
-  testthat::local_mocked_bindings(
+  local_mocked_bindings(
     show_sidebar         = function(...) invisible(list(...)),
     keep_or_hide_sidebar = function(...) invisible(list(...)),
     hide_sidebar         = function(...) invisible(list(...)),
@@ -27,15 +27,15 @@ local_mocked_sidebar <- function(env = parent.frame()) {
 }
 
 expect_added_link <- function(upd, id, from, to, input) {
-  testthat::expect_length(upd, 1L)
-  testthat::expect_named(upd, "links")
-  testthat::expect_named(upd$links, "add")
-  testthat::expect_s3_class(upd$links$add, "links")
+  expect_length(upd, 1L)
+  expect_named(upd, "links")
+  expect_named(upd$links, "add")
+  expect_s3_class(upd$links$add, "links")
   df <- as.data.frame(upd$links$add)
-  testthat::expect_identical(df$id, id)
-  testthat::expect_identical(df$from, from)
-  testthat::expect_identical(df$to, to)
-  testthat::expect_identical(df$input, input)
+  expect_identical(df$id, id)
+  expect_identical(df$from, from)
+  expect_identical(df$to, to)
+  expect_identical(df$input, input)
 }
 
 test_that("add link action: OUTGOING commit uses the default port", {
@@ -469,12 +469,12 @@ edit_link_menu <- function(session, from = NULL, to = NULL,
 # An edit is committed as a `links$mod` delta: a named list of the changed
 # constructor-argument values, keyed by the (unchanged) link id.
 expect_link_mod <- function(upd, id, delta) {
-  testthat::expect_named(upd, "links")
-  testthat::expect_named(upd$links, "mod")
-  testthat::expect_named(upd$links$mod, id)
+  expect_named(upd, "links")
+  expect_named(upd$links, "mod")
+  expect_named(upd$links$mod, id)
   # A `mod` entry is a partial-arg delta, not a full `links` object.
-  testthat::expect_false(inherits(upd$links$mod, "links"))
-  testthat::expect_identical(upd$links$mod[[id]], delta)
+  expect_false(inherits(upd$links$mod, "links"))
+  expect_identical(upd$links$mod[[id]], delta)
 }
 
 edit_link_env <- function(links, board_id = "b") {

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -443,3 +443,334 @@ test_that("remove link action", {
     }
   )
 })
+
+# The edit menu's fields are real Shiny inputs at `menu-from`, `menu-to`,
+# `menu-input_port` / `menu-input_name`, committed by the `menu-confirm`
+# button. Drive them directly to simulate a user editing a link. Only the
+# fields the user touches need setting; an untouched field falls back to
+# the link's current value.
+edit_link_menu <- function(session, from = NULL, to = NULL,
+                           input_port = NULL, input_name = NULL, confirm = 1L) {
+  vals <- list(`menu-confirm` = confirm)
+  if (!is.null(from)) vals[["menu-from"]] <- from
+  if (!is.null(to)) vals[["menu-to"]] <- to
+  if (!is.null(input_port)) vals[["menu-input_port"]] <- input_port
+  if (!is.null(input_name)) vals[["menu-input_name"]] <- input_name
+  do.call(session$setInputs, vals)
+}
+
+expect_link_mod <- function(upd, id, delta) {
+  testthat::expect_length(upd, 1L)
+  testthat::expect_named(upd, "links")
+  testthat::expect_named(upd$links, "mod")
+  testthat::expect_named(upd$links$mod, id)
+  # `mod` entries are partial-arg deltas (a named list of `new_link()`
+  # argument values), not a full `links` object.
+  testthat::expect_false(inherits(upd$links$mod, "links"))
+  testthat::expect_identical(upd$links$mod[[id]], delta)
+}
+
+edit_link_env <- function(links, board_id = "b") {
+  reactiveValues(
+    board = new_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_dataset_block("mtcars"),
+        h = new_head_block(),
+        m = new_merge_block(),
+        r = new_rbind_block()
+      ),
+      links = links
+    ),
+    board_id = board_id
+  )
+}
+
+test_that("edit link action: redirecting the target commits a mod delta", {
+  local_mocked_sidebar()
+  r_board <- edit_link_env(links(l1 = new_link("a", "h", "data")))
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # Re-point a -> h onto the merge block's `y` port; from is untouched.
+      edit_link_menu(session, to = "m", input_port = "y")
+
+      expect_link_mod(r_update(), "l1", list(to = "m", input = "y"))
+    }
+  )
+})
+
+test_that("edit link action: switching the input slot commits only input", {
+  local_mocked_sidebar()
+  r_board <- edit_link_env(links(l1 = new_link("a", "m", "x")))
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      edit_link_menu(session, input_port = "y")
+
+      expect_link_mod(r_update(), "l1", list(input = "y"))
+    }
+  )
+})
+
+test_that("edit link action: naming a variadic positional slot", {
+  local_mocked_sidebar()
+  r_board <- edit_link_env(links(l1 = new_link("a", "r", "")))
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # The variadic target renders a name field; a blank slot becomes named.
+      edit_link_menu(session, input_name = "left")
+
+      expect_link_mod(r_update(), "l1", list(input = "left"))
+    }
+  )
+})
+
+test_that("edit link action: redirecting the source commits only from", {
+  local_mocked_sidebar()
+  r_board <- edit_link_env(links(l1 = new_link("a", "h", "data")))
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      edit_link_menu(session, from = "b")
+
+      expect_link_mod(r_update(), "l1", list(from = "b"))
+    }
+  )
+})
+
+test_that("edit link action: an unchanged confirm issues no update", {
+  local_mocked_sidebar()
+  r_board <- edit_link_env(links(l1 = new_link("a", "m", "x")))
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # Confirm without touching a field: the delta is empty, so no
+      # `links$mod` is emitted (which would needlessly re-evaluate).
+      edit_link_menu(session)
+
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("edit link action: a redirect that closes a cycle is rejected", {
+  local_mocked_sidebar()
+  r_board <- edit_link_env(
+    links(l1 = new_link("a", "h", "data"), l2 = new_link("h", "m", "x"))
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # l1 is a -> h; `m` already reaches h via l2 (h -> m), so re-pointing
+      # l1's source to `m` makes m -> h, which closes a cycle and is
+      # rejected (m != h, so it is not caught as a self-link).
+      edit_link_menu(session, from = "m")
+
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("edit link action: a self-link is rejected", {
+  local_mocked_sidebar()
+  r_board <- edit_link_env(links(l1 = new_link("a", "m", "x")))
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      edit_link_menu(session, from = "m")
+
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("edit link action: removing the edited link closes the sidebar", {
+  hide_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(id, ...) {
+      hide_calls[[length(hide_calls) + 1L]] <<- id
+      invisible(NULL)
+    },
+    sidebar_state = function(id, ...) list(open = TRUE, pinned = TRUE)
+  )
+
+  r_board <- edit_link_env(links(l1 = new_link("a", "h", "data")))
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      expect_length(hide_calls, 0L)
+
+      # Remove the edited link elsewhere -> sidebar closes live.
+      r_board$board <- new_board(board_blocks(r_board$board))
+      session$flushReact()
+
+      expect_gte(length(hide_calls), 1L)
+      expect_identical(hide_calls[[1L]], "b-actions_sidebar")
+    }
+  )
+})
+
+test_that("edit link menu renders source / target pickers and a confirm", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), m = new_merge_block()),
+    links = links(l1 = new_link("a", "m", "x"))
+  )
+
+  doc <- xml2::read_html(as.character(edit_link_menu_ui("mid", board, "l1")))
+  by_id <- function(suffix) {
+    xml2::xml_find_first(doc, paste0("//*[@id='mid-", suffix, "']"))
+  }
+
+  expect_false(is.na(xml2::xml_attr(by_id("from"), "id")))
+  expect_false(is.na(xml2::xml_attr(by_id("to"), "id")))
+  # The port / name control is server-rendered into this uiOutput slot.
+  expect_false(is.na(xml2::xml_attr(by_id("input_field"), "id")))
+  confirm <- xml2::xml_find_first(
+    doc,
+    paste0(
+      "//*[contains(concat(' ', normalize-space(@class), ' '),",
+      " ' blockr-link-edit-confirm ')]"
+    )
+  )
+  expect_false(is.na(xml2::xml_attr(confirm, "class")))
+})
+
+test_that("edit link menu ui is empty for an unknown link", {
+  board <- new_board(c(a = new_dataset_block("iris")))
+  doc <- xml2::read_html(as.character(edit_link_menu_ui("mid", board, "gone")))
+  notice <- xml2::xml_find_first(
+    doc,
+    paste0(
+      "//*[contains(concat(' ', normalize-space(@class), ' '),",
+      " ' blockr-block-browser-empty ')]"
+    )
+  )
+  expect_match(xml2::xml_text(notice), "no longer on the board")
+})
+
+test_that("edit link input field switches on target arity", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), m = new_merge_block(),
+      r = new_rbind_block()),
+    links = links(l1 = new_link("a", "m", "x"))
+  )
+  row <- edit_link_row(board, "l1")
+  ns <- function(x) paste0("mid-", x)
+
+  finite <- as.character(edit_link_input_field(ns, board, "l1", "m", row))
+  expect_true(grepl("mid-input_port", finite, fixed = TRUE))
+  # The edited link's own slot reads as free, so both merge ports appear.
+  expect_true(grepl(">x<", finite) && grepl(">y<", finite))
+
+  variadic <- as.character(edit_link_input_field(ns, board, "l1", "r", row))
+  expect_true(grepl("mid-input_name", variadic, fixed = TRUE))
+})
+
+test_that("edit link helpers: row lookup, exclusion and delta", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), m = new_merge_block()),
+    links = links(l1 = new_link("a", "m", "x"), l2 = new_link("a", "m", "y"))
+  )
+
+  expect_identical(
+    edit_link_row(board, "l1"),
+    list(from = "a", to = "m", input = "x")
+  )
+  expect_null(edit_link_row(board, "nope"))
+  expect_null(edit_link_row(board, NULL))
+
+  expect_identical(names(links_without(board, "l1")), "l2")
+
+  expect_length(
+    edit_link_delta(list(from = "a", to = "m", input = "x"), board, "l1"),
+    0L
+  )
+  expect_identical(
+    edit_link_delta(list(from = "m", to = "m", input = "z"), board, "l1"),
+    list(from = "m", input = "z")
+  )
+})

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -825,6 +825,20 @@ test_that("edit link input field switches on target arity", {
   expect_true(grepl("mid-input_name", variadic, fixed = TRUE))
 })
 
+test_that("edit link target picker offers only blocks with free capacity", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      m = new_merge_block(), r = new_rbind_block(), h = new_head_block()),
+    links = links(l1 = new_link("a", "m", "x"), l3 = new_link("m", "h", "data"))
+  )
+
+  # Editing l3 (m -> h): source-only datasets a / b (arity 0) are dropped;
+  # m (free y port), r (variadic) and h (its own slot freed) are offered.
+  expect_setequal(edit_link_target_ids(board, "l3"), c("m", "r", "h"))
+  expect_false("a" %in% edit_link_target_ids(board, "l3"))
+  expect_true("h" %in% edit_link_target_ids(board, "l3"))
+})
+
 test_that("edit link helpers: row lookup, exclusion and delta", {
   board <- new_board(
     c(a = new_dataset_block("iris"), m = new_merge_block()),

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -466,18 +466,15 @@ edit_link_menu <- function(session, from = NULL, to = NULL,
   session$setInputs(`menu-confirm` = confirm)
 }
 
-# An edit is committed as a remove + re-add of the same id (not a
-# `links$mod` delta): the id survives and the full link is re-applied.
-expect_link_edit <- function(upd, id, from, to, input) {
+# An edit is committed as a `links$mod` delta: a named list of the changed
+# constructor-argument values, keyed by the (unchanged) link id.
+expect_link_mod <- function(upd, id, delta) {
   testthat::expect_named(upd, "links")
-  testthat::expect_setequal(names(upd$links), c("rm", "add"))
-  testthat::expect_identical(upd$links$rm, id)
-  testthat::expect_s3_class(upd$links$add, "links")
-  df <- as.data.frame(upd$links$add)
-  testthat::expect_identical(df$id, id)
-  testthat::expect_identical(df$from, from)
-  testthat::expect_identical(df$to, to)
-  testthat::expect_identical(df$input, input)
+  testthat::expect_named(upd$links, "mod")
+  testthat::expect_named(upd$links$mod, id)
+  # A `mod` entry is a partial-arg delta, not a full `links` object.
+  testthat::expect_false(inherits(upd$links$mod, "links"))
+  testthat::expect_identical(upd$links$mod[[id]], delta)
 }
 
 edit_link_env <- function(links, board_id = "b") {
@@ -515,7 +512,7 @@ test_that("edit link action: redirecting the target commits a mod delta", {
       # Re-point a -> h onto the merge block's `y` port; from is untouched.
       edit_link_menu(session, to = "m", input_port = "y")
 
-      expect_link_edit(r_update(), "l1", from = "a", to = "m", input = "y")
+      expect_link_mod(r_update(), "l1", list(to = "m", input = "y"))
     }
   )
 })
@@ -538,7 +535,7 @@ test_that("edit link action: switching the input slot commits only input", {
       session$flushReact()
       edit_link_menu(session, input_port = "y")
 
-      expect_link_edit(r_update(), "l1", from = "a", to = "m", input = "y")
+      expect_link_mod(r_update(), "l1", list(input = "y"))
     }
   )
 })
@@ -562,7 +559,7 @@ test_that("edit link action: naming a variadic positional slot", {
       # The variadic target renders a name field; a blank slot becomes named.
       edit_link_menu(session, input_name = "left")
 
-      expect_link_edit(r_update(), "l1", from = "a", to = "r", input = "left")
+      expect_link_mod(r_update(), "l1", list(input = "left"))
     }
   )
 })
@@ -585,7 +582,7 @@ test_that("edit link action: redirecting the source commits only from", {
       session$flushReact()
       edit_link_menu(session, from = "b")
 
-      expect_link_edit(r_update(), "l1", from = "b", to = "h", input = "data")
+      expect_link_mod(r_update(), "l1", list(from = "b"))
     }
   )
 })

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -4,7 +4,7 @@
 # `menu-stack_color`, and `menu-stack_id`. Drive them directly to
 # simulate the user creating / editing a stack.
 local_mocked_sidebar <- function(env = parent.frame()) {
-  testthat::local_mocked_bindings(
+  local_mocked_bindings(
     show_sidebar         = function(...) invisible(list(...)),
     keep_or_hide_sidebar = function(...) invisible(list(...)),
     hide_sidebar         = function(...) invisible(list(...)),

--- a/tests/testthat/test-model-interleaving.R
+++ b/tests/testthat/test-model-interleaving.R
@@ -166,22 +166,22 @@ model_placement_total <- function(st) {
 # Every per-step invariant in one place, tagged for replay by seed / step.
 check_invariants <- function(st, commit, info) {
 
-  testthat::expect_no_error(validate_board(st$board))
+  expect_no_error(validate_board(st$board))
 
   shown <- model_shown(st)
   members <- model_members(st)
 
   # No ghost rendering: a panel absent from membership never reaches placement.
-  testthat::expect_true(all(shown %in% members),
-                        info = paste(info, "| ghost render"))
+  expect_true(all(shown %in% members),
+              info = paste(info, "| ghost render"))
 
   # Membership authoritative: the view shows exactly its members.
-  testthat::expect_true(model_placement_total(st),
-                        info = paste(info, "| placement"))
+  expect_true(model_placement_total(st),
+              info = paste(info, "| placement"))
 
   # One event, at most one board commit.
-  testthat::expect_lte(commit, 1L)
-  testthat::expect_gte(commit, 0L)
+  expect_lte(commit, 1L)
+  expect_gte(commit, 0L)
 }
 
 model_gesture <- function(st) {


### PR DESCRIPTION
## Summary

- New `edit_link_action`: a sidebar editor for one existing link. It can rename the link's input (turn an unnamed positional slot into a named one, or change an existing name), switch the input slot on a finite target, and redirect the link's source or target. It parallels `edit_stack_action` and is registered as a board action for surfaces such as blockr.dag to trigger (the DAG edge-menu adoption is a companion issue).
- The edit commits as a `links` `mod` delta carrying only the changed fields, so the link id survives — a remove-and-recreate would drop it and force a variadic target's positional order to be rebuilt by hand, which is the motivating gap.
- Constraints are enforced at commit with the same rules the "Connect ..." menu applies up front: no self-link, no cycle-closing redirect, and input-name uniqueness / free-port capacity on the target (the edited link is excluded from occupancy so its own slot reads as free). This reuses the eligibility helpers (`free_named_inputs()`, `descendants_of()`) and mirrors `validate_link_spec()`'s uniqueness check; a shared default-slot helper keeps an untouched control and its server-side fallback in agreement, so a no-op confirm produces no delta.
- Deliberately out of scope: folding the edit-board DT link table onto this model. That path is a batch, multi-link editor with a different interaction model; consolidating the two is a larger separate change, best taken once the DAG adoption exercises this action.

Fixes #341