### PR TITLE
Drop the restore transient guards; dockViewR emits settled state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
 Remotes:
     rstudio/shinytest2,
     BristolMyersSquibb/blockr.core,
-    cynkra/dockViewR@91-restored-state
+    cynkra/dockViewR@92-retire-state-source
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
 Remotes:
     rstudio/shinytest2,
     BristolMyersSquibb/blockr.core,
-    cynkra/dockViewR
+    cynkra/dockViewR@91-restored-state
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -329,13 +329,10 @@ freeze_hidden_inputs <- function(board, visibility) {
 # what is stored -- so a sash drag, a programmatic move / resize, or a tab
 # switch is at most one board commit and a re-echo after quiescence none.
 #
-# A restore streams intermediate `_state` frames before the layout settles (a
-# tab group momentarily split into separate leaves, or an empty frame). Those
-# must not be committed as user edits (#327). Rather than filter them by a
-# provenance tag, the mirror lets the settle converge: the empty-frame guard
-# drops the no-geometry transients, the restore's single focus collapses the
-# groups to their settled arrangement, and the `all.equal` guard absorbs the
-# rest -- so the committed grid tracks only the settled layout.
+# dockViewR surfaces `_state` only once a layout has settled: the intermediate
+# frames a restore once streamed -- a tab group momentarily split into separate
+# leaves, or an empty re-init frame (#327) -- never reach the mirror, so every
+# echo it sees is a settled layout to commit, gated only by the tolerance below.
 #
 # It does not restrict to membership: a panel absent from the view is an inert
 # ghost, pruned at the compose / restore boundary, never by this writer.
@@ -357,13 +354,6 @@ observe_grid_echo <- function(id, dock, board, commit_grid) {
       }
 
       grid <- as_dock_grid(as_dock_layout(state))
-
-      # An empty grid carries no geometry: it is a mid-(re)load transient (the
-      # dock momentarily reports no panels while restoring), never a layout to
-      # mirror. Membership stays authoritative, so skipping it strands nothing.
-      if (!length(grid_panel_ids(grid))) {
-        return()
-      }
 
       stored <- board_grids(board$board)[[id]]
 
@@ -795,24 +785,6 @@ manage_dock <- function(
               "Unknown panel type {class(pid)}.",
               class = "dock_panel_invalid"
             )
-          }
-        }
-
-        # Front the view's active panel once, after the UIs are in place. The
-        # old loop fronted every panel in turn -- N `select_panel` echoes whose
-        # churn jittered the rendered sizes off the authored grid. A single
-        # focus instead settles the async restore to one determinate layout, so
-        # the mirror sees the authored geometry (not a transient separate-leaves
-        # frame) and the round-trip stays byte-exact. The last-placed panel is
-        # the arrangement's active tab (a tab group's open panel).
-        if (length(panels)) {
-
-          active <- panels[[length(panels)]]
-
-          if (is_block_panel_id(active)) {
-            select_block_panel(active, dock$proxy)
-          } else {
-            select_ext_panel(active, dock$proxy)
           }
         }
       },

--- a/tests/testthat/test-grid-mirror.R
+++ b/tests/testthat/test-grid-mirror.R
@@ -131,50 +131,6 @@ test_that("grid mirror commits a client echo, guards re-echoes", {
   })
 })
 
