### PR TITLE
Replace page busy-pulse with a subtle navbar spinner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -118,9 +118,11 @@
 * Per-block condition UI (warnings, messages, errors) is updated surgically by
   the stable condition id, so a persistent warning no longer flashes on every
   re-evaluation.
-* The busy pulse no longer flashes on a plain panel switch: a CSS rule gates it
-  on a genuinely recomputing output, so startup and block evaluation still
-  pulse but bare navigation does not.
+* The intrusive page-wide busy pulse is replaced by a small, unobtrusive
+  spinner in the navbar, next to the board-options gear. It turns while the
+  session does real block evaluation and disappears otherwise -- scoped (as the
+  pulse was) to a genuinely recomputing output in the visible view, so startup
+  and block evaluation spin it while a bare panel switch does not.
 * The "Edit board" extension no longer churns on a board re-emit -- it re-syncs
   its staged working copy only when links or stacks actually change, stops
   flickering the manage-links cell inputs, and overlays half-finished staged

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -60,6 +60,16 @@ board_ui.dock_board <- function(
             )
           )
         },
+        # Busy spinner. Shown/hidden purely by CSS off the `.shiny-busy` class
+        # Shiny toggles on <html> during a flush -- no server observer -- and
+        # scoped to real block evaluation so a bare panel switch does not spin
+        # it. Sits just before the gear so its show/hide never nudges that
+        # (right-anchored) button. Announced like the lock indicator beside it.
+        tags$span(
+          class = "blockr-navbar-spinner",
+          role = "status",
+          `aria-label` = "Busy"
+        ),
         # Pure-JS open trigger via `data-blockr-sidebar-target`. The
         # settings sidebar's body is pre-rendered into its mount below, so
         # no server observer is needed: clicking the gear toggles the

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -30,12 +30,11 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
           "btn-active-bg-shade-amount" = "5%",
           "enable-negative-margins" = "true"
         ),
-        # Use shiny's busy indicator
-        useBusyIndicators(spinners = FALSE, pulse = TRUE),
-        busyIndicatorOptions(
-          pulse_background = "#5e626b",
-          pulse_height = "5px"
-        ),
+        # Disable bslib's built-in busy indicators (the page-wide pulse and
+        # per-output spinners). The dock drives its own subtle navbar spinner
+        # off the `.shiny-busy` class Shiny sets on <html> instead -- see the
+        # `.blockr-navbar-spinner` slot in board_ui.dock_board() and its CSS.
+        useBusyIndicators(spinners = FALSE, pulse = FALSE),
         shinyjs::useShinyjs(),
         board_ui(id, x, plugins, options = options)
       ),

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -187,8 +187,8 @@
    border) so the dot matches the DAG node badge, which rings its fill the same
    way. The dot output must stay in flow when empty (never display:none) so it
    is not suspended while hidden and left stuck ".recalculating", which would
-   trip the busy-pulse scope; an empty inline output takes no space on its
-   own. */
+   trip the navbar busy-spinner scope; an empty inline output takes no space on
+   its own. */
 .blockr-block-icon {
   position: relative;
   display: inline-flex;
@@ -1156,20 +1156,46 @@ label:has(input[type="file"]) {
 }
 
 /* ============================================
-   Busy pulse — scope to real computation
+   Navbar busy spinner — scope to real computation
    ============================================ */
 
-/* Shiny's page pulse (enabled in serve() via useBusyIndicators(pulse = TRUE))
-   shows whenever the session is busy, i.e. on any observer flush. A plain panel
-   switch round-trips to the server -- the on-screen visibility report and the
-   layout fold -- without recomputing any visible output, so the pulse would
-   fire for what is only layout bookkeeping. Gate it on a genuinely
-   recalculating output inside the visible view container: block evaluation
-   marks its output "recalculating" there, bookkeeping does not. Scoping to the
-   view container is deliberate -- an off-screen block parked in the (hidden)
-   offcanvas pool stays "recalculating" while it waits for evaluation, and that
-   pool sits outside the container, so a pending hidden block never forces the
-   pulse. Startup and real recompute still pulse; a bare panel switch does not. */
-html[data-shiny-busy-pulse].shiny-busy:not(:has(.blockr-view-container .recalculating))::after {
+/* A small ring next to the board-options gear that spins while the session
+   does real block evaluation, replacing bslib's page-wide busy pulse. Driven
+   purely off the `.shiny-busy` class Shiny puts on <html> during a flush -- no
+   server observer, no page darkening.
+
+   Scoped exactly as the old pulse was: a plain panel switch round-trips to the
+   server -- the on-screen visibility report and the layout fold -- without
+   recomputing any visible output, so gating on `.shiny-busy` alone would spin
+   for what is only layout bookkeeping. Require a genuinely recalculating output
+   inside the visible view container: block evaluation marks its output
+   "recalculating" there, bookkeeping does not. Scoping to the container is
+   deliberate -- an off-screen block parked in the (hidden) offcanvas pool stays
+   "recalculating" while it waits for evaluation, and that pool sits outside the
+   container, so a pending hidden block never spins the navbar. Startup and real
+   recompute spin; a bare panel switch does not. */
+.blockr-navbar-spinner {
   display: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--blockr-color-text-muted);
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: blockr-navbar-spin 0.7s linear infinite;
+}
+
+html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinner {
+  display: inline-block;
+}
+
+@keyframes blockr-navbar-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blockr-navbar-spinner {
+    animation: none;
+  }
 }

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -137,6 +137,37 @@ test_that("locked mode renders a navbar lock indicator", {
   expect_match(locked_html, ">Read-only<", fixed = TRUE)
 })
 
