### PR TITLE
Add view reordering via a views$order delta and nav controls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # blockr.dock (development version)
 
+* Views (pages) can now be reordered from the nav dropdown: each item carries
+  up / down controls beside its rename and remove actions. Order is board
+  content, so the move travels through the update lifecycle as a new
+  `views$order` delta (a total permutation of the view ids) and survives save /
+  restore; the server applies it and pushes the settled order back to the nav
+  (#351).
+
 * A served board now honours a `?view=<id>` URL query parameter: it opens on
   the named view instead of the board's default active view (matching by
   stable view id, the immutable handle). An absent or unknown id falls back

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -75,6 +75,7 @@ board_server_callback <- function(board, update, visibility, ...,
   add_view_observer(client_views, session, board, update)
   remove_view_observer(client_views, session, update)
   rename_view_observer(client_views, session, update)
+  reorder_view_observer(client_views, session, update)
 
   # Freeze the inputs of every block whose controls are hidden -- and every
   # block on a locked board -- so a forged input behind the hidden / read-only
@@ -610,6 +611,14 @@ reconcile_views <- function(board, update, docks, active_dock,
         list(rename = list(id = v, to = new_nm))
       )
     }
+  }
+
+  # A pure reorder is invisible to the set-diffing loops above (same members,
+  # same names), so re-sequence the nav explicitly when the board order and the
+  # client's differ. `as.list()` forces a JSON array even for a single id.
+  if (!identical(names(state), want)) {
+    state <- reorder_dock_views(state, want)
+    session$sendInputMessage("view_nav", list(order = as.list(want)))
   }
 
   # Dock lifecycle: tear down docks whose view the board dropped, then build the
@@ -1163,6 +1172,50 @@ rename_view_observer <- function(client_views, session, update) {
     update(
       list(views = list(rename = set_names(list(rename$to), rename$id)))
     )
+  })
+}
+
+# Translate a relative up / down nudge of one view into the total order it
+# yields. Clamped: nudging the first view up or the last down is a no-op, as is
+# an unknown id.
+reorder_by_move <- function(order, id, dir) {
+
+  idx <- match(id, order)
+
+  if (is.na(idx)) {
+    return(order)
+  }
+
+  swap <- switch(dir, up = idx - 1L, down = idx + 1L, NA_integer_)
+
+  if (is.na(swap) || swap < 1L || swap > length(order)) {
+    return(order)
+  }
+
+  order[c(idx, swap)] <- order[c(swap, idx)]
+
+  order
+}
+
+# View order is board content, not client-owned geometry: the up / down gesture
+# carries only a relative `{id, dir}` intent. The order the client shows is
+# authoritative here, so the total permutation is derived from
+# `names(client_views())` and travels the update lifecycle as a `views$order`
+# delta; reconcile then pushes the settled order back to the nav. A boundary
+# nudge yields the same order and emits nothing.
+reorder_view_observer <- function(client_views, session, update) {
+  input <- session$input
+
+  observeEvent(input$view_nav_reorder, {
+    req(views_can_crud(client_views()))
+
+    move <- input$view_nav_reorder
+    order <- names(client_views())
+    reordered <- reorder_by_move(order, move$id, move$dir)
+
+    if (!identical(reordered, order)) {
+      update(list(views = list(order = reordered)))
+    }
   })
 }
 

--- a/R/dock-board.R
+++ b/R/dock-board.R
@@ -370,6 +370,10 @@ apply_board_update.dock_board <- function(board, upd, ...) {
     board <- apply_views_mod(upd$views$mod, board)
   }
 
+  if (length(upd$views$order)) {
+    board <- apply_views_order(upd$views$order, board)
+  }
+
   if (length(upd$views$grid)) {
     board <- apply_views_grid(upd$views$grid, board)
   }

--- a/R/dock-view.R
+++ b/R/dock-view.R
@@ -177,6 +177,23 @@ finalize_views_active <- function(views) {
   res
 }
 
+# Resequence a `dock_views` by a total permutation of its ids. Bare `[` on the
+# list drops the class and the `active` attribute, and routing through
+# `finalize_views_active()` would reset active to whatever now sits first -- so
+# re-stamp the active view explicitly, keeping the active page put across a
+# reorder.
+reorder_dock_views <- function(x, order) {
+
+  active <- active_view(x)
+  res <- structure(x[order], class = "dock_views")
+
+  if (not_null(active)) {
+    active_view(res) <- active
+  }
+
+  res
+}
+
 # Assemble a keyed list of views into a `dock_views`, minting an id for each
 # keyless entry (like an unnamed block) with blockr.core's `rand_names()` --
 # the same generator block / stack / link ids use. `reserved` lists ids
