### PR TITLE
Anchor navbar spinner leftmost and add a minimum-busy delay

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -145,10 +145,14 @@
   the stable condition id, so a persistent warning no longer flashes on every
   re-evaluation.
 * The intrusive page-wide busy pulse is replaced by a small, unobtrusive
-  spinner in the navbar, next to the board-options gear. It turns while the
-  session does real block evaluation and disappears otherwise -- scoped (as the
-  pulse was) to a genuinely recomputing output in the visible view, so startup
-  and block evaluation spin it while a bare panel switch does not.
+  spinner in the navbar. It turns while the session does real block evaluation
+  and disappears otherwise -- scoped (as the pulse was) to a genuinely
+  recomputing output in the visible view, so startup and block evaluation spin
+  it while a bare panel switch does not. It is anchored at the left of the
+  navbar's right-hand controls, so revealing or clearing it never shifts them,
+  and a configurable minimum-busy delay (`blockr.spinner_delay_ms`, default
+  200 ms; `0` to disable) holds the reveal so a sub-threshold flush no longer
+  flashes it (#345, #355).
 * The "Edit board" extension no longer churns on a board re-emit -- it re-syncs
   its staged working copy only when links or stacks actually change, stops
   flickering the manage-links cell inputs, and overlays half-finished staged

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -38,6 +38,7 @@ board_ui.dock_board <- function(
     ),
     div(
       class = "blockr-navbar",
+      style = sprintf("--blockr-spinner-delay: %dms;", spinner_delay_ms()),
       div(
         class = "blockr-navbar-left",
         if ("preserve_board" %in% names(plugins)) {
@@ -46,6 +47,20 @@ board_ui.dock_board <- function(
       ),
       div(
         class = "blockr-navbar-right",
+        # Busy spinner. Shown/hidden purely by CSS off the `.shiny-busy` class
+        # Shiny toggles on <html> during a flush -- no server observer -- and
+        # scoped to real block evaluation so a bare panel switch does not spin
+        # it. Placed leftmost in this right-anchored group: the group packs
+        # rightward, so its always-present (visibility-toggled) slot is absorbed
+        # at the group's left edge, in the empty navbar middle -- no visible
+        # control shifts when it reveals. The reveal is held for
+        # `--blockr-spinner-delay` ms (set on the navbar above) so a sub-
+        # threshold flush never flashes it. Announced like the lock indicator.
+        tags$span(
+          class = "blockr-navbar-spinner",
+          role = "status",
+          `aria-label` = "Busy"
+        ),
         v_nav,
         if (is_dock_locked()) {
           tags$span(
@@ -60,16 +75,6 @@ board_ui.dock_board <- function(
             )
           )
         },
-        # Busy spinner. Shown/hidden purely by CSS off the `.shiny-busy` class
-        # Shiny toggles on <html> during a flush -- no server observer -- and
-        # scoped to real block evaluation so a bare panel switch does not spin
-        # it. Sits just before the gear so its show/hide never nudges that
-        # (right-anchored) button. Announced like the lock indicator beside it.
-        tags$span(
-          class = "blockr-navbar-spinner",
-          role = "status",
-          `aria-label` = "Busy"
-        ),
         # Pure-JS open trigger via `data-blockr-sidebar-target`. The
         # settings sidebar's body is pre-rendered into its mount below, so
         # no server observer is needed: clicking the gear toggles the
@@ -260,6 +265,13 @@ settings_body <- function(
       )
     )
   )
+}
+
+spinner_delay_ms <- function() {
+
+  ms <- suppressWarnings(as.integer(blockr_option("spinner_delay_ms", 200L)))
+
+  if (length(ms) != 1L || is.na(ms) || ms < 0L) 200L else ms
 }
 
 blockr_dock_dep <- function() {

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -1166,13 +1166,13 @@ label:has(input[type="file"]) {
 }
 
 /* ============================================
-   Navbar busy spinner — scope to real computation
+   Navbar busy spinner
    ============================================ */
 
-/* A small ring next to the board-options gear that spins while the session
-   does real block evaluation, replacing bslib's page-wide busy pulse. Driven
-   purely off the `.shiny-busy` class Shiny puts on <html> during a flush -- no
-   server observer, no page darkening.
+/* A small ring in the navbar that spins while the session does real block
+   evaluation, replacing bslib's page-wide busy pulse. Driven purely off the
+   `.shiny-busy` class Shiny puts on <html> during a flush -- no server
+   observer, no page darkening.
 
    Scoped exactly as the old pulse was: a plain panel switch round-trips to the
    server -- the on-screen visibility report and the layout fold -- without
@@ -1183,19 +1183,32 @@ label:has(input[type="file"]) {
    deliberate -- an off-screen block parked in the (hidden) offcanvas pool stays
    "recalculating" while it waits for evaluation, and that pool sits outside the
    container, so a pending hidden block never spins the navbar. Startup and real
-   recompute spin; a bare panel switch does not. */
+   recompute spin; a bare panel switch does not.
+
+   Reveal is by `visibility`/`opacity`, not `display`, so the slot is always
+   laid out (leftmost in the navbar's right-hand group, absorbed at that group's
+   left edge) and showing it never reflows a neighbour. The show transition
+   carries `transition-delay: var(--blockr-spinner-delay)` -- set on
+   `.blockr-navbar` from the `spinner_delay_ms` option -- while the hide has no
+   delay. So the ring appears only once the session has stayed busy for the full
+   delay (a flush that clears sooner is interrupted mid-delay and never shows)
+   and it clears the instant work finishes. */
 .blockr-navbar-spinner {
-  display: none;
+  visibility: hidden;
+  opacity: 0;
   width: 16px;
   height: 16px;
   border: 2px solid var(--blockr-color-text-muted);
   border-right-color: transparent;
   border-radius: 50%;
   animation: blockr-navbar-spin 0.7s linear infinite;
+  transition: opacity 0s, visibility 0s;
 }
 
 html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinner {
-  display: inline-block;
+  visibility: visible;
+  opacity: 1;
+  transition-delay: var(--blockr-spinner-delay, 0ms);
 }
 
 @keyframes blockr-navbar-spin {

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -137,35 +137,94 @@ test_that("locked mode renders a navbar lock indicator", {
   expect_match(locked_html, ">Read-only<", fixed = TRUE)
 })
 
-test_that("navbar renders a busy spinner beside the gear (#345)", {
+test_that("navbar busy spinner is leftmost and announced (#345, #355)", {
 
   brd <- new_dock_board(blocks = c(a = new_dataset_block()))
 
-  spinner_of <- function(html) {
+  by_class <- function(node, token) {
     xml2::xml_find_all(
-      xml2::read_html(html),
+      node,
       paste0(
-        ".//span[contains(concat(' ', normalize-space(@class), ' '), ",
-        "' blockr-navbar-spinner ')]"
+        ".//*[contains(concat(' ', normalize-space(@class), ' '), ' ",
+        token,
+        " ')]"
       )
     )
   }
 
-  spinner <- spinner_of(as.character(board_ui("test", brd)))
+  doc <- xml2::read_html(as.character(board_ui("test", brd)))
+  spinner <- by_class(doc, "blockr-navbar-spinner")
 
   # A CSS-only busy ring driven off `.shiny-busy`, announced like the lock
-  # indicator beside it.
+  # indicator.
   expect_length(spinner, 1)
   expect_identical(xml2::xml_attr(spinner, "role"), "status")
   expect_identical(xml2::xml_attr(spinner, "aria-label"), "Busy")
+
+  # Leftmost in the right-anchored navbar group: the group packs rightward, so
+  # a leftmost item's width is absorbed at its left edge and revealing the
+  # spinner shifts no visible control (#355).
+  navbar_right <- by_class(doc, "blockr-navbar-right")[[1]]
+  expect_match(
+    xml2::xml_attr(xml2::xml_children(navbar_right)[[1]], "class"),
+    "blockr-navbar-spinner",
+    fixed = TRUE
+  )
 
   # Blocks still evaluate while read-only, so the spinner survives locked mode
   # (unlike the editing chrome it sits beside).
   locked <- withr::with_options(
     list(blockr.locked = TRUE),
-    spinner_of(as.character(board_ui("test", brd)))
+    by_class(
+      xml2::read_html(as.character(board_ui("test", brd))),
+      "blockr-navbar-spinner"
+    )
   )
   expect_length(locked, 1)
+})
+
+test_that("navbar carries the spinner display delay from the option (#355)", {
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()))
+
+  navbar_style <- function(opts) {
+    html <- withr::with_options(opts, as.character(board_ui("test", brd)))
+    navbar <- xml2::xml_find_first(
+      xml2::read_html(html),
+      paste0(
+        ".//div[contains(concat(' ', normalize-space(@class), ' '), ",
+        "' blockr-navbar ')]"
+      )
+    )
+    xml2::xml_attr(navbar, "style")
+  }
+
+  # A 200 ms minimum-busy delay by default, fed into the CSS custom property
+  # the spinner's show transition reads.
+  expect_match(
+    navbar_style(list(blockr.spinner_delay_ms = NULL)),
+    "--blockr-spinner-delay: 200ms",
+    fixed = TRUE
+  )
+
+  # A caller-set delay flows through as-is; 0 restores immediate display.
+  expect_match(
+    navbar_style(list(blockr.spinner_delay_ms = 50L)),
+    "--blockr-spinner-delay: 50ms",
+    fixed = TRUE
+  )
+  expect_match(
+    navbar_style(list(blockr.spinner_delay_ms = 0L)),
+    "--blockr-spinner-delay: 0ms",
+    fixed = TRUE
+  )
+
+  # A nonsense value falls back to the default rather than emitting broken CSS.
+  expect_match(
+    navbar_style(list(blockr.spinner_delay_ms = -5L)),
+    "--blockr-spinner-delay: 200ms",
+    fixed = TRUE
+  )
 })
 
 test_that("locked mode drops the board-options accordion (#135)", {

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -842,7 +842,7 @@ test_that("single-page board renders one auto-named view (#236)", {
   expect_identical(docks$id, nav$id)
 })
 
-test_that("navbar spinner tracks real work, not bookkeeping (#285, #345)", {
+test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355)", {
 
   skip_on_cran()
 
@@ -857,25 +857,27 @@ test_that("navbar spinner tracks real work, not bookkeeping (#285, #345)", {
 
   app$wait_for_idle()
 
-  # The navbar spinner (a ring next to the gear) replaces shiny's page pulse: it
-  # turns while the session does real block evaluation. A panel switch marks the
-  # session busy (the visibility report and layout fold round-trips) without
-  # recomputing a visible output, so gating on `.shiny-busy` alone would spin
-  # for what is only layout bookkeeping; block evaluation marks its output
-  # `.recalculating` inside the view container. The live transition is a
-  # sub-second transient, racy to sample, so drive the two busy states directly
-  # and read the spinner's computed display (`none` when idle-scoped; a shown
-  # value otherwise -- `block`, since the flex navbar blockifies the shown flex
-  # item). The recalculating element is placed outside the view container (a
-  # hidden block still pending evaluation in the offcanvas pool) versus inside
-  # it (real visible work) to pin the scope.
+  # The navbar spinner replaces shiny's page pulse: it turns while the session
+  # does real block evaluation. A panel switch marks the session busy (the
+  # visibility report and layout fold round-trips) without recomputing a visible
+  # output, so gating on `.shiny-busy` alone would spin for what is only layout
+  # bookkeeping; block evaluation marks its output `.recalculating` inside the
+  # view container. The reveal toggles `visibility` (not `display`) and is held
+  # by a `transition-delay`, so drive the two busy states directly and read the
+  # spinner's computed `visibility` (`hidden` when idle-scoped, `visible` when
+  # computing) with transitions disabled -- otherwise the delayed reveal would
+  # not have landed by the time the synchronous probe reads it. The
+  # recalculating element is placed outside the view container (a hidden block
+  # still pending evaluation in the offcanvas pool) versus inside it (real
+  # visible work) to pin the scope.
   probe <- jsonlite::fromJSON(
     app$get_js(
       r"(JSON.stringify((function () {
         var html = document.documentElement;
         var spinner = document.querySelector('.blockr-navbar-spinner');
-        var display = function () {
-          return spinner ? getComputedStyle(spinner).display : null;
+        if (spinner) spinner.style.transition = 'none';
+        var vis = function () {
+          return spinner ? getComputedStyle(spinner).visibility : null;
         };
         var mark = function (parent) {
           var el = document.createElement('div');
@@ -899,15 +901,16 @@ test_that("navbar spinner tracks real work, not bookkeeping (#285, #345)", {
         real.forEach(function (el) { el.classList.remove('recalculating'); });
 
         var hidden = mark(document.body);
-        var bookkeeping = display();
+        var bookkeeping = vis();
         hidden.remove();
 
         var visible = mark(container);
-        var computing = display();
+        var computing = vis();
         visible.remove();
 
         real.forEach(function (el) { el.classList.add('recalculating'); });
         html.classList.remove('shiny-busy');
+        if (spinner) spinner.style.transition = '';
 
         return {
           pulseOff: pulseOff, hasSpinner: spinner !== null,
@@ -928,6 +931,6 @@ test_that("navbar spinner tracks real work, not bookkeeping (#285, #345)", {
   # panel switch, or a hidden block still pending in the offcanvas) keeps the
   # spinner hidden; busy with a recalculating output inside it (block
   # evaluation) shows it.
-  expect_identical(probe$bookkeeping, "none")
-  expect_identical(probe$computing, "block")
+  expect_identical(probe$bookkeeping, "hidden")
+  expect_identical(probe$computing, "visible")
 })


### PR DESCRIPTION
## Summary

- Stop the layout shift: the spinner is now the leftmost child of the right-anchored `.blockr-navbar-right`, and its toggle switches from `display:none↔inline-block` to `visibility`/`opacity`. The slot is therefore always laid out and absorbed at the group's left edge (in the empty navbar middle), so revealing it reflows nothing — verified live that the view-nav and gear move 0 px. This replaces the old "sits just before the gear" placement, which only shielded the gear while the controls to the spinner's left still jumped.
- Add a minimum-busy display delay: the show transition carries `transition-delay: var(--blockr-spinner-delay)`, set on `.blockr-navbar` from a package option (default 200 ms). If `.shiny-busy` clears before the delay elapses the transition is interrupted mid-delay and the spinner never shows, so a sub-threshold flush no longer flashes it. The hide has no delay (clears the instant work finishes), and `0` restores today's immediate behaviour. Stays CSS-only, no server observer — same design as #347.
- Option name: I wired this through the package's `blockr_option()` wrapper, so the knob is `blockr.spinner_delay_ms` (option) / `BLOCKR_SPINNER_DELAY_MS` (env), uniform with `blockr.locked`, `blockr.stack_color`, etc. — not the issue's literal `blockr.dock.spinner_delay_ms`, which no other dock option follows. A nonsense value falls back to 200 ms rather than emitting broken CSS.
- The #285/#345 e2e probe now reads the spinner's computed `visibility` (with transitions disabled so the delayed reveal doesn't race the synchronous read) instead of `display`, since `display` is now always `block` for the always-laid-out flex item. Scope semantics (real work vs bookkeeping) are unchanged.

Fixes #355