### PR TITLE
Retarget shinytest2 pin from nbenn fork to rstudio upstream

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     knitr,
     rmarkdown
 Remotes:
-    nbenn/shinytest2@wait-for-app-serving,
+    rstudio/shinytest2,
     BristolMyersSquibb/blockr.core,
     cynkra/dockViewR
 Config/testthat/edition: 3


### PR DESCRIPTION
## Summary

- Retarget the shinytest2 `Remotes:` pin from `nbenn/shinytest2@wait-for-app-serving` (a personal fork) to canonical `rstudio/shinytest2`.
- The port-binding fix that fork carried landed upstream in rstudio/shinytest2#448 (merged via #449), plus the follow-up Windows-timeout CI fixes (#450) — upstream `main` is a strict superset of the fork branch.
- The fix isn't in a CRAN release yet, so the pin stays; this changes only *which* source it resolves from. `pak` dependency resolution verified clean.
- Interim step toward #310: the pin comes out entirely — along with `setup-idle-debug.R` and the `new_app_driver()` 60s-timeout helper — once the fix reaches CRAN. Keeping #310 open until then.

Refs #310