@@ -603,6 +620,18 @@ view_item_ui <- function(view_id, view_name, active_id = NULL,
     actions <- tags$span(
       class = "blockr-view-item-actions",
       tags$span(
+        class = "blockr-view-action blockr-view-up",
+        role = "button",
+        title = "Move up",
+        bsicons::bs_icon("chevron-up")
+      ),
+      tags$span(
+        class = "blockr-view-action blockr-view-down",
+        role = "button",
+        title = "Move down",
+        bsicons::bs_icon("chevron-down")
+      ),
+      tags$span(
         class = "blockr-view-action blockr-view-edit",
         role = "button",
         title = "Rename",
@@ -752,7 +781,7 @@ validate_views_delta <- function(views, board, upd) {
   }
 
   unknown_keys <- setdiff(
-    names(views), c("add", "mod", "rm", "active", "rename", "grid")
+    names(views), c("add", "mod", "rm", "active", "rename", "grid", "order")
   )
   if (length(unknown_keys)) {
     blockr_abort(
@@ -899,6 +928,19 @@ validate_views_delta <- function(views, board, upd) {
       blockr_abort(
         "Active view {active} does not resolve to an existing view.",
         class = "dock_views_delta_active_invalid"
+      )
+    }
+  }
+
+  if (not_null(views$order)) {
+
+    order <- views$order
+
+    if (!is.character(order) || anyDuplicated(order) ||
+          !setequal(order, post_views)) {
+      blockr_abort(
+        "`views$order` must be a total permutation of the post-state view ids.",
+        class = "dock_views_delta_order_invalid"
       )
     }
   }
@@ -1531,6 +1573,16 @@ apply_views_add <- function(add_views, board) {
   if (seeded) {
     board_grids(board) <- new_dock_grids(grids)
   }
+
+  board
+}
+
+# Reorder the board's views by a total permutation of their ids -- the sequence
+# the nav dropdown and serialization walk. `board_grids()` is id-keyed and so
+# order-independent, needing no change.
+apply_views_order <- function(order, board) {
+
+  board_views(board) <- reorder_dock_views(board_views(board), order)
 
   board
 }

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -940,6 +940,16 @@ label:has(input[type="file"]) {
   color: var(--blockr-color-danger, #dc3545);
 }
 
+/* Reorder is bounded: the first view can't move up, the last can't move down.
+   Only view items are `<div>` children of the nav (divider is `<hr>`, add is a
+   `<button>`), so `:first/last-of-type` track the ends and re-evaluate live as
+   the order push re-sequences nodes -- no JS state to maintain. */
+.blockr-view-item:first-of-type .blockr-view-up,
+.blockr-view-item:last-of-type .blockr-view-down {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
 /* Inline rename input */
 .blockr-view-rename-input {
   flex: 1;

--- a/inst/assets/js/view-binding.js
+++ b/inst/assets/js/view-binding.js
@@ -183,6 +183,24 @@ $(function () {
         Shiny.setInputValue(navId + '_remove', viewId, { priority: 'event' });
       });
 
+      // Reorder click: view order is board state, so the gesture carries only a
+      // relative move intent. The server applies it and pushes the settled
+      // order back via receiveMessage; the DOM never moves optimistically.
+      $(el).on('click.viewBinding', '.blockr-view-up, .blockr-view-down', function (e) {
+        e.stopPropagation();
+        e.preventDefault();
+
+        var $item = $(this).closest('.blockr-view-item');
+        var $nav = $item.closest('.blockr-view-nav');
+        var navId = $nav.attr('id');
+        var dir = $(this).hasClass('blockr-view-up') ? 'up' : 'down';
+
+        Shiny.setInputValue(navId + '_reorder', {
+          id: $item.attr('data-view-id'),
+          dir: dir
+        }, { priority: 'event' });
+      });
+
       // Add click
       $(el).on('click.viewBinding', '.blockr-view-add', function (e) {
         e.stopPropagation();
@@ -216,12 +234,24 @@ $(function () {
           );
 
         if (canCrud) {
+          var chevronUpSvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-chevron-up" style="height:1em;width:1em;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img"><path fill-rule="evenodd" d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z"></path></svg>';
+          var chevronDownSvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-chevron-down" style="height:1em;width:1em;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img"><path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"></path></svg>';
           var pencilSvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-pencil" style="height:1em;width:1em;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"></path></svg>';
           var xLgSvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-x-lg" style="height:1em;width:1em;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img"><path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z"></path></svg>';
           newItem.append(
             $('<span>')
               .addClass('blockr-view-item-actions')
               .append(
+                $('<span>')
+                  .addClass('blockr-view-action blockr-view-up')
+                  .attr('role', 'button')
+                  .attr('title', 'Move up')
+                  .html(chevronUpSvg),
+                $('<span>')
+                  .addClass('blockr-view-action blockr-view-down')
+                  .attr('role', 'button')
+                  .attr('title', 'Move down')
+                  .html(chevronDownSvg),
                 $('<span>')
                   .addClass('blockr-view-action blockr-view-edit')
                   .attr('role', 'button')
@@ -265,6 +295,23 @@ $(function () {
         if ($target.hasClass('active')) {
           setToggleLabel($(el), data.rename.to);
         }
+      }
+
+      if (data.hasOwnProperty('order')) {
+        var $nav = $(el);
+        var $anchor = $nav.find('.dropdown-divider');
+        // Re-append each item in the server's order; re-appending an existing
+        // node moves it, so iterating in order lands the DOM in that order.
+        data.order.forEach(function (viewId) {
+          var $item = $nav.find(
+            '.blockr-view-item[data-view-id="' + viewId + '"]'
+          );
+          if ($anchor.length) {
+            $anchor.before($item);
+          } else {
+            $nav.append($item);
+          }
+        });
       }
 
       $(el).trigger('change');

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -88,6 +88,28 @@ test_that("a multi-view board round-trips identically through ser/des", {
   expect_identical(board_grids(des), board_grids(brd))
 })
 
+test_that("dock_views preserve a non-alphabetical key order through ser/des", {
+
+  # View order is implicit in the list's key sequence -- no separate slot -- so
+  # it survives save / restore only by JSON key ordering. Pin that with ids in
+  # reverse-alphabetical order (and a non-first active): a layer that sorted
+  # keys would reorder these and fail.
+  brd <- new_dock_board(
+    blocks = c(
+      a = new_dataset_block(),
+      b = new_head_block(),
+      c = new_head_block()
+    ),
+    views = list(zebra = "a", mango = "b", apple = "c"),
+    active = "mango"
+  )
+
+  des <- blockr_deser(blockr_ser(brd))
+
+  expect_identical(names(board_views(des)), c("zebra", "mango", "apple"))
+  expect_identical(active_view(board_views(des)), "mango")
+})
+
 test_that("serialized dock_views records view id, name and active", {
 
   # Fixed ids (the list keys) keep the wire shape deterministic so the id

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -623,6 +623,49 @@ test_that("view lifecycle: switch, rename, remove a view (#232)", {
   expect_true(docks$active)
 })
 
+test_that("a view moves down via the nav reorder control (#351)", {
+
+  skip_on_cran()
+
+  app <- new_app_driver(
+    system.file("examples", "multi-view", "app.R", package = "blockr.dock"),
+    name = "view-reorder",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 20 * 1000
+  )
+  withr::defer(app$stop())
+
+  app$wait_for_idle()
+
+  # Two seeded views, First active and on top.
+  nav <- read_view_nav(app)
+  expect_identical(nav$label, c("First", "Second"))
+  expect_identical(nav$label[nav$active], "First")
+
+  first <- nav$id[nav$label == "First"]
+
+  # Nudge First down via its chevron: the gesture sends a relative
+  # `view_nav_reorder`, the server applies the order and pushes it back, and the
+  # binding re-sequences the nav. Order is board content, so the active view
+  # rides along rather than snapping to the new first entry.
+  app$run_js(
+    paste0(
+      "document.querySelector('",
+      sprintf(
+        "#my_board-view_nav .blockr-view-item[data-view-id=\"%s\"]", first
+      ),
+      " .blockr-view-down').click()"
+    )
+  )
+  app$wait_for_idle()
+
+  nav <- read_view_nav(app)
+  expect_identical(nav$label, c("Second", "First"))
+  expect_false(anyDuplicated(nav$id) > 0L)
+  expect_identical(nav$label[nav$active], "First")
+})
+
 test_that("dock panel move updates layout state and serialization (#234)", {
 
   skip_on_cran()

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -1105,3 +1105,138 @@ test_that("apply_views_rm is a pure board transform", {
   expect_silent(out <- apply_views_rm(vid(brd, "B"), brd))
   expect_identical(unname(view_names(board_views(out))), "A")
 })
+
+test_that("reorder_by_move swaps a neighbour and clamps at the ends", {
+
+  o <- c("A", "B", "C")
+
+  expect_identical(reorder_by_move(o, "B", "up"), c("B", "A", "C"))
+  expect_identical(reorder_by_move(o, "B", "down"), c("A", "C", "B"))
+
+  # A boundary nudge or an unknown id yields the same order (the observer then
+  # emits nothing).
+  expect_identical(reorder_by_move(o, "A", "up"), o)
+  expect_identical(reorder_by_move(o, "C", "down"), o)
+  expect_identical(reorder_by_move(o, "Z", "up"), o)
+})
+
+test_that("apply_views_order reorders views, keeping the active one", {
+
+  brd <- new_dock_board(
+    blocks = c(
+      a = new_dataset_block(),
+      b = new_head_block(),
+      c = new_head_block()
+    ),
+    views = list(A = "a", B = "b", C = "c")
+  )
+  active_view(brd) <- "B"
+
+  out <- apply_views_order(c("C", "A", "B"), brd)
+
+  expect_identical(names(board_views(out)), c("C", "A", "B"))
+  # Routing through finalize_views_active() would reset active to the new first
+  # view ("C"); a reorder must leave the active page put.
+  expect_identical(active_view(board_views(out)), "B")
+})
+
+test_that("a views$order delta reorders the board through apply_board_update", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = "a", B = "b")
+  )
+
+  upd <- augment_board_update(list(views = list(order = c("B", "A"))), brd)
+  out <- apply_board_update(brd, upd)
+
+  expect_identical(names(board_views(out)), c("B", "A"))
+})
+
+test_that("order permutes the post-rm ids when combined with rm", {
+
+  brd <- new_dock_board(
+    blocks = c(
+      a = new_dataset_block(),
+      b = new_head_block(),
+      c = new_head_block()
+    ),
+    views = list(A = "a", B = "b", C = "c")
+  )
+
+  upd <- augment_board_update(
+    list(views = list(rm = "B", order = c("C", "A"))),
+    brd
+  )
+  out <- apply_board_update(brd, upd)
+
+  expect_identical(names(board_views(out)), c("C", "A"))
+})
+
+test_that("validate_views_delta rejects a non-permutation order", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = "a", B = "b")
+  )
+
+  expect_error(
+    augment_board_update(list(views = list(order = c("A", "A"))), brd),
+    class = "dock_views_delta_order_invalid"
+  )
+  expect_error(
+    augment_board_update(list(views = list(order = "A")), brd),
+    class = "dock_views_delta_order_invalid"
+  )
+  expect_error(
+    augment_board_update(list(views = list(order = c("A", "B", "Z"))), brd),
+    class = "dock_views_delta_order_invalid"
+  )
+})
+
+test_that("reconcile_views pushes the settled order to the nav", {
+
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = "a", B = "b")
+  )
+
+  sent <- list()
+  session <- list(
+    ns = identity,
+    sendInputMessage = function(input_id, message) {
+      sent[[length(sent) + 1L]] <<- message
+      invisible()
+    },
+    sendCustomMessage = function(type, message) invisible()
+  )
+
+  docks <- reactiveValues()
+  for (id in names(board_views(brd))) {
+    ids <- as.character(view_members(board_views(brd)[[id]]))
+    docks[[id]] <- list(
+      layout = function() NULL,
+      live_panels = reactiveVal(ids)
+    )
+  }
+  active_dock <- reactiveValues()
+  client_active <- reactiveVal(active_view(board_views(brd)))
+  client_views <- reactiveVal(seed_view_state(board_views(brd)))
+
+  # The board now carries [B, A]; the client still shows [A, B], so reconcile
+  # detects the reorder, pushes the order and re-sequences client_views.
+  reordered <- apply_views_order(c("B", "A"), brd)
+  board <- reactiveValues(board = reordered)
+
+  isolate(
+    reconcile_views(board, function(...) NULL, docks, active_dock,
+                    client_active, client_views, session)
+  )
+
+  expect_true(
+    any(lgl_ply(sent, function(m) {
+      identical(as.character(unlist(m$order)), c("B", "A"))
+    }))
+  )
+  expect_identical(names(isolate(client_views())), c("B", "A"))
+})


### PR DESCRIPTION
## Summary

A board's view order is a real fact of the model — it drives the nav dropdown and survives save/restore by list-key order — but nothing could change it, and a view added at runtime always landed last. This adds the missing mutation path and a gesture for it.

- New `views$order` delta carrying a total permutation of the post-state view ids: idempotent, validated in one line, and travelling the update lifecycle like the other view verbs.
- Up/down controls on each nav item, beside rename and remove. View order is board content, not client-owned geometry, so the gesture sends only a relative `{id, dir}` intent; the server derives the total order, applies it, and pushes the settled order back — the DOM never moves optimistically.
- Reordering preserves the active view: `apply_views_order` re-stamps `active` rather than routing through `finalize_views_active`, which would otherwise snap it to whatever now sits first.
- `reconcile_views` gains an order branch, since a pure permutation is invisible to its set-diff loops; the disabled first-up / last-down affordances are pure structural CSS with no JS state.

Fixes #351
