### PR TITLE
Consume core's threaded query for ?view= deep links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rmarkdown
 Remotes:
     rstudio/shinytest2,
-    BristolMyersSquibb/blockr.core,
+    BristolMyersSquibb/blockr.core@291-apply-query-params,
     cynkra/dockViewR
 Config/testthat/edition: 3
 Collate:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rmarkdown
 Remotes:
     rstudio/shinytest2,
-    BristolMyersSquibb/blockr.core@291-apply-query-params,
+    BristolMyersSquibb/blockr.core,
     cynkra/dockViewR
 Config/testthat/edition: 3
 Collate:

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -9,9 +9,15 @@ blockr_app_options.dock_board <- function(x, ...) {
 }
 
 #' @export
-blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
+blockr_app_ui.dock_board <- function(id, x, plugins, options, ...,
+                                     query = list()) {
 
   args <- list(...)
+
+  # A `?view=<id>` deep link renders the GET navbar highlight and the
+  # prioritized offcanvas card shells for that view directly rather than the
+  # default one's, so the first paint already shows the requested view.
+  x <- apply_url_view(x, query)
 
   # `options` is forwarded to `board_ui()` so the settings sidebar's
   # pre-rendered body reflects `serve(board, options = custom_options(...))`
@@ -44,12 +50,13 @@ blockr_app_ui.dock_board <- function(id, x, plugins, options, ...) {
 }
 
 #' @export
-blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
+blockr_app_server.dock_board <- function(id, x, plugins, options, ...,
+                                         query = list()) {
 
   # A `?view=<id>` deep link opens the board on that view. Applied here, before
   # board_server snapshots the board, so the first reconcile builds that view's
   # dock directly -- no default-view dock built then switched away.
-  x <- select_url_view(x)
+  x <- apply_url_view(x, query)
 
   # Core threads `plugins` to its own block server but not to board callbacks,
   # so capture them for the callback to stash on active_dock -- the deferred
@@ -65,15 +72,9 @@ blockr_app_server.dock_board <- function(id, x, plugins, options, ...) {
 
 view_url_param <- "view"
 
-select_url_view <- function(board, session = get_session()) {
+apply_url_view <- function(board, query) {
 
-  if (is.null(session)) {
-    return(board)
-  }
-
-  target <- resolve_url_view(
-    board_views(board), isolate(session$clientData$url_search)
-  )
+  target <- resolve_url_view(board_views(board), query)
 
   if (not_null(target)) {
     active_view(board) <- target
@@ -84,9 +85,9 @@ select_url_view <- function(board, session = get_session()) {
 
 # Matched by stable view id -- the immutable handle -- not the editable display
 # name; NULL when the param is absent, empty, or names no view.
-resolve_url_view <- function(views, search) {
+resolve_url_view <- function(views, query) {
 
-  sel <- parseQueryString(coal(search, ""))[[view_url_param]]
+  sel <- query[[view_url_param]]
 
   if (is.null(sel) || !nzchar(sel) || !sel %in% names(views)) {
     return(NULL)

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -38,18 +38,17 @@ test_that("resolve_url_view matches the ?view= param to a view id", {
     )
   )
 
-  expect_identical(resolve_url_view(views, "?view=Second"), "Second")
-  expect_identical(resolve_url_view(views, "?view=First"), "First")
+  expect_identical(resolve_url_view(views, list(view = "Second")), "Second")
+  expect_identical(resolve_url_view(views, list(view = "First")), "First")
 
-  # Absent, empty, unknown, or no query string all decline to select.
-  expect_null(resolve_url_view(views, "?other=1"))
-  expect_null(resolve_url_view(views, "?view="))
-  expect_null(resolve_url_view(views, "?view=nope"))
-  expect_null(resolve_url_view(views, ""))
-  expect_null(resolve_url_view(views, NULL))
+  # Absent, empty, or unknown all decline to select.
+  expect_null(resolve_url_view(views, list(other = "1")))
+  expect_null(resolve_url_view(views, list(view = "")))
+  expect_null(resolve_url_view(views, list(view = "nope")))
+  expect_null(resolve_url_view(views, list()))
 })
 
-test_that("select_url_view opens the board on the ?view= view (#323)", {
+test_that("apply_url_view opens the board on the ?view= view (#323)", {
 
   brd <- new_dock_board(
     blocks = c(a = new_dataset_block(), b = new_dataset_block()),
@@ -57,28 +56,57 @@ test_that("select_url_view opens the board on the ?view= view (#323)", {
     active = "First"
   )
 
-  fake_session <- function(search) {
-    list(clientData = list(url_search = search))
-  }
-
   # The default active view is "First", so flipping to "Second" is a real
   # (non-vacuous) change driven purely by the query param.
   expect_identical(active_view(brd), "First")
   expect_identical(
-    active_view(select_url_view(brd, fake_session("?view=Second"))),
+    active_view(apply_url_view(brd, list(view = "Second"))),
     "Second"
   )
 
-  # An unknown id, an absent param, or no session leaves the default active.
+  # An unknown id or an absent param leaves the default active.
   expect_identical(
-    active_view(select_url_view(brd, fake_session("?view=nope"))),
+    active_view(apply_url_view(brd, list(view = "nope"))),
     "First"
   )
-  expect_identical(
-    active_view(select_url_view(brd, fake_session(""))),
-    "First"
+  expect_identical(active_view(apply_url_view(brd, list())), "First")
+})
+
+test_that("blockr_app_ui threads the ?view= query into the GET nav (#357)", {
+
+  skip_if_not_installed("xml2")
+
+  board <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_dataset_block()),
+    views = list(First = blk("a"), Second = blk("b")),
+    active = "First"
   )
-  expect_identical(active_view(select_url_view(brd, NULL)), "First")
+
+  item_xpath <- sprintf(
+    "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]",
+    "blockr-view-item"
+  )
+
+  active_nav_id <- function(query) {
+
+    ui <- blockr_app_ui(
+      "test", board, blockr_app_plugins(board), blockr_app_options(board),
+      query = query
+    )
+
+    items <- xml2::xml_find_all(xml2::read_html(as.character(ui)), item_xpath)
+    is_active <- grepl("(^| )active( |$)", xml2::xml_attr(items, "class"))
+
+    xml2::xml_attr(items, "data-view-id")[is_active]
+  }
+
+  # Absent the param, the GET nav highlights the board's default active view.
+  expect_identical(active_nav_id(list()), "First")
+
+  # `?view=Second` pre-sets active_view before board_ui, so the GET nav
+  # highlights Second -- the query is consumed by the method, not splatted into
+  # page_fillable (without the `query` formal it would leak through `...`).
+  expect_identical(active_nav_id(list(view = "Second")), "Second")
 })
 
 test_that("grids_stable holds when the live grid is the stored fixed point", {


### PR DESCRIPTION
## Summary

- `blockr_app_ui.dock_board()` and `blockr_app_server.dock_board()` gain a `query` formal and pre-set `active_view` from `query[["view"]]` (via `resolve_url_view()`) at both the GET and the websocket phase, so the first paint already renders the requested view's navbar highlight and prioritized card shells instead of the default view's (previously corrected on connect, a brief flash).
- Retires the server-only `select_url_view()` shim: the `session$clientData$url_search` read now lives in core's shared `resolve_query()`, threaded into the builders by BristolMyersSquibb/blockr.core#293. `resolve_url_view()` now takes the parsed `query` list rather than a raw search string.
- Adds a unit test asserting the GET-rendered nav highlights the `?view=` view — proving the threaded `query` is consumed by the method rather than splatted into `page_fillable` as a stray child (which is what would happen without the `query` formal).

## Coordination — blocks on core#293

Draft until BristolMyersSquibb/blockr.core#293 lands. Core threads the parsed `query` into the app UI/server builders there; dropping the server-only shim before that exists would break `?view=` against core `main`, so this must land after (or together with) #293. `DESCRIPTION` temporarily pins `BristolMyersSquibb/blockr.core@291-apply-query-params` so CI resolves against that branch — unpin once #293 is on `main`.

Fixes #357