+test_that("navbar renders a busy spinner beside the gear (#345)", {
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+
+  spinner_of <- function(html) {
+    xml2::xml_find_all(
+      xml2::read_html(html),
+      paste0(
+        ".//span[contains(concat(' ', normalize-space(@class), ' '), ",
+        "' blockr-navbar-spinner ')]"
+      )
+    )
+  }
+
+  spinner <- spinner_of(as.character(board_ui("test", brd)))
+
+  # A CSS-only busy ring driven off `.shiny-busy`, announced like the lock
+  # indicator beside it.
+  expect_length(spinner, 1)
+  expect_identical(xml2::xml_attr(spinner, "role"), "status")
+  expect_identical(xml2::xml_attr(spinner, "aria-label"), "Busy")
+
+  # Blocks still evaluate while read-only, so the spinner survives locked mode
+  # (unlike the editing chrome it sits beside).
+  locked <- withr::with_options(
+    list(blockr.locked = TRUE),
+    spinner_of(as.character(board_ui("test", brd)))
+  )
+  expect_length(locked, 1)
+})
+
 test_that("locked mode drops the board-options accordion (#135)", {
 
   brd <- new_dock_board(blocks = c(a = new_dataset_block()))

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -753,13 +753,13 @@ test_that("single-page board renders one auto-named view (#236)", {
   expect_identical(docks$id, nav$id)
 })
 
-test_that("busy pulse tracks real work, not layout bookkeeping (#285)", {
+test_that("navbar spinner tracks real work, not bookkeeping (#285, #345)", {
 
   skip_on_cran()
 
   app <- new_app_driver(
     system.file("examples", "multi-view", "app.R", package = "blockr.dock"),
-    name = "busy-pulse",
+    name = "navbar-spinner",
     seed = 42,
     load_timeout = 30 * 1000,
     timeout = 20 * 1000
@@ -768,22 +768,25 @@ test_that("busy pulse tracks real work, not layout bookkeeping (#285)", {
 
   app$wait_for_idle()
 
-  # serve() opts the dock into shiny's page pulse. A panel switch marks the
+  # The navbar spinner (a ring next to the gear) replaces shiny's page pulse: it
+  # turns while the session does real block evaluation. A panel switch marks the
   # session busy (the visibility report and layout fold round-trips) without
-  # recomputing a visible output, so the pulse would fire for what is only
-  # layout bookkeeping; block evaluation marks its output `.recalculating`
-  # inside the view container. The live pulse is a sub-second transient, racy
-  # to sample, so drive the two busy states directly and read the pulse
-  # pseudo-element's computed display (fixed positioning blockifies it when
-  # shown, so a visible pulse is "block"). The recalculating element is placed
-  # outside the view container (a hidden block still pending evaluation in the
-  # offcanvas pool) versus inside it (real visible work) to pin the scope.
+  # recomputing a visible output, so gating on `.shiny-busy` alone would spin
+  # for what is only layout bookkeeping; block evaluation marks its output
+  # `.recalculating` inside the view container. The live transition is a
+  # sub-second transient, racy to sample, so drive the two busy states directly
+  # and read the spinner's computed display (`none` when idle-scoped; a shown
+  # value otherwise -- `block`, since the flex navbar blockifies the shown flex
+  # item). The recalculating element is placed outside the view container (a
+  # hidden block still pending evaluation in the offcanvas pool) versus inside
+  # it (real visible work) to pin the scope.
   probe <- jsonlite::fromJSON(
     app$get_js(
       r"(JSON.stringify((function () {
         var html = document.documentElement;
-        var pulse = function () {
-          return getComputedStyle(html, '::after').display;
+        var spinner = document.querySelector('.blockr-navbar-spinner');
+        var display = function () {
+          return spinner ? getComputedStyle(spinner).display : null;
         };
         var mark = function (parent) {
           var el = document.createElement('div');
@@ -792,14 +795,14 @@ test_that("busy pulse tracks real work, not layout bookkeeping (#285)", {
           return el;
         };
 
-        var enabled = html.dataset.shinyBusyPulse === 'true';
+        var pulseOff = html.dataset.shinyBusyPulse !== 'true';
         var container = document.querySelector('.blockr-view-container');
         html.classList.add('shiny-busy');
 
         // The app's own outputs may still be settling -- a block card inside a
         // view container can hold a lingering `.recalculating` well past
         // wait_for_idle(). Neutralise every real in-container marker (the exact
-        // pulse-CSS scope) so only the synthetic markers below drive the
+        // spinner-CSS scope) so only the synthetic markers below drive the
         // reading, then restore them.
         var real = Array.from(
           document.querySelectorAll('.blockr-view-container .recalculating')
@@ -807,33 +810,35 @@ test_that("busy pulse tracks real work, not layout bookkeeping (#285)", {
         real.forEach(function (el) { el.classList.remove('recalculating'); });
 
         var hidden = mark(document.body);
-        var bookkeeping = pulse();
+        var bookkeeping = display();
         hidden.remove();
 
         var visible = mark(container);
-        var computing = pulse();
+        var computing = display();
         visible.remove();
 
         real.forEach(function (el) { el.classList.add('recalculating'); });
         html.classList.remove('shiny-busy');
 
         return {
-          enabled: enabled, hasContainer: container !== null,
+          pulseOff: pulseOff, hasSpinner: spinner !== null,
+          hasContainer: container !== null,
           bookkeeping: bookkeeping, computing: computing
         };
       })()))"
     )
   )
 
-  # The dock opts into the pulse, and the view container the scope keys on is
-  # present.
-  expect_true(probe$enabled)
+  # The page pulse is off, and the navbar spinner and the view container the
+  # scope keys on are both present.
+  expect_true(probe$pulseOff)
+  expect_true(probe$hasSpinner)
   expect_true(probe$hasContainer)
 
   # Busy with a recalculating output only outside the view container (a bare
-  # panel switch, or a hidden block still pending in the offcanvas) hides the
-  # pulse; busy with a recalculating output inside it (block evaluation) shows
-  # it.
+  # panel switch, or a hidden block still pending in the offcanvas) keeps the
+  # spinner hidden; busy with a recalculating output inside it (block
+  # evaluation) shows it.
   expect_identical(probe$bookkeeping, "none")
   expect_identical(probe$computing, "block")
 })


### PR DESCRIPTION
## Summary

- bslib's page-wide busy pulse stayed on continuously during a long background construction (or any heavy recompute), so the whole page read as "stuck loading". It's replaced by a small, muted ring in the navbar next to the board-options gear.
- The ring is driven purely off the `.shiny-busy` class Shiny sets on `<html>` during a flush — no server observer. It's scoped exactly as the pulse was, to a genuinely recalculating output inside the visible view container, so startup and real block evaluation spin it while a bare panel switch (layout bookkeeping) does not.
- `useBusyIndicators(spinners = FALSE, pulse = FALSE)` now disables both bslib built-ins; the ring carries `role="status"` + an `aria-label` like the lock indicator beside it, and honours `prefers-reduced-motion`.
- Tests: the `#285` scope probe is ported from the pulse pseudo-element to the spinner's computed display, plus a fast `board_ui` DOM unit test for the spinner element and its a11y attributes.

Fixes #345