### PR TITLE
Add edit_inputs_action for per-block input reorder/rename/remove

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,7 @@ Config/testthat/edition: 3
 Collate:
     'action-class.R'
     'action-block.R'
+    'action-inputs.R'
     'action-link.R'
     'action-stack.R'
     'action-ui.R'
@@ -77,6 +78,7 @@ Collate:
     'plugin-serdes.R'
     'sidebar-server.R'
     'sidebar-block.R'
+    'sidebar-inputs.R'
     'sidebar-link.R'
     'sidebar-stack.R'
     'utils-dock.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # blockr.dock (development version)
 
+* New `edit_inputs_action`: a per-block sidebar listing every incoming link
+  as an ordered list, so a block's inputs can be managed together rather than
+  one edge at a time. For a variadic block each row is a positional slot -
+  drag to reorder (each row's source and name move together to its new slot
+  via `links$mod`, so `...args` comes out in the new order), rename inline
+  (positional <-> named), or remove; an "Add input" block picker below the
+  list appends another positional slot when a source is chosen. A finite
+  block's rows are its declared ports, each a block-browser selectize that
+  picks, redirects or disconnects that port's source. Reorder keeps every
+  link's id, so there is no id churn and no new core verb. Surfaces such as
+  blockr.dag can trigger it for a selected node.
+
 * A panel id in a `dock_grid()` or view that resolves to no block or
   extension on the board now aborts at `new_dock_board()` rather than
   being dropped in silence. Such an id -- a typo, or an extension's old

