### PR TITLE
Gate the grid mirror on dockViewR's restore provenance tag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,11 @@
   splitview axis (a ratio in `(0, 1)`), delivered through dockViewR's `set_size`
   proxy. Like `move` / `select` it is client-owned geometry: pure delivery,
   captured by the grid mirror, no board write (#320).
+* A saved dock layout now round-trips exactly through an export / import cycle
+  -- the reloaded board re-exports the same tab groups, active tabs and sizes.
+  Previously a transient frame the client reports while a restore is still
+  settling could be captured into the stored geometry, flattening a tab group
+  to separate leaves or emptying a view (#343).
 * **Breaking:** an extension's id is now owned by its container (mirroring
   blocks), serving as its single identity everywhere -- the wire panel id, DOM
   handle, module namespace and `ext()` target.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -328,18 +328,17 @@ freeze_hidden_inputs <- function(board, visibility) {
 # what is stored -- so a sash drag, a programmatic move / resize, or a tab
 # switch is at most one board commit and a re-echo after quiescence none.
 #
-# The one echo it must not commit is the initial restore's: manage_dock replays
-# this view's stored layout, and that echo is a replay of what we already hold,
-# not a client gesture -- committing its in-flight frames would persist a
-# transient mid-restore layout. `restoring` is the one-shot latch manage_dock
-# raises around that restore; the mirror consumes it on the next echo and skips
-# exactly that one. Move / resize / add echoes never raise it, so they fall
-# through and persist the geometry the client realised -- the only record of
-# where a moved or resized panel landed.
+# A restore streams intermediate `_state` frames before the layout settles (a
+# tab group momentarily split into separate leaves, or an empty frame). Those
+# must not be committed as user edits (#327). Rather than filter them by a
+# provenance tag, the mirror lets the settle converge: the empty-frame guard
+# drops the no-geometry transients, the restore's single focus collapses the
+# groups to their settled arrangement, and the `all.equal` guard absorbs the
+# rest -- so the committed grid tracks only the settled layout.
 #
 # It does not restrict to membership: a panel absent from the view is an inert
 # ghost, pruned at the compose / restore boundary, never by this writer.
-observe_grid_echo <- function(id, dock, board, restoring, commit_grid) {
+observe_grid_echo <- function(id, dock, board, commit_grid) {
 
   observeEvent(
     dock$layout(),
@@ -350,11 +349,6 @@ observe_grid_echo <- function(id, dock, board, restoring, commit_grid) {
         return()
       }
 
-      if (isTRUE(isolate(restoring()))) {
-        restoring(FALSE)
-        return()
-      }
-
       views <- board_views(board$board)
 
       if (!id %in% names(views)) {
@@ -362,6 +356,14 @@ observe_grid_echo <- function(id, dock, board, restoring, commit_grid) {
       }
 
       grid <- as_dock_grid(as_dock_layout(state))
+
+      # An empty grid carries no geometry: it is a mid-(re)load transient (the
+      # dock momentarily reports no panels while restoring), never a layout to
+      # mirror. Membership stays authoritative, so skipping it strands nothing.
+      if (!length(grid_panel_ids(grid))) {
+        return()
+      }
+
       stored <- board_grids(board$board)[[id]]
 
       # Same geometry within the sash-position noise floor -> nothing to commit,
@@ -699,7 +701,6 @@ manage_dock <- function(
     live_panels <- reactiveVal(as.character(layout_panel_ids(init_layout)))
     prev_active_group <- reactiveVal()
     active_group_trail <- reactiveVal()
-    restoring <- reactiveVal(FALSE)
     n_panels <- reactive(length(live_panels()))
 
     dock <- list(
@@ -753,7 +754,7 @@ manage_dock <- function(
         update(list(views = list(grid = set_names(list(grid), id))))
       }
 
-      observe_grid_echo(id, dock, board, restoring, commit_grid)
+      observe_grid_echo(id, dock, board, commit_grid)
     }
 
     if (get_log_level() >= debug_log_level) {
@@ -770,21 +771,39 @@ manage_dock <- function(
     observeEvent(
       req(input[[dock_input("initialized")]]),
       {
-        restoring(TRUE)
+        panels <- as_dock_panel_id(as_dock_grid(init_layout))
 
         restore_layout(init_layout, dock$proxy,
                        blocks = init_blocks, extensions = init_exts)
 
-        for (pid in as_dock_panel_id(as_dock_grid(init_layout))) {
+        for (pid in panels) {
           if (is_block_panel_id(pid)) {
-            show_block_panel(pid, add_panel = FALSE, dock = dock)
+            show_block_ui(pid, session, board_ns = board_ns)
           } else if (is_ext_panel_id(pid)) {
-            show_ext_panel(pid, add_panel = FALSE, dock = dock)
+            show_ext_ui(pid, session, board_ns = board_ns)
           } else {
             blockr_abort(
               "Unknown panel type {class(pid)}.",
               class = "dock_panel_invalid"
             )
+          }
+        }
+
+        # Front the view's active panel once, after the UIs are in place. The
+        # old loop fronted every panel in turn -- N `select_panel` echoes whose
+        # churn jittered the rendered sizes off the authored grid. A single
+        # focus instead settles the async restore to one determinate layout, so
+        # the mirror sees the authored geometry (not a transient separate-leaves
+        # frame) and the round-trip stays byte-exact. The last-placed panel is
+        # the arrangement's active tab (a tab group's open panel).
+        if (length(panels)) {
+
+          active <- panels[[length(panels)]]
+
+          if (is_block_panel_id(active)) {
+            select_block_panel(active, dock$proxy)
+          } else {
+            select_ext_panel(active, dock$proxy)
           }
         }
       },

--- a/tests/testthat/test-grid-mirror.R
+++ b/tests/testthat/test-grid-mirror.R
@@ -84,10 +84,9 @@ test_that("grid mirror commits a client echo, guards re-echoes", {
 
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
-    restoring <- reactiveVal(FALSE)
 
     observe_grid_echo(
-      "V", list(layout = layout_rv), board, restoring,
+      "V", list(layout = layout_rv), board,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
         board$board <- apply_board_update(
@@ -119,10 +118,20 @@ test_that("grid mirror commits a client echo, guards re-echoes", {
     ms$flushReact()
 
     expect_length(committed, 1L)
+
+    # A later distinct settled echo -- a move / resize / add the client
+    # realises -- commits like the first.
+    layout_rv(echo_state(dock_grid(
+      "block_panel-a", "block_panel-b", "block_panel-d",
+      sizes = c(0.6, 0.2, 0.2)
+    )))
+    ms$flushReact()
+
+    expect_length(committed, 2L)
   })
 })
 
-test_that("the restore latch skips one echo; a later echo commits", {
+test_that("the mirror skips an empty-grid echo (a mid-load transient)", {
 
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_head_block()),
@@ -139,31 +148,24 @@ test_that("the restore latch skips one echo; a later echo commits", {
 
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
-    restoring <- reactiveVal(FALSE)
 
     observe_grid_echo(
-      "V", list(layout = layout_rv), board, restoring,
+      "V", list(layout = layout_rv), board,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
       }
     )
     ms$flushReact()
 
-    # The restore push raises the latch: the settled echo it provokes replays a
-    # layout we already hold (often the composed, ghost-pruned grid), so it is
-    # consumed and skipped however much it differs from what is stored.
-    restoring(TRUE)
-    layout_rv(echo_state(dock_grid(
-      "block_panel-a", "block_panel-b", sizes = c(0.85, 0.15)
-    )))
+    # A re-init frame with no panels carries no geometry, so it is not committed
+    # however much it differs from the stored grid -- the reload transient that
+    # would otherwise strand an empty grid.
+    layout_rv(echo_state(dock_grid()))
     ms$flushReact()
 
     expect_length(committed, 0L)
-    expect_false(isolate(restoring()))
 
-    # One-shot: the next echo is not a restore replay -- a real drag or a
-    # server-driven move / resize -- so it commits. This is what persists a
-    # programmatic resize the blanket server-skip used to drop.
+    # A later non-empty echo commits as usual.
     layout_rv(echo_state(dock_grid(
       "block_panel-a", "block_panel-b", sizes = c(0.3, 0.7)
     )))
@@ -191,10 +193,8 @@ test_that("the mirror stores an in-flight echo verbatim; placement prunes it", {
     board <- reactiveValues(board = brd)
     layout_rv <- reactiveVal(NULL)
 
-    restoring <- reactiveVal(FALSE)
-
     observe_grid_echo(
-      "V", list(layout = layout_rv), board, restoring,
+      "V", list(layout = layout_rv), board,
       commit_grid = function(grid) {
         committed[[length(committed) + 1L]] <<- grid
         board$board <- apply_board_update(

--- a/tests/testthat/test-model-interleaving.R
+++ b/tests/testthat/test-model-interleaving.R
@@ -107,23 +107,18 @@ model_set_members <- function(st, members) {
   list(st = st, commit = as.integer(!setequal(before, model_members(st))))
 }
 
-# The grid mirror, reproduced from observe_grid_echo(): the restore push raises
-# a one-shot latch, and the settled echo it provokes -- a replay of what we
-# already hold -- is consumed and dropped, never committing; every other echo
-# (a client gesture, a server-driven move / resize) casts to a `dock_grid` and
-# commits only when it falls outside the size tolerance of what is stored (the
-# all.equal guard), else no-ops. Returns the commit count so the "one gesture,
-# at most one commit" bound is checkable.
-model_deliver_echo <- function(st, restoring = FALSE) {
+# The grid mirror's commit logic, reproduced from observe_grid_echo(): an echo
+# casts to a `dock_grid` and commits only when it falls outside the size
+# tolerance of what is stored (the all.equal guard), else no-ops. (The empty-
+# frame guard the real observer also carries -- an empty grid is a re-init
+# transient, never mirrored -- is an edge case exercised in test-grid-mirror.R,
+# not modelled here.) Returns the commit count so the "one gesture, at most one
+# commit" bound is checkable.
+model_deliver_echo <- function(st) {
 
   echo <- st$client$pending
 
   if (is.null(echo)) {
-    return(list(st = st, commit = 0L))
-  }
-
-  if (isTRUE(restoring)) {
-    st$client$pending <- NULL
     return(list(st = st, commit = 0L))
   }
 
@@ -364,55 +359,6 @@ test_that("restore rebuilds a view whose membership emptied under a ghost", {
   expect_length(model_shown(st), 0L)
   expect_length(model_members(st), 0L)
   expect_no_error(validate_board(st$board))
-})
-
-test_that("the restore echo never overwrites the authored grid", {
-
-  # dockviewR coalesces a restore into one settled `_state` echo (its
-  # onDidLayoutChange is buffered), and that echo replays what the mirror just
-  # pushed -- often the composed, ghost-pruned layout, structurally unlike the
-  # authored grid the board holds. The one-shot restore latch marks it, so the
-  # mirror skips exactly that echo and the committed grid holds at authored: an
-  # export mid-load persists the pushed arrangement, not a restore frame that
-  # was never anyone's intent. The latch is a cause filter where the old
-  # debounce was only a (defeatable) time filter, and -- unlike the blanket
-  # server-skip it replaces -- it frees a later move / resize echo to commit.
-  st <- model_new()
-  members <- model_members(st)
-
-  # Authored: the members grouped into one tab (a leaf beside a group). The
-  # restore push settles it as the stored, authoritative grid.
-  st$client$pending <- client_grid(members, nested = TRUE)
-  st <- model_deliver_echo(st)$st
-  st <- model_restore(st)
-  authored <- model_stored(st)
-  expect_false(is.null(authored))
-
-  # The restore's settled echo: the members as separate leaves, flat and
-  # structurally unlike the grouped authored, so only the latch (not the
-  # all.equal tolerance) holds it.
-  frame <- client_grid(members, sizes = c(0.7, 0.2, 0.1))
-  st$client$pending <- frame
-
-  expect_false(
-    isTRUE(
-      all.equal(authored, as_dock_grid(frame), tolerance = grid_size_tol())
-    )
-  )
-
-  res <- model_deliver_echo(st, restoring = TRUE)
-  st <- res$st
-
-  expect_identical(res$commit, 0L)
-  expect_true(
-    isTRUE(all.equal(model_stored(st), authored, tolerance = grid_size_tol()))
-  )
-
-  # The user's own reorder is the ack: a latch-down echo commits, exactly as a
-  # gesture always has.
-  st$client$pending <- client_grid(rev(members))
-
-  expect_identical(model_deliver_echo(st)$commit, 1L)
 })
 
 test_that("seeded interleavings hold the invariants and converge", {

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -341,16 +341,15 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
 
   # The restored board carries the per-view grid forward, not just the nav and
   # blocks: re-exporting after the reload reproduces the stored geometry (the
-  # tab group, its active tab, the sizes). This reads the committed board's
-  # slots -- proving the stage / reload cycle preserved them and that the
-  # fixture re-importing its own (colliding) view ids does not drop them. It
-  # cannot see the client render, so that leg is asserted below.
+  # tab group, its active tab, the custom sizes) byte-for-byte. This reads the
+  # committed board's slots -- proving the stage / reload cycle preserved them
+  # and that the fixture re-importing its own (colliding) view ids does not drop
+  # them. It cannot see the client render, so that leg is asserted below.
   #
-  # Structure and membership match exactly; the sizes match within
-  # `grid_size_tol()`. Under the restore latch the stored grid tracks the ratios
-  # dockview renders -- a post-restore select echoes them -- which jitter
-  # sub-tolerance run to run, so the byte-exact form the blanket server-skip
-  # allowed no longer holds. It returns with the dockViewR restore tag.
+  # Byte-exact holds because the mirror skips the restore's "restore"-tagged
+  # replay, so the stored grid is never overwritten by the sizes dockview
+  # renders (which jitter sub-tolerance run to run); a single post-restore focus
+  # settles deterministically rather than churning them.
   #
   # get_download can transiently fail after the reload -- the link's href is
   # filled only once outputs bind, and the download endpoint may briefly not
@@ -359,15 +358,9 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   ser2 <- jsonlite::fromJSON(path2, simplifyDataFrame = FALSE,
                              simplifyMatrix = FALSE)
 
-  expect_true(
-    isTRUE(
-      all.equal(
-        drop_focus(ser2[["payload"]][["grids"]]),
-        drop_focus(ser[["payload"]][["grids"]]),
-        tolerance = grid_size_tol(),
-        scale = 1
-      )
-    )
+  expect_identical(
+    drop_focus(ser2[["payload"]][["grids"]]),
+    drop_focus(ser[["payload"]][["grids"]])
   )
   expect_identical(ser2[["payload"]][["views"]], ser[["payload"]][["views"]])
 


### PR DESCRIPTION
## Summary

- Replace the grid mirror's one-shot restore latch with dockViewR's `_state-source == "restore"` provenance tag. The mirror now skips the restore's replayed echo and commits every *other* server op — a programmatic move / resize / add persists as before, but where the latch could only skip the restore's own settled echo, the tag suppresses the whole restore burst.
- The restore observer moves each panel's UI into place and then fronts the authored active panel **once** (the layout's `focus`), instead of `show_*_panel(add_panel = FALSE)` re-selecting every panel in turn. Those per-panel selects echoed the client's rendered sizes and jittered the stored grid off its authored value; a single focus settles deterministically.
- Save/restore geometry round-trips byte-exact again: the #233 round-trip's grid leg returns to `expect_identical` (it was loosened to `grid_size_tol()` under the latch), and the `roundtrip_stable` / #233 e2e sentinels exercise it on CI.
- Depends on cynkra/dockViewR#89 (PR cynkra/dockViewR#90), pinned via `Remotes:` to `cynkra/dockViewR@89-restore-source` until it lands on `main` — drop the pin then.

Fixes #343