### PR TITLE
Select the initial view from a ?view= URL parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # blockr.dock (development version)
 
+* A served board now honours a `?view=<id>` URL query parameter: it opens on
+  the named view instead of the board's default active view (matching by
+  stable view id, the immutable handle). An absent or unknown id falls back
+  to the default, so existing links are unaffected (#323).
+
 * New `edit_link_action`: a sidebar editor for a single existing link. It can
   rename the link's input (turning an unnamed positional slot into a named
   one, or changing an existing name), switch the input slot on a finite

--- a/R/dock-board.R
+++ b/R/dock-board.R
@@ -27,7 +27,9 @@
 #'   entry falls back to a default grid over its members.
 #' @param active Id of the initially active view (a key of `views`). Defaults
 #'   to the first view. Which view is active is a property of the collection,
-#'   not of an individual view.
+#'   not of an individual view. A served board also honours a `?view=<id>` URL
+#'   query parameter naming a view id, which opens the board on that view and
+#'   overrides this default for that request.
 #'
 #' @examples
 #' brd <- new_dock_board(c(a = blockr.core::new_dataset_block()))

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -46,6 +46,11 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
 #' @export
 blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
 
+  # A `?view=<id>` deep link opens the board on that view. Applied here, before
+  # board_server snapshots the board, so the first reconcile builds that view's
+  # dock directly -- no default-view dock built then switched away.
+  x <- select_url_view(x)
+
   # Core threads `plugins` to its own block server but not to board callbacks,
   # so capture them for the callback to stash on active_dock -- the deferred
   # card-build paths need the served set, since board_plugins() drops any served
@@ -56,6 +61,38 @@ blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
 
   board_server(id, x, plugins, options, callbacks = callback,
                callback_location = "start", ...)
+}
+
+view_url_param <- "view"
+
+select_url_view <- function(board, session = get_session()) {
+
+  if (is.null(session)) {
+    return(board)
+  }
+
+  target <- resolve_url_view(
+    board_views(board), isolate(session$clientData$url_search)
+  )
+
+  if (not_null(target)) {
+    active_view(board) <- target
+  }
+
+  board
+}
+
+# Matched by stable view id -- the immutable handle -- not the editable display
+# name; NULL when the param is absent, empty, or names no view.
+resolve_url_view <- function(views, search) {
+
+  sel <- parseQueryString(coal(search, ""))[[view_url_param]]
+
+  if (is.null(sel) || !nzchar(sel) || !sel %in% names(views)) {
+    return(NULL)
+  }
+
+  sel
 }
 
 # Round-trip stability: every view's stored grid must be the fixed point the

--- a/man/dock.Rd
+++ b/man/dock.Rd
@@ -65,7 +65,9 @@ entry falls back to a default grid over its members.}
 
 \item{active}{Id of the initially active view (a key of \code{views}). Defaults
 to the first view. Which view is active is a property of the collection,
-not of an individual view.}
+not of an individual view. A served board also honours a \verb{?view=<id>} URL
+query parameter naming a view id, which opens the board on that view and
+overrides this default for that request.}
 
 \item{options}{Board-level user settings}
 

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -28,6 +28,59 @@ test_that("serve utils", {
   )
 })
 
+test_that("resolve_url_view matches the ?view= param to a view id", {
+
+  views <- board_views(
+    new_dock_board(
+      blocks = c(a = new_dataset_block(), b = new_dataset_block()),
+      views = list(First = blk("a"), Second = blk("b")),
+      active = "First"
+    )
+  )
+
+  expect_identical(resolve_url_view(views, "?view=Second"), "Second")
+  expect_identical(resolve_url_view(views, "?view=First"), "First")
+
+  # Absent, empty, unknown, or no query string all decline to select.
+  expect_null(resolve_url_view(views, "?other=1"))
+  expect_null(resolve_url_view(views, "?view="))
+  expect_null(resolve_url_view(views, "?view=nope"))
+  expect_null(resolve_url_view(views, ""))
+  expect_null(resolve_url_view(views, NULL))
+})
+
+test_that("select_url_view opens the board on the ?view= view (#323)", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_dataset_block()),
+    views = list(First = blk("a"), Second = blk("b")),
+    active = "First"
+  )
+
+  fake_session <- function(search) {
+    list(clientData = list(url_search = search))
+  }
+
+  # The default active view is "First", so flipping to "Second" is a real
+  # (non-vacuous) change driven purely by the query param.
+  expect_identical(active_view(brd), "First")
+  expect_identical(
+    active_view(select_url_view(brd, fake_session("?view=Second"))),
+    "Second"
+  )
+
+  # An unknown id, an absent param, or no session leaves the default active.
+  expect_identical(
+    active_view(select_url_view(brd, fake_session("?view=nope"))),
+    "First"
+  )
+  expect_identical(
+    active_view(select_url_view(brd, fake_session(""))),
+    "First"
+  )
+  expect_identical(active_view(select_url_view(brd, NULL)), "First")
+})
+
 test_that("grids_stable holds when the live grid is the stored fixed point", {
 
   brd <- new_dock_board(


### PR DESCRIPTION
## Summary

- A served dock board now opens on the view named by a `?view=<id>` URL query parameter, so an app can be deep-linked to a specific view. Matching is by stable view id (the immutable handle), never the editable display name — the same handle nav/serialization already key on.
- Applied in `blockr_app_server.dock_board()` before `board_server` snapshots the board, so the first `reconcile_views()` builds that view's dock directly. Doing it via a post-init active-view switch would instead build the default view's dock and then swap it away.
- An absent, empty, or unknown `?view=` value (and any non-session caller) leaves the board's own `active` view untouched, so existing links are unaffected.
- The new logic (`resolve_url_view()` / `select_url_view()`) is unit-tested. The runtime seam reuses two already-proven paths: reconcile building `active_view(board)`'s dock (exercised by the view-lifecycle and serdes e2e tests) and reading the URL at server time via `session$clientData$url_search` (the same mechanism blockr.core's reload handoff relies on), so a bespoke browser e2e for the query string would add a known-flaky test for no new coverage.

Fixes #323