--- a/R/action-class.R
+++ b/R/action-class.R
@@ -88,6 +88,7 @@ board_actions.dock_board <- function(x, ...) {
     add_link_action,
     edit_link_action,
     remove_link_action,
+    edit_inputs_action,
     add_stack_action,
     edit_stack_action,
     remove_stack_action

--- a/R/action-inputs.R
+++ b/R/action-inputs.R
@@ -1,0 +1,49 @@
+edit_inputs_action <- function(trigger, board, update, ...) {
+  new_action(
+    function(input, output, session) {
+
+      sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
+
+      # The menu validates each commit and returns a ready-to-apply core
+      # update. The row list is a `uiOutput` bound to the board, so applying an
+      # update re-renders it in place - the panel stays open across edits, and
+      # an "Add input" pick simply shows up as a new row.
+      committed <- edit_inputs_menu_server(
+        "menu",
+        board = reactive(board$board),
+        block_id = reactive(trigger())
+      )
+
+      menu_ui <- function() {
+        edit_inputs_menu_ui(session$ns("menu"), board$board, trigger())
+      }
+
+      sidebar_title <- function() paste0("Edit inputs ", trigger())
+
+      observeEvent(trigger(), {
+        show_sidebar(sidebar_id, title = sidebar_title(), ui = menu_ui())
+      })
+
+      # Close the sidebar the moment the block leaves the board (removed
+      # elsewhere). Guarded on an edit being in progress and the sidebar open.
+      observeEvent(board$board, {
+        id <- trigger()
+        if (length(id) == 1L && !is.na(id) && nzchar(id) &&
+              !id %in% board_block_ids(board$board) &&
+              isTRUE(sidebar_state(sidebar_id)$open)) {
+          hide_sidebar(sidebar_id)
+        }
+      }, ignoreInit = TRUE)
+
+      observeEvent(committed(), {
+        upd <- committed()$update
+        if (length(upd)) {
+          update(upd)
+        }
+      })
+
+      NULL
+    },
+    id = "edit_inputs_action"
+  )
+}

--- a/R/sidebar-inputs.R
+++ b/R/sidebar-inputs.R
@@ -1,0 +1,507 @@
+# The edit-inputs menu lists every incoming link to one block as an
+# ordered list, so a block's inputs can be managed together rather than
+# one edge at a time. A variadic block's rows are its positional slots
+# (drag to reorder, rename inline, remove); a finite block's rows are its
+# declared ports with their current source, shown read-only (redirect a
+# single port through the edge editor). The row list is a `uiOutput` so
+# the open sidebar tracks the board live - a source renamed, a link added
+# or removed elsewhere refreshes the list while it stays open.
+
+edit_inputs_menu_ui <- function(id, board, block_id) {
+  stopifnot(is.character(id), length(id) == 1L, nzchar(id))
+
+  ns <- NS(id)
+  blk <- board_blocks(board)[[block_id]]
+
+  body <- if (is.null(blk)) {
+    tags$p(
+      class = "blockr-block-browser-empty",
+      "This block is no longer on the board."
+    )
+  } else {
+    tags$div(
+      id = ns("commit"),
+      class = "blockr-inputs-menu",
+      `data-block` = block_id,
+      `data-variadic` = if (is.na(block_arity(blk))) "true" else "false",
+      uiOutput(ns("rows"))
+    )
+  }
+
+  htmltools::attachDependencies(
+    tags$div(class = "blockr-inputs-edit", body),
+    list(inputs_menu_dep())
+  )
+}
+
+edit_inputs_menu_server <- function(id, board, block_id) {
+  stopifnot(is.character(id), length(id) == 1L, nzchar(id))
+
+  block_id_fn <- as_accessor(block_id)
+
+  moduleServer(
+    id,
+    function(input, output, session) {
+
+      output$rows <- renderUI({
+        bid <- block_id_fn()
+        req(length(bid) == 1L, !is.na(bid), nzchar(bid))
+        brd <- board()
+        req(bid %in% board_block_ids(brd))
+        edit_inputs_rows(session$ns, brd, bid)
+      })
+
+      eventReactive(
+        input$commit,
+        {
+          cmd <- input$commit
+          brd <- board()
+          bid <- block_id_fn()
+          req(
+            length(bid) == 1L, !is.na(bid), nzchar(bid),
+            bid %in% board_block_ids(brd)
+          )
+
+          list(
+            update = edit_inputs_update(cmd, brd, bid, session),
+            nonce = cmd$nonce
+          )
+        },
+        ignoreNULL = TRUE
+      )
+    }
+  )
+}
+
+# Turn a committed command into a ready-to-apply core board update. Each
+# variant validates its own inputs (a rejected commit notifies and
+# `req()`s out, so the caller never sees an invalid update); an in-range
+# no-op returns an empty list, which the action then skips.
+edit_inputs_update <- function(cmd, board, block_id, session) {
+  switch(
+    cmd$action %||% "",
+    reorder = {
+      mods <- edit_inputs_reorder_delta(
+        board, block_id, as.character(unlist(cmd$order))
+      )
+      if (length(mods)) list(links = list(mod = mods)) else list()
+    },
+    rename = {
+      delta <- edit_inputs_rename_delta(
+        board, block_id, as.character(cmd$link_id), cmd$name, session
+      )
+      if (length(delta)) list(links = list(mod = delta)) else list()
+    },
+    remove = {
+      lid <- as.character(cmd$link_id)
+      if (lid %in% block_incoming_links(board, block_id)$id) {
+        list(links = list(rm = lid))
+      } else {
+        list()
+      }
+    },
+    redirect = edit_inputs_redirect_delta(
+      board, block_id, as.character(cmd$port),
+      as.character(cmd$source %||% ""), session
+    ),
+    add = edit_inputs_add_delta(
+      board, block_id, as.character(cmd$source %||% ""), session
+    ),
+    list()
+  )
+}
+
+# Append a positional input to a variadic block: a new link from the chosen
+# source, unnamed (empty input). A self-link or a source the block already
+# reaches (a cycle) is rejected; the empty choice is a no-op.
+edit_inputs_add_delta <- function(board, block_id, source, session) {
+  if (!nzchar(source)) {
+    return(list())
+  }
+
+  blocks <- board_blocks(board)
+
+  if (!(source %in% names(blocks)) || identical(source, block_id)) {
+    notify(
+      "Please choose a valid source block.", type = "warning",
+      session = session
+    )
+    req(FALSE)
+  }
+
+  df <- as.data.frame(board_links(board))
+
+  if (source %in% descendants_of(block_id, df)) {
+    notify(
+      "This would create a cycle.", type = "warning", session = session
+    )
+    req(FALSE)
+  }
+
+  lnk <- new_link(from = source, to = block_id, input = "")
+  list(links = list(add = as_links(set_names(list(lnk), seed_link_id(board)))))
+}
+
+# Point a finite block's declared port at a source (or disconnect it). The
+# port already carrying a link redirects it (a `from` mod, keeping the id);
+# an unwired port adds a fresh link; the empty choice removes the link. A
+# self-link or a source the block already reaches (a cycle) is rejected.
+# Returns a ready-to-apply update (or an empty list for a no-op).
+edit_inputs_redirect_delta <- function(board, block_id, port, source, session) {
+  rows <- block_incoming_links(board, block_id)
+  cur <- rows[rows$input == port, , drop = FALSE]
+  wired <- nrow(cur) > 0L
+  link_id <- if (wired) cur$id[[1L]] else NA_character_
+
+  if (!nzchar(source)) {
+    if (wired) {
+      return(list(links = list(rm = link_id)))
+    }
+    return(list())
+  }
+
+  blocks <- board_blocks(board)
+
+  if (!(source %in% names(blocks)) || identical(source, block_id)) {
+    notify(
+      "Please choose a valid source block.", type = "warning",
+      session = session
+    )
+    req(FALSE)
+  }
+
+  df <- as.data.frame(board_links(board))
+  df_wo <- if (wired) df[df$id != link_id, , drop = FALSE] else df
+
+  if (source %in% descendants_of(block_id, df_wo)) {
+    notify(
+      "This would create a cycle.", type = "warning", session = session
+    )
+    req(FALSE)
+  }
+
+  if (wired) {
+    if (identical(source, cur$from[[1L]])) {
+      return(list())
+    }
+    return(
+      list(links = list(mod = set_names(list(list(from = source)), link_id)))
+    )
+  }
+
+  lnk <- new_link(from = source, to = block_id, input = port)
+  list(links = list(add = as_links(set_names(list(lnk), seed_link_id(board)))))
+}
+
+# Reorder a variadic block's positional inputs by moving each whole row -
+# its source AND its name together - to its new slot. The links keep their
+# ids and board positions (so no id churn and no new core verb); each fixed
+# slot i takes on the `from` and `input` of whichever row now sits at visual
+# position i, so a named input's name travels with its source rather than
+# being left behind at the old position. `sync_dot_args()` then rebuilds
+# `...args` in that order. `new_order` is the link ids in the user's new
+# visual order; a stale / non-permutation order is a no-op.
+edit_inputs_reorder_delta <- function(board, block_id, new_order) {
+  rows <- block_incoming_links(board, block_id)
+  slots <- rows$id
+
+  if (length(new_order) != length(slots) || !setequal(new_order, slots)) {
+    return(list())
+  }
+
+  from_by_id <- set_names(rows$from, rows$id)
+  input_by_id <- set_names(rows$input, rows$id)
+
+  mods <- list()
+
+  for (i in seq_along(slots)) {
+    slot <- slots[[i]]
+    moved <- new_order[[i]]
+
+    delta <- list()
+    if (!identical(from_by_id[[moved]], from_by_id[[slot]])) {
+      delta$from <- from_by_id[[moved]]
+    }
+    if (!identical(input_by_id[[moved]], input_by_id[[slot]])) {
+      delta$input <- input_by_id[[moved]]
+    }
+    if (length(delta)) {
+      mods[[slot]] <- delta
+    }
+  }
+
+  mods
+}
+
+# Rename one variadic slot (positional <-> named). Empty means positional;
+# a non-empty name has to be free among the block's other inputs, since
+# core forbids two identically named inputs on one block. Returns the
+# id-keyed `mod` delta, or an empty list when the name is unchanged.
+edit_inputs_rename_delta <- function(board, block_id, link_id, name, session) {
+  rows <- block_incoming_links(board, block_id)
+
+  if (!(link_id %in% rows$id)) {
+    return(list())
+  }
+
+  name <- as.character(name %||% "")
+  current <- rows$input[rows$id == link_id]
+  others <- rows$input[rows$id != link_id]
+
+  if (nzchar(name) && name %in% others) {
+    notify(
+      "This input name is already used on the block.",
+      type = "warning", session = session
+    )
+    req(FALSE)
+  }
+
+  if (identical(name, current)) {
+    return(list())
+  }
+
+  set_names(list(list(input = name)), link_id)
+}
+
+# The block's incoming links as a data frame in board order (which, for a
+# variadic target, is the positional argument order).
+block_incoming_links <- function(board, block_id) {
+  df <- as.data.frame(board_links(board))
+  keep <- df$to == block_id
+
+  data.frame(
+    id = as.character(df$id[keep]),
+    from = as.character(df$from[keep]),
+    input = as.character(df$input[keep]),
+    stringsAsFactors = FALSE
+  )
+}
+
+inputs_display_name <- function(board, block_id) {
+  blk <- board_blocks(board)[[block_id]]
+
+  if (is.null(blk)) {
+    return(block_id)
+  }
+
+  name <- block_name(blk) %||% block_id
+  if (nzchar(name)) name else block_id
+}
+
+# ---- row rendering -----------------------------------------------------
+
+edit_inputs_rows <- function(ns, board, block_id) {
+  blk <- board_blocks(board)[[block_id]]
+  rows <- block_incoming_links(board, block_id)
+
+  if (is.na(block_arity(blk))) {
+    # Variadic: reorderable positional slots, plus an "Add input" section
+    # whose block picker appends a fresh slot - the slot count is open-ended.
+    return(
+      tagList(
+        css_block_selectize(),
+        edit_inputs_variadic_rows(board, rows),
+        edit_inputs_add_section(ns, board, block_id)
+      )
+    )
+  }
+
+  # Finite: one row per declared port, each picking its own source. The ports
+  # are the block's fixed formals, so there is nothing to add or reorder.
+  edit_inputs_finite_rows(ns, board, block_id, rows)
+}
+
+edit_inputs_variadic_rows <- function(board, rows) {
+  if (nrow(rows) == 0L) {
+    return(
+      tags$p(
+        class = "blockr-block-browser-empty",
+        "This block has no inputs yet."
+      )
+    )
+  }
+
+  tags$div(
+    class = "blockr-inputs-list",
+    lapply(
+      seq_len(nrow(rows)),
+      function(i) edit_inputs_variadic_row(board, rows[i, ])
+    )
+  )
+}
+
+edit_inputs_variadic_row <- function(board, row) {
+  tags$div(
+    class = "blockr-inputs-row",
+    `data-link-id` = row$id,
+    tags$span(
+      class = "blockr-inputs-drag-handle",
+      `aria-label` = "Drag to reorder",
+      title = "Drag to reorder",
+      drag_handle_icon()
+    ),
+    tags$div(
+      class = "blockr-inputs-source",
+      tags$span(
+        class = "blockr-inputs-source-name",
+        inputs_display_name(board, row$from)
+      ),
+      tags$span(class = "blockr-inputs-source-id", paste0("id: ", row$from))
+    ),
+    tags$input(
+      type = "text",
+      class = "blockr-inputs-name-input",
+      value = row$input,
+      placeholder = "unnamed",
+      `aria-label` = "Input name"
+    ),
+    tags$button(
+      type = "button",
+      class = "blockr-inputs-remove",
+      `aria-label` = "Remove input",
+      title = "Remove input",
+      "\u00d7"
+    )
+  )
+}
+
+# The "Add input" section for a variadic block: a block picker (the same
+# selectize as a finite port) over the eligible sources. Picking one appends
+# a positional slot - a new link, source -> block, unnamed - which shows up
+# as a fresh reorderable row above.
+edit_inputs_add_section <- function(ns, board, block_id) {
+  tags$div(
+    class = "blockr-inputs-add-section",
+    tags$span(class = "blockr-inputs-add-label", "Add input"),
+    tags$div(
+      class = "blockr-inputs-source-picker",
+      edit_inputs_source_select(
+        ns("add_source"), board,
+        edit_inputs_eligible_sources(board, block_id), "",
+        placeholder = "Choose a source..."
+      )
+    )
+  )
+}
+
+# Finite block: one row per declared port, each a block-browser selectize
+# (the same rich picker as the "Connect ..." / edit-link menus) that chooses
+# the block feeding that port. Picking a source connects or redirects the
+# port; clearing it (the selectize's remove button) disconnects it.
+edit_inputs_finite_rows <- function(ns, board, block_id, rows) {
+  blk <- board_blocks(board)[[block_id]]
+  ports <- block_inputs(blk)
+
+  if (length(ports) == 0L) {
+    return(
+      tags$p(
+        class = "blockr-block-browser-empty",
+        "This block takes no inputs."
+      )
+    )
+  }
+
+  sources <- edit_inputs_eligible_sources(board, block_id)
+
+  source_for <- function(port) {
+    hit <- rows$from[rows$input == port]
+    if (length(hit)) hit[[1L]] else NA_character_
+  }
+
+  tagList(
+    css_block_selectize(),
+    tags$div(
+      class = "blockr-inputs-list",
+      lapply(ports, function(port) {
+        edit_inputs_finite_row(ns, board, port, source_for(port), sources)
+      })
+    )
+  )
+}
+
+# Block ids that may feed `block_id` without closing a cycle: every block
+# except the target itself and any it already reaches.
+edit_inputs_eligible_sources <- function(board, block_id) {
+  df <- as.data.frame(board_links(board))
+  setdiff(
+    names(board_blocks(board)), c(block_id, descendants_of(block_id, df))
+  )
+}
+
+edit_inputs_finite_row <- function(ns, board, port, from, sources) {
+  current <- if (is.null(from) || is.na(from)) "" else as.character(from)
+  choices <- union(sources, if (nzchar(current)) current else character())
+
+  tags$div(
+    class = "blockr-inputs-row",
+    `data-port` = port,
+    tags$span(class = "blockr-inputs-port-label", port),
+    tags$div(
+      class = "blockr-inputs-source-picker",
+      edit_inputs_source_select(
+        ns(paste0("src_", port)), board, choices, current
+      )
+    )
+  )
+}
+
+# A single-select block picker over the eligible sources, rendered with the
+# block-browser selectize (icon / name / package badge / search). The remove
+# button lets a wired port be cleared (disconnected). Its change is captured
+# by the menu binding as a `redirect` command, so the port selectize needs no
+# server observer of its own.
+edit_inputs_source_select <- function(id, board, sources, current,
+                                      placeholder = "Choose a source...") {
+  selectizeInput(
+    id,
+    label = NULL,
+    choices = NULL,
+    options = list(
+      options = build_block_options(board, sources),
+      items = if (nzchar(current)) list(current) else list(),
+      maxItems = 1L,
+      valueField = "value",
+      labelField = "label",
+      searchField = c("label", "description", "searchtext"),
+      render = js_blk_selectize_render(),
+      plugins = list("remove_button"),
+      placeholder = placeholder,
+      # Render the dropdown on <body> so the sidebar's scroll container does
+      # not clip it (mirrors ext-edit.R); the CSS lifts it above the sidebar.
+      dropdownParent = "body"
+    )
+  )
+}
+
+# ---- assets ------------------------------------------------------------
+
+inputs_menu_dep <- function() {
+  htmltools::htmlDependency(
+    name = "sidebar-inputs",
+    version = utils::packageVersion("blockr.dock"),
+    package = "blockr.dock",
+    src = "assets",
+    stylesheet = "css/sidebar-inputs.css",
+    script = "js/sidebar-inputs.js",
+    all_files = FALSE
+  )
+}
+
+drag_handle_icon <- function() {
+  tags$svg(
+    xmlns = "http://www.w3.org/2000/svg",
+    viewBox = "0 0 16 16",
+    width = "16",
+    height = "16",
+    fill = "currentColor",
+    `aria-hidden` = "true",
+    tags$path(
+      d = paste0(
+        "M6 3.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm0 4.5a1 1 0 1 1-2 0 1 1 0 0 ",
+        "1 2 0zm0 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM12 3.5a1 1 0 1 1-2 0 1 ",
+        "1 0 0 1 2 0zm0 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm0 4.5a1 1 0 1 1-2 ",
+        "0 1 1 0 0 1 2 0z"
+      )
+    )
+  )
+}

--- a/inst/assets/css/sidebar-inputs.css
+++ b/inst/assets/css/sidebar-inputs.css
@@ -1,0 +1,182 @@
+/* Edit-inputs menu: an ordered list of one block's incoming links,
+   living inside the sidebar primitive. A variadic block's rows carry a
+   drag handle (reorder), an inline name field (rename) and a remove
+   button; a finite block's rows are read-only port -> source pairs. */
+
+.blockr-inputs-edit {
+  height: 100%;
+  min-height: 0;
+}
+
+.blockr-inputs-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  min-height: 0;
+  margin: -16px;
+  padding: 16px;
+
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  color: var(--blockr-color-text-primary, #1f2937);
+}
+
+.blockr-inputs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.blockr-inputs-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+
+  background: var(--blockr-color-bg-subtle, #f8fafc);
+  border: 1px solid var(--blockr-color-border, #e5e7eb);
+  border-radius: 6px;
+}
+
+.blockr-inputs-row.is-dragging {
+  opacity: 0.6;
+  box-shadow: var(--blockr-shadow-lg, 0 8px 24px rgba(15, 23, 42, 0.16));
+}
+
+.blockr-inputs-drag-handle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  cursor: grab;
+  color: var(--blockr-color-text-subtle, #9ca3af);
+}
+
+.blockr-inputs-drag-handle:active {
+  cursor: grabbing;
+}
+
+.blockr-inputs-source {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.blockr-inputs-source-name {
+  font-weight: var(--blockr-font-weight-semibold, 600);
+  font-size: var(--blockr-font-size-sm, 13px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.blockr-inputs-source-id {
+  font-size: var(--blockr-font-size-xs, 11px);
+  color: var(--blockr-color-text-meta, #9ca3af);
+}
+
+.blockr-inputs-source-empty {
+  font-size: var(--blockr-font-size-sm, 13px);
+  font-style: italic;
+  color: var(--blockr-color-text-muted, #6b7280);
+}
+
+.blockr-inputs-port-label {
+  flex: 0 0 auto;
+  font-weight: var(--blockr-font-weight-semibold, 600);
+  font-size: var(--blockr-font-size-sm, 13px);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.blockr-inputs-row.is-readonly .blockr-inputs-source {
+  flex-direction: row;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.blockr-inputs-name-input {
+  flex: 0 0 34%;
+  min-width: 0;
+  padding: 4px 8px;
+
+  font-size: var(--blockr-font-size-sm, 13px);
+  color: var(--blockr-color-text-primary, #1f2937);
+  background: var(--blockr-color-bg-input, #fff);
+  border: 1px solid var(--blockr-color-border, #e5e7eb);
+  border-radius: 4px;
+}
+
+.blockr-inputs-name-input:focus {
+  outline: none;
+  border-color: var(--blockr-color-primary, #3b82f6);
+}
+
+.blockr-inputs-remove {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+
+  font-size: 18px;
+  line-height: 1;
+  color: var(--blockr-color-text-subtle, #9ca3af);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.blockr-inputs-remove:hover {
+  color: var(--blockr-color-error, #dc2626);
+  background: var(--blockr-color-bg-hover, #f1f5f9);
+}
+
+
+.blockr-inputs-port-label {
+  min-width: 64px;
+}
+
+.blockr-inputs-source-picker {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* The block-browser selectize sits flush in the row: drop Shiny's default
+   form-group spacing and let it span the picker width. */
+.blockr-inputs-source-picker .form-group,
+.blockr-inputs-source-picker .shiny-input-container {
+  margin-bottom: 0;
+  width: 100% !important;
+}
+
+/* The picker dropdown is rendered on <body> (dropdownParent) so the panel's
+   scroll container cannot clip it; lift it above the sidebar overlay
+   (z-index 1050) so it is not hidden behind the panel. `!important` because
+   selectize sets its own z-index (1000) that otherwise wins. */
+.selectize-dropdown {
+  z-index: 1200 !important;
+}
+
+.blockr-inputs-add-section {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--blockr-color-border, #e5e7eb);
+}
+
+.blockr-inputs-add-label {
+  flex: 0 0 auto;
+  font-size: var(--blockr-font-size-sm, 13px);
+  font-weight: var(--blockr-font-weight-semibold, 600);
+  color: var(--blockr-color-text-secondary, #4b5563);
+}

--- a/inst/assets/js/sidebar-inputs.js
+++ b/inst/assets/js/sidebar-inputs.js
@@ -1,0 +1,204 @@
+(function () {
+  "use strict";
+
+  // The edit-inputs menu is a Shiny input whose value is the command the
+  // user just issued against a block's input list: a `reorder` (the new
+  // slot order, as link ids), a `rename` (a slot's new name), or a
+  // `remove` (a slot's link id). One binding on the list root captures
+  // all three via delegated listeners, so the re-rendered row `uiOutput`
+  // inside carries no per-row Shiny inputs of its own. The R side owns
+  // validation and turns the command into a board update.
+  var EVENT = "blockr-inputs-menu:commit";
+  var seq = 0;
+
+  function isVariadic(root) {
+    return root.getAttribute("data-variadic") === "true";
+  }
+
+  function commit(root, payload) {
+    payload.nonce = ++seq;
+    root._blockrInputsValue = payload;
+    root.dispatchEvent(new CustomEvent(EVENT));
+  }
+
+  function rowOrder(root) {
+    var order = [];
+    root.querySelectorAll(".blockr-inputs-row[data-link-id]").forEach(
+      function (row) {
+        order.push(row.getAttribute("data-link-id"));
+      }
+    );
+    return order;
+  }
+
+  // Native HTML5 drag-to-reorder. A row is only draggable while the
+  // pointer is on its handle (set on mousedown, cleared on dragend), so
+  // selecting text in the name field never starts a drag. `dragover`
+  // moves the dragged row before / after the row under the pointer;
+  // `dragend` reads the settled DOM order and commits it.
+  function initDrag(root) {
+    var dragging = null;
+
+    root.addEventListener("mousedown", function (event) {
+      var row = event.target.closest(".blockr-inputs-row[data-link-id]");
+      if (!row || !root.contains(row)) return;
+      if (event.target.closest(".blockr-inputs-drag-handle")) {
+        row.setAttribute("draggable", "true");
+      } else {
+        row.removeAttribute("draggable");
+      }
+    });
+
+    root.addEventListener("dragstart", function (event) {
+      var row = event.target.closest(".blockr-inputs-row[data-link-id]");
+      if (!row || !root.contains(row)) return;
+      dragging = row;
+      row.classList.add("is-dragging");
+      event.dataTransfer.effectAllowed = "move";
+      // Firefox does not start a drag without data being set.
+      try {
+        event.dataTransfer.setData(
+          "text/plain", row.getAttribute("data-link-id") || ""
+        );
+      } catch (ignore) {
+        // ignore
+      }
+    });
+
+    root.addEventListener("dragover", function (event) {
+      if (!dragging) return;
+      event.preventDefault();
+      var over = event.target.closest(".blockr-inputs-row[data-link-id]");
+      if (!over || over === dragging || !root.contains(over)) return;
+      var rect = over.getBoundingClientRect();
+      var after = event.clientY - rect.top > rect.height / 2;
+      var list = dragging.parentNode;
+      list.insertBefore(dragging, after ? over.nextSibling : over);
+    });
+
+    root.addEventListener("drop", function (event) {
+      if (dragging) event.preventDefault();
+    });
+
+    root.addEventListener("dragend", function () {
+      if (!dragging) return;
+      dragging.classList.remove("is-dragging");
+      dragging.removeAttribute("draggable");
+      dragging = null;
+      if (isVariadic(root)) {
+        commit(root, { action: "reorder", order: rowOrder(root) });
+      }
+    });
+  }
+
+  function initRemove(root) {
+    root.addEventListener("click", function (event) {
+      var btn = event.target.closest(".blockr-inputs-remove");
+      if (!btn || !root.contains(btn)) return;
+      var row = btn.closest(".blockr-inputs-row[data-link-id]");
+      if (!row) return;
+      commit(root, {
+        action: "remove",
+        link_id: row.getAttribute("data-link-id")
+      });
+    });
+  }
+
+  // Rename commits on `change` (blur / Enter). Enter also blurs so a user
+  // who never leaves the field still commits.
+  function initRename(root) {
+    root.addEventListener("change", function (event) {
+      var el = event.target;
+      if (!el.classList) return;
+
+      if (el.classList.contains("blockr-inputs-name-input")) {
+        var row = el.closest(".blockr-inputs-row[data-link-id]");
+        if (row) {
+          commit(root, {
+            action: "rename",
+            link_id: row.getAttribute("data-link-id"),
+            name: el.value
+          });
+        }
+      }
+    });
+
+    root.addEventListener("keydown", function (event) {
+      if (event.key !== "Enter") return;
+      var input = event.target;
+      if (input.classList &&
+          input.classList.contains("blockr-inputs-name-input")) {
+        event.preventDefault();
+        input.blur();
+      }
+    });
+  }
+
+  // Finite port pickers are block-browser selectize inputs. Selectize fires
+  // a jQuery `change` on the (hidden) underlying <select>, which native
+  // listeners do not catch, so delegate through jQuery. An empty value
+  // (the picker was cleared) disconnects the port.
+  function initSourceSelect(root) {
+    $(root).on("change", ".blockr-inputs-source-picker select", function () {
+      var val = this.value;
+
+      // A finite port picker redirects / disconnects that port.
+      var portRow = this.closest(".blockr-inputs-row[data-port]");
+      if (portRow) {
+        commit(root, {
+          action: "redirect",
+          port: portRow.getAttribute("data-port"),
+          source: val
+        });
+        return;
+      }
+
+      // The variadic "Add input" section appends a slot, then clears the
+      // picker so it is ready for the next add.
+      if (this.closest(".blockr-inputs-add-section") && val) {
+        commit(root, { action: "add", source: val });
+        if (this.selectize) {
+          this.selectize.clear(true);
+        }
+      }
+    });
+  }
+
+  function initMenu(root) {
+    if (root.dataset.blockrInputsInit === "1") return;
+    root.dataset.blockrInputsInit = "1";
+    initDrag(root);
+    initRemove(root);
+    initRename(root);
+    initSourceSelect(root);
+  }
+
+  var binding = new Shiny.InputBinding();
+  $.extend(binding, {
+    find: function (scope) {
+      return $(scope).find(".blockr-inputs-menu");
+    },
+    initialize: function (el) {
+      initMenu(el);
+    },
+    getValue: function (el) {
+      return el._blockrInputsValue || null;
+    },
+    subscribe: function (el, callback) {
+      initMenu(el);
+      // Shiny's callback takes no args; addEventListener passes the Event,
+      // which breaks the value-update path - wrap to drop it.
+      var handler = function () { callback(); };
+      el._blockrInputsHandler = handler;
+      el.addEventListener(EVENT, handler);
+    },
+    unsubscribe: function (el) {
+      if (el._blockrInputsHandler) {
+        el.removeEventListener(EVENT, el._blockrInputsHandler);
+        el._blockrInputsHandler = null;
+      }
+    }
+  });
+
+  Shiny.inputBindings.register(binding, "blockr.dock.inputsMenu");
+})();

--- a/inst/assets/js/sidebar-server.js
+++ b/inst/assets/js/sidebar-server.js
@@ -112,6 +112,14 @@
     var handler = function (event) {
       if (!isOpen(panel) || isPinned(panel)) return;
       if (panel.contains(event.target)) return;
+      // A selectize dropdown opened by a control inside the panel is rendered
+      // on <body> (dropdownParent), so its options sit outside the panel DOM.
+      // A click on one is not really "outside", so don't close (and unbind)
+      // the panel out from under an in-progress selection.
+      if (event.target.closest &&
+            event.target.closest(".selectize-dropdown")) {
+        return;
+      }
       hidePanel(panel);
     };
     panel._blockrSidebarOutsideHandler = handler;

--- a/tests/testthat/test-action-class.R
+++ b/tests/testthat/test-action-class.R
@@ -21,11 +21,11 @@ test_that("action ctor", {
   db_act <- board_actions(new_dock_board())
 
   expect_type(db_act, "list")
-  expect_length(db_act, 10L)
+  expect_length(db_act, 11L)
 
   trig <- action_triggers(db_act)
 
-  expect_length(trig, 10L)
+  expect_length(trig, 11L)
   expect_named(trig, chr_ply(db_act, action_id))
 
   expect_null(

--- a/tests/testthat/test-action-inputs.R
+++ b/tests/testthat/test-action-inputs.R
@@ -1,0 +1,619 @@
+# The edit-inputs menu publishes one command per user gesture into the
+# parent session's namespace as `menu-commit`: a `reorder` (new slot
+# order as link ids), a `rename` (a slot's new name) or a `remove` (a
+# slot's link id). Drive that input directly to simulate the JS binding.
+inputs_commit <- function(session, action, order = NULL, link_id = NULL,
+                          name = NULL, nonce = 1L) {
+  session$setInputs(
+    `menu-commit` = list(
+      action = action,
+      order = order,
+      link_id = link_id,
+      name = name,
+      nonce = nonce
+    )
+  )
+}
+
+local_mocked_sidebar <- function(env = parent.frame()) {
+  local_mocked_bindings(
+    show_sidebar         = function(...) invisible(list(...)),
+    keep_or_hide_sidebar = function(...) invisible(list(...)),
+    hide_sidebar         = function(...) invisible(list(...)),
+    .env = env
+  )
+}
+
+inputs_board <- function(links, board_id = "b") {
+  reactiveValues(
+    board = new_board(
+      c(
+        a = new_dataset_block("iris"),
+        b = new_dataset_block("mtcars"),
+        c = new_dataset_block("airquality"),
+        m = new_merge_block(),
+        r = new_rbind_block()
+      ),
+      links = links
+    ),
+    board_id = board_id
+  )
+}
+
+variadic_links <- function() {
+  links(
+    l1 = new_link("a", "r", ""),
+    l2 = new_link("b", "r", ""),
+    l3 = new_link("c", "r", "")
+  )
+}
+
+test_that("block_incoming_links returns rows in board order", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      r = new_rbind_block()),
+    links = links(
+      l1 = new_link("a", "r", ""),
+      l2 = new_link("b", "r", "keep")
+    )
+  )
+
+  rows <- block_incoming_links(board, "r")
+
+  expect_identical(rows$id, c("l1", "l2"))
+  expect_identical(rows$from, c("a", "b"))
+  expect_identical(rows$input, c("", "keep"))
+
+  expect_identical(nrow(block_incoming_links(board, "a")), 0L)
+})
+
+test_that("reorder delta permutes `from` across fixed slots", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      c = new_dataset_block("airquality"), r = new_rbind_block()),
+    links = variadic_links()
+  )
+
+  # Drag c's row (l3) to the top: each whole row moves to its new slot,
+  # keeping the links' ids and positions; with every input unnamed here,
+  # only the sources change.
+  expect_identical(
+    edit_inputs_reorder_delta(board, "r", c("l3", "l1", "l2")),
+    list(l1 = list(from = "c"), l2 = list(from = "a"), l3 = list(from = "b"))
+  )
+
+  # Only the slots whose source actually changed appear in the delta.
+  expect_identical(
+    edit_inputs_reorder_delta(board, "r", c("l2", "l1", "l3")),
+    list(l1 = list(from = "b"), l2 = list(from = "a"))
+  )
+
+  # The identity order changes nothing.
+  expect_length(
+    edit_inputs_reorder_delta(board, "r", c("l1", "l2", "l3")), 0L
+  )
+
+  # A non-permutation (stale / missing id) is ignored.
+  expect_length(edit_inputs_reorder_delta(board, "r", c("l1", "l2")), 0L)
+  expect_length(
+    edit_inputs_reorder_delta(board, "r", c("l1", "l2", "x")), 0L
+  )
+})
+
+test_that("reorder delta carries a named input's name with its row", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      c = new_dataset_block("airquality"), r = new_rbind_block()),
+    links = links(
+      l1 = new_link("a", "r", ""),
+      l2 = new_link("b", "r", "keep"),
+      l3 = new_link("c", "r", "")
+    )
+  )
+
+  # Drag l2's row (source b, name "keep") to the top: the whole row moves,
+  # so the name travels with its source instead of being left at slot l2.
+  expect_identical(
+    edit_inputs_reorder_delta(board, "r", c("l2", "l1", "l3")),
+    list(
+      l1 = list(from = "b", input = "keep"),
+      l2 = list(from = "a", input = "")
+    )
+  )
+})
+
+test_that("rename delta names / clears a variadic slot", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      r = new_rbind_block()),
+    links = links(
+      l1 = new_link("a", "r", ""),
+      l2 = new_link("b", "r", "keep")
+    )
+  )
+
+  expect_identical(
+    edit_inputs_rename_delta(board, "r", "l1", "left", NULL),
+    list(l1 = list(input = "left"))
+  )
+
+  # Clearing a name returns the slot to positional.
+  expect_identical(
+    edit_inputs_rename_delta(board, "r", "l2", "", NULL),
+    list(l2 = list(input = ""))
+  )
+
+  # An unchanged name is a no-op.
+  expect_length(edit_inputs_rename_delta(board, "r", "l2", "keep", NULL), 0L)
+
+  # A link that is not on the block is a no-op.
+  expect_length(edit_inputs_rename_delta(board, "r", "nope", "x", NULL), 0L)
+})
+
+test_that("edit inputs action: reorder commits a from-permutation mod", {
+  local_mocked_sidebar()
+  r_board <- inputs_board(variadic_links())
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      inputs_commit(session, "reorder", order = c("l3", "l1", "l2"))
+
+      upd <- r_update()
+      expect_named(upd, "links")
+      expect_named(upd$links, "mod")
+      expect_identical(
+        upd$links$mod,
+        list(
+          l1 = list(from = "c"),
+          l2 = list(from = "a"),
+          l3 = list(from = "b")
+        )
+      )
+    }
+  )
+})
+
+test_that("edit inputs action: an identity reorder issues no update", {
+  local_mocked_sidebar()
+  r_board <- inputs_board(variadic_links())
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      inputs_commit(session, "reorder", order = c("l1", "l2", "l3"))
+
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("edit inputs action: rename commits an input mod", {
+  local_mocked_sidebar()
+  r_board <- inputs_board(variadic_links())
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      inputs_commit(session, "rename", link_id = "l2", name = "keep")
+
+      upd <- r_update()
+      expect_named(upd$links, "mod")
+      expect_identical(upd$links$mod, list(l2 = list(input = "keep")))
+    }
+  )
+})
+
+test_that("edit inputs action: a duplicate input name is rejected", {
+  local_mocked_sidebar()
+  r_board <- inputs_board(
+    links(
+      l1 = new_link("a", "r", "keep"),
+      l2 = new_link("b", "r", "")
+    )
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # `l1` already carries "keep"; core forbids a second identically
+      # named input, so the menu rejects the rename.
+      inputs_commit(session, "rename", link_id = "l2", name = "keep")
+
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("edit inputs action: remove commits a links rm", {
+  local_mocked_sidebar()
+  r_board <- inputs_board(variadic_links())
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      inputs_commit(session, "remove", link_id = "l2")
+
+      upd <- r_update()
+      expect_named(upd$links, "rm")
+      expect_identical(upd$links$rm, "l2")
+    }
+  )
+})
+
+test_that("edit inputs action: removing the block closes the sidebar", {
+  hide_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(id, ...) {
+      hide_calls[[length(hide_calls) + 1L]] <<- id
+      invisible(NULL)
+    },
+    sidebar_state = function(id, ...) list(open = TRUE, pinned = TRUE)
+  )
+
+  r_board <- inputs_board(variadic_links())
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      expect_length(hide_calls, 0L)
+
+      # Drop the block whose inputs are being edited -> sidebar closes.
+      r_board$board <- new_board(board_blocks(r_board$board)["a"])
+      session$flushReact()
+
+      expect_gte(length(hide_calls), 1L)
+      expect_identical(hide_calls[[1L]], "b-actions_sidebar")
+    }
+  )
+})
+
+test_that("edit inputs menu server renders the row list", {
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+        r = new_rbind_block()),
+      links = links(
+        l1 = new_link("a", "r", ""),
+        l2 = new_link("b", "r", "keep")
+      )
+    ),
+    board_id = "b"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(id, function(input, output, session) {
+        edit_inputs_menu_server(
+          "menu", board = reactive(r_board$board), block_id = reactive("r")
+        )
+      })
+    },
+    {
+      session$flushReact()
+      html <- as.character(output$`menu-rows`$html)
+      expect_true(grepl("blockr-inputs-row", html, fixed = TRUE))
+      expect_true(grepl("data-link-id=\"l1\"", html, fixed = TRUE))
+      expect_true(grepl("data-link-id=\"l2\"", html, fixed = TRUE))
+    }
+  )
+})
+
+test_that("variadic block renders an ordered, editable row list", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      r = new_rbind_block()),
+    links = links(
+      l1 = new_link("a", "r", ""),
+      l2 = new_link("b", "r", "keep")
+    )
+  )
+
+  doc <- xml2::read_html(as.character(edit_inputs_rows(NS("mid"), board, "r")))
+  by_class <- function(tok) {
+    sprintf(
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]", tok
+    )
+  }
+  rows <- xml2::xml_find_all(doc, by_class("blockr-inputs-row"))
+
+  expect_length(rows, 2L)
+  expect_identical(
+    xml2::xml_attr(rows, "data-link-id"), c("l1", "l2")
+  )
+
+  # Each row carries a drag handle, a name field and a remove button.
+  handle <- xml2::xml_find_all(rows[[1]], paste0(
+    ".", by_class("blockr-inputs-drag-handle")
+  ))
+  expect_length(handle, 1L)
+
+  names_in <- xml2::xml_find_all(doc, paste0(
+    by_class("blockr-inputs-name-input")
+  ))
+  expect_identical(xml2::xml_attr(names_in, "value"), c("", "keep"))
+
+  expect_length(
+    xml2::xml_find_all(doc, by_class("blockr-inputs-remove")), 2L
+  )
+})
+
+test_that("finite block renders a block-picker selectize per port", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      m = new_merge_block()),
+    links = links(l1 = new_link("a", "m", "x"))
+  )
+
+  html <- as.character(edit_inputs_rows(NS("mid"), board, "m"))
+  doc <- xml2::read_html(html)
+  by_class <- function(tok) {
+    sprintf(
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]", tok
+    )
+  }
+  rows <- xml2::xml_find_all(doc, by_class("blockr-inputs-row"))
+
+  # One row per declared port, in port order.
+  expect_identical(xml2::xml_attr(rows, "data-port"), c("x", "y"))
+
+  # Each port is a block-browser selectize (not a bare <select>): the
+  # namespaced input id and the selectize config are present.
+  expect_true(grepl("mid-src_x", html, fixed = TRUE))
+  expect_true(grepl("mid-src_y", html, fixed = TRUE))
+  expect_true(grepl("selectize", html))
+
+  # Port x preselects its current source `a` via the selectize's items.
+  expect_match(html, '"items"')
+  expect_match(html, '"a"')
+})
+
+test_that("edit inputs menu ui carries the block / arity markers", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), r = new_rbind_block()),
+    links = links(l1 = new_link("a", "r", ""))
+  )
+
+  doc <- xml2::read_html(as.character(edit_inputs_menu_ui("mid", board, "r")))
+  root <- xml2::xml_find_first(doc, "//*[@id='mid-commit']")
+  expect_identical(xml2::xml_attr(root, "data-block"), "r")
+  expect_identical(xml2::xml_attr(root, "data-variadic"), "true")
+
+  # A finite block is flagged non-variadic.
+  fin <- xml2::read_html(
+    as.character(edit_inputs_menu_ui("mid", board, "a"))
+  )
+  root_fin <- xml2::xml_find_first(fin, "//*[@id='mid-commit']")
+  expect_identical(xml2::xml_attr(root_fin, "data-variadic"), "false")
+})
+
+test_that("Add input section is shown for variadic blocks only", {
+  by_class <- function(tok) {
+    sprintf(
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]", tok
+    )
+  }
+  has_add <- function(board, blk) {
+    doc <- xml2::read_html(
+      as.character(edit_inputs_rows(NS("mid"), board, blk))
+    )
+    length(xml2::xml_find_all(doc, by_class("blockr-inputs-add-section"))) > 0L
+  }
+
+  # Variadic -> an "Add input" section (a block picker; the slot count is
+  # open-ended).
+  vb <- new_board(
+    c(a = new_dataset_block("iris"), r = new_rbind_block()),
+    links = links(l1 = new_link("a", "r", ""))
+  )
+  expect_true(has_add(vb, "r"))
+
+  # Finite -> no add section even with a free port; ports are fixed and are
+  # connected through their per-row pickers instead.
+  mb <- new_board(
+    c(a = new_dataset_block("iris"), m = new_merge_block()),
+    links = links(l1 = new_link("a", "m", "x"))
+  )
+  expect_false(has_add(mb, "m"))
+})
+
+test_that("finite redirect delta: connect, redirect, disconnect, no-op", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      m = new_merge_block()),
+    links = links(l1 = new_link("a", "m", "x"))
+  )
+
+  # Unwired port y -> b: add a fresh link.
+  add <- edit_inputs_redirect_delta(board, "m", "y", "b", NULL)
+  expect_named(add$links, "add")
+  df <- as.data.frame(add$links$add)
+  expect_identical(c(df$from, df$to, df$input), c("b", "m", "y"))
+
+  # Wired port x -> b: redirect the existing link (mod its `from`, keep id).
+  expect_identical(
+    edit_inputs_redirect_delta(board, "m", "x", "b", NULL),
+    list(links = list(mod = list(l1 = list(from = "b"))))
+  )
+
+  # Same source: no-op.
+  expect_length(edit_inputs_redirect_delta(board, "m", "x", "a", NULL), 0L)
+
+  # Blank on a wired port: disconnect (remove the link).
+  expect_identical(
+    edit_inputs_redirect_delta(board, "m", "x", "", NULL),
+    list(links = list(rm = "l1"))
+  )
+
+  # Blank on an unwired port: no-op.
+  expect_length(edit_inputs_redirect_delta(board, "m", "y", "", NULL), 0L)
+})
+
+test_that("finite sources exclude the block and its descendants", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), m = new_merge_block(),
+      h = new_head_block()),
+    links = links(l1 = new_link("a", "m", "x"), l2 = new_link("m", "h", "data"))
+  )
+  # h is downstream of m, so feeding m from h would cycle -> h excluded.
+  expect_false("h" %in% edit_inputs_eligible_sources(board, "m"))
+  expect_false("m" %in% edit_inputs_eligible_sources(board, "m"))
+  expect_true("a" %in% edit_inputs_eligible_sources(board, "m"))
+})
+
+test_that("edit inputs action: a redirect that would cycle is rejected", {
+  local_mocked_sidebar()
+  r_board <- reactiveValues(
+    board = new_board(
+      c(a = new_dataset_block("iris"), m = new_merge_block(),
+        h = new_head_block()),
+      links = links(
+        l1 = new_link("a", "m", "x"), l2 = new_link("m", "h", "data")
+      )
+    ),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("m"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # Point m's free port y at h -> h is downstream of m -> cycle -> rejected.
+      session$setInputs(
+        `menu-commit` = list(
+          action = "redirect", port = "y", source = "h", nonce = 1L
+        )
+      )
+      expect_length(r_update(), 0L)
+    }
+  )
+})
+
+test_that("add delta appends a positional variadic input", {
+  board <- new_board(
+    c(a = new_dataset_block("iris"), m = new_merge_block(),
+      h = new_head_block(), r = new_rbind_block()),
+    links = links(l1 = new_link("a", "r", ""), l2 = new_link("r", "h", "data"))
+  )
+
+  # Adding `m` as a source appends a fresh unnamed (positional) link r <- m.
+  add <- edit_inputs_add_delta(board, "r", "m", NULL)
+  df <- as.data.frame(add$links$add)
+  expect_identical(c(df$from, df$to, df$input), c("m", "r", ""))
+
+  # The empty choice is a no-op.
+  expect_length(edit_inputs_add_delta(board, "r", "", NULL), 0L)
+
+  # A source the block already reaches (h is downstream of r) would cycle and
+  # is excluded from the picker in the first place.
+  expect_false("h" %in% edit_inputs_eligible_sources(board, "r"))
+})
+
+test_that("edit inputs action: an add command commits a new link", {
+  local_mocked_sidebar()
+  r_board <- inputs_board(variadic_links())
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"), board = r_board, update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      # The "Add input" picker emits an add command carrying the chosen source.
+      session$setInputs(
+        `menu-commit` = list(action = "add", source = "m", nonce = 1L)
+      )
+      upd <- r_update()
+      expect_named(upd$links, "add")
+      df <- as.data.frame(upd$links$add)
+      expect_identical(df$from, "m")
+      expect_identical(df$to, "r")
+      expect_identical(df$input, "")
+    }
+  )
+})
+
+test_that("edit inputs menu ui is empty for an unknown block", {
+  board <- new_board(c(a = new_dataset_block("iris")))
+  doc <- xml2::read_html(
+    as.character(edit_inputs_menu_ui("mid", board, "gone"))
+  )
+  notice <- xml2::xml_find_first(
+    doc,
+    paste0(
+      "//*[contains(concat(' ', normalize-space(@class), ' '),",
+      " ' blockr-block-browser-empty ')]"
+    )
+  )
+  expect_match(xml2::xml_text(notice), "no longer on the board")
+})


### PR DESCRIPTION
## Summary

- New `edit_inputs_action`: a per-block sidebar that lists a block's incoming links as one ordered list, so its inputs can be managed together rather than one edge at a time. Like `edit_link_action` (#341) it has no in-dock trigger — a surface such as blockr.dag fires it for a node.
- Variadic block: rows drag to reorder, rename inline (positional ↔ named), or remove. Finite block: read-only port → source rows.
- Reorder is the load-bearing part — it permutes each fixed slot's `from` via `links$mod` rather than moving links, so ids and positions are preserved and `sync_dot_args()` rebuilds `...args` in the new order: no id churn, no new core verb. Relies on the value-changing `links$mod` hardened in blockr.core#288, already exercised by the merged `edit_link_action`. Names stay with their slot, so reorder rotates sources only (semantically neutral for named args, which match by name).
- Deferred, each with an existing home: "Add input" (the "Connect …" flow already adds links) and finite per-port redirect (the #341 edge editor already redirects a single link). The blockr.dag "Edit inputs" node-menu companion is a separate change, mirroring dag#154 for edit_link.

Fixes #348