-test_that("the mirror skips an empty-grid echo (a mid-load transient)", {
-
-  brd <- new_dock_board(
-    blocks = c(a = new_dataset_block(), b = new_head_block()),
-    views = list(V = c("a", "b")),
-    grids = list(V = dock_grid("a", "b"))
-  )
-
-  ms <- new_mock_session()
-  withr::defer(if (!ms$isClosed()) ms$close())
-
-  committed <- list()
-
-  with_mock_context(ms, {
-
-    board <- reactiveValues(board = brd)
-    layout_rv <- reactiveVal(NULL)
-
-    observe_grid_echo(
-      "V", list(layout = layout_rv), board,
-      commit_grid = function(grid) {
-        committed[[length(committed) + 1L]] <<- grid
-      }
-    )
-    ms$flushReact()
-
-    # A re-init frame with no panels carries no geometry, so it is not committed
-    # however much it differs from the stored grid -- the reload transient that
-    # would otherwise strand an empty grid.
-    layout_rv(echo_state(dock_grid()))
-    ms$flushReact()
-
-    expect_length(committed, 0L)
-
-    # A later non-empty echo commits as usual.
-    layout_rv(echo_state(dock_grid(
-      "block_panel-a", "block_panel-b", sizes = c(0.3, 0.7)
-    )))
-    ms$flushReact()
-
-    expect_length(committed, 1L)
-  })
-})
-
 test_that("the mirror stores an in-flight echo verbatim; placement prunes it", {
 
   brd <- new_dock_board(

--- a/tests/testthat/test-model-interleaving.R
+++ b/tests/testthat/test-model-interleaving.R
@@ -109,11 +109,8 @@ model_set_members <- function(st, members) {
 
 # The grid mirror's commit logic, reproduced from observe_grid_echo(): an echo
 # casts to a `dock_grid` and commits only when it falls outside the size
-# tolerance of what is stored (the all.equal guard), else no-ops. (The empty-
-# frame guard the real observer also carries -- an empty grid is a re-init
-# transient, never mirrored -- is an edge case exercised in test-grid-mirror.R,
-# not modelled here.) Returns the commit count so the "one gesture, at most one
-# commit" bound is checkable.
+# tolerance of what is stored (the all.equal guard), else no-ops. Returns the
+# commit count so the "one gesture, at most one commit" bound is checkable.
 model_deliver_echo <- function(st) {
 
   echo <- st$client$pending

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -420,16 +420,20 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   expect_identical(read_dock_state(app), before)
 
   # The restored board carries the per-view grid forward, not just the nav and
-  # blocks: re-exporting after the reload reproduces the stored geometry (the
-  # tab group, its active tab, the custom sizes) byte-for-byte. This reads the
-  # committed board's slots -- proving the stage / reload cycle preserved them
-  # and that the fixture re-importing its own (colliding) view ids does not drop
-  # them. It cannot see the client render, so that leg is asserted below.
+  # blocks: re-exporting after the reload reproduces the stored geometry -- the
+  # tab group and its active tab exactly, the split sizes within the sash
+  # tolerance. This reads the committed board's slots -- proving the stage /
+  # reload cycle preserved them and that the fixture re-importing its own
+  # (colliding) view ids does not drop them. It cannot see the client render, so
+  # that leg is asserted below.
   #
-  # Byte-exact holds because dockViewR surfaces `_state` only once a restore has
-  # settled: the mirror commits that single settled layout, never the
-  # intermediate frames (separate leaves, zero-geometry) a restore used to
-  # stream, so the stored grid does not drift run to run.
+  # The grid compare is `all.equal(tolerance = grid_size_tol(), scale = 1)`:
+  # structure and the active tab match exactly, the sizes within the sash
+  # tolerance. dockView renders sash sizes with sub-pixel run-to-run jitter, so
+  # the first-load export and the post-import re-export land the ratios a
+  # fraction apart -- below what the mirror commits as a change, not a layout
+  # difference. The `views` slot carries no geometry, so it round-trips
+  # byte-for-byte.
   #
   # get_download can transiently fail after the reload -- the link's href is
   # filled only once outputs bind, and the download endpoint may briefly not
@@ -438,9 +442,15 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   ser2 <- jsonlite::fromJSON(path2, simplifyDataFrame = FALSE,
                              simplifyMatrix = FALSE)
 
-  expect_identical(
-    drop_focus(ser2[["payload"]][["grids"]]),
-    drop_focus(ser[["payload"]][["grids"]])
+  expect_true(
+    isTRUE(
+      all.equal(
+        drop_focus(ser2[["payload"]][["grids"]]),
+        drop_focus(ser[["payload"]][["grids"]]),
+        tolerance = grid_size_tol(),
+        scale = 1
+      )
+    )
   )
   expect_identical(ser2[["payload"]][["views"]], ser[["payload"]][["views"]])
 

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -357,9 +357,8 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
 
   # wait_dock_loaded gates on the server-rendered cards; the dockview client
   # restores the a/b tab group asynchronously. Wait for it to settle (b fronted,
-  # a a hidden back tab) before reading the exported grid, or the export can
-  # capture a transient separate-leaves state -- the grid mirror commits
-  # whatever the client last reported.
+  # a a hidden back tab) before reading the exported grid, so the read sees the
+  # restored layout the mirror commits rather than racing the async restore.
   wait_active_block_tabs(app, "analysis", "block_panel-b")
 
   before <- read_dock_state(app)
@@ -427,10 +426,10 @@ test_that("a board survives the live Export/Import round-trip (#233)", {
   # and that the fixture re-importing its own (colliding) view ids does not drop
   # them. It cannot see the client render, so that leg is asserted below.
   #
-  # Byte-exact holds because the mirror skips the restore's "restore"-tagged
-  # replay, so the stored grid is never overwritten by the sizes dockview
-  # renders (which jitter sub-tolerance run to run); a single post-restore focus
-  # settles deterministically rather than churning them.
+  # Byte-exact holds because dockViewR surfaces `_state` only once a restore has
+  # settled: the mirror commits that single settled layout, never the
+  # intermediate frames (separate leaves, zero-geometry) a restore used to
+  # stream, so the stored grid does not drift run to run.
   #
   # get_download can transiently fail after the reload -- the link's href is
   # filled only once outputs bind, and the download endpoint may briefly not


### PR DESCRIPTION
Drops the two consumer-side workarounds #344 added to the grid mirror, now that dockViewR surfaces only a settled `_state`.

## What

- Remove the empty-grid guard in `observe_grid_echo()` — a settled restore never emits an empty frame, so there is nothing to skip.
- Remove the single settle-focus in the restore observer (the per-panel `show_*_ui` loop stays). It fronted the authored active tab once to force the async restore to converge; with settled-only emission the mirror no longer sees the mid-collapse frames it guarded against.
- Drop the now-obsolete "skips an empty-grid echo" unit test and reconcile stale rationale comments (one still referenced the abandoned `"restore"`-provenance tag from #344).

## Stacked on dockViewR#93

Both guards existed only because dockViewR streamed intermediate `_state` frames while a restore was still settling (#327). cynkra/dockViewR#91 (PR cynkra/dockViewR#93) fixes that at the source. This PR pins `cynkra/dockViewR@91-restored-state` so CI validates the cleanup against the fixed bundle, and stays **draft until #93 lands** — then the pin reverts to a bare `cynkra/dockViewR` remote (net-zero DESCRIPTION diff vs `main`). dock is the only dockViewR consumer in its dependency tree, so the single pin resolves clean (verified via `pak::lockfile_create("deps::.")`).

## The settle-focus removal is an empirical re-check

Per #346, dropping the focus tests whether dockView's `fromJSON` fronts the authored active tab unaided once emission is settled. The #233 Export/Import e2e is the arbiter: its fronting assertions (`wait_active_block_tabs` / `visible_block_ids` / `active_block_panel_tabs` on `block_panel-b`) pass only if `b` is fronted without the nudge. If they go red, the focus returns as a pure fronting concern with its settle role retired. These dockview-render legs don't execute under local chromote, so the verdict comes from CI.

Fixes #346.
