### PR TITLE
Keep navbar busy spinner always visible, beside the gear

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -145,14 +145,15 @@
   the stable condition id, so a persistent warning no longer flashes on every
   re-evaluation.
 * The intrusive page-wide busy pulse is replaced by a small, unobtrusive
-  spinner in the navbar. It turns while the session does real block evaluation
-  and disappears otherwise -- scoped (as the pulse was) to a genuinely
-  recomputing output in the visible view, so startup and block evaluation spin
-  it while a bare panel switch does not. It is anchored at the left of the
-  navbar's right-hand controls, so revealing or clearing it never shifts them,
-  and a configurable minimum-busy delay (`blockr.spinner_delay_ms`, default
-  200 ms; `0` to disable) holds the reveal so a sub-threshold flush no longer
-  flashes it (#345, #355).
+  spinner in the navbar, just left of the board-options gear. It always
+  occupies its slot as a dim, static ring and, while the session does real
+  block evaluation, rises to full contrast and spins -- scoped (as the pulse
+  was) to a genuinely recomputing output in the visible view, so startup and
+  block evaluation liven it while a bare panel switch does not. Because it is
+  always present it never shifts its neighbours and never blinks in or out; a
+  configurable minimum-busy delay (`blockr.spinner_delay_ms`, default 200 ms;
+  `0` to disable) holds the transition to the busy state so a sub-threshold
+  flush no longer flashes it (#345, #355, #360).
 * The "Edit board" extension no longer churns on a board re-emit -- it re-syncs
   its staged working copy only when links or stacks actually change, stops
   flickering the manage-links cell inputs, and overlays half-finished staged

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -47,20 +47,6 @@ board_ui.dock_board <- function(
       ),
       div(
         class = "blockr-navbar-right",
-        # Busy spinner. Shown/hidden purely by CSS off the `.shiny-busy` class
-        # Shiny toggles on <html> during a flush -- no server observer -- and
-        # scoped to real block evaluation so a bare panel switch does not spin
-        # it. Placed leftmost in this right-anchored group: the group packs
-        # rightward, so its always-present (visibility-toggled) slot is absorbed
-        # at the group's left edge, in the empty navbar middle -- no visible
-        # control shifts when it reveals. The reveal is held for
-        # `--blockr-spinner-delay` ms (set on the navbar above) so a sub-
-        # threshold flush never flashes it. Announced like the lock indicator.
-        tags$span(
-          class = "blockr-navbar-spinner",
-          role = "status",
-          `aria-label` = "Busy"
-        ),
         v_nav,
         if (is_dock_locked()) {
           tags$span(
@@ -75,6 +61,20 @@ board_ui.dock_board <- function(
             )
           )
         },
+        # Busy spinner. Always rendered and always visible, driven purely by CSS
+        # off the `.shiny-busy` class Shiny toggles on <html> during a flush --
+        # no server observer. Idle it is a dim, static ring; a flush scoped to
+        # real block evaluation (a bare panel switch does not qualify) raises it
+        # to full contrast and spins it. It sits just left of the gear; because
+        # it is always painted (never shown/hidden) its constant slot shifts no
+        # neighbour. The switch to the busy appearance is held for
+        # `--blockr-spinner-delay` ms (set on the navbar above) so a sub-
+        # threshold flush never flickers it. Announced like the lock indicator.
+        tags$span(
+          class = "blockr-navbar-spinner",
+          role = "status",
+          `aria-label` = "Busy"
+        ),
         # Pure-JS open trigger via `data-blockr-sidebar-target`. The
         # settings sidebar's body is pre-rendered into its mount below, so
         # no server observer is needed: clicking the gear toggles the

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -1185,29 +1185,30 @@ label:has(input[type="file"]) {
    container, so a pending hidden block never spins the navbar. Startup and real
    recompute spin; a bare panel switch does not.
 
-   Reveal is by `visibility`/`opacity`, not `display`, so the slot is always
-   laid out (leftmost in the navbar's right-hand group, absorbed at that group's
-   left edge) and showing it never reflows a neighbour. The show transition
-   carries `transition-delay: var(--blockr-spinner-delay)` -- set on
-   `.blockr-navbar` from the `spinner_delay_ms` option -- while the hide has no
-   delay. So the ring appears only once the session has stayed busy for the full
-   delay (a flush that clears sooner is interrupted mid-delay and never shows)
-   and it clears the instant work finishes. */
+   The slot is always laid out and always painted -- there is no show/hide, so
+   nothing ever blinks in or out and it reflows no neighbour wherever it sits;
+   it rests just left of the navbar gear. Idle it is a dim, static ring; a busy
+   flush raises it to full contrast and spins it. Both the contrast raise (a 0s
+   `opacity` transition) and the spin (an `animation-delay`) are held by
+   `var(--blockr-spinner-delay)` -- set on `.blockr-navbar` from the
+   `spinner_delay_ms` option -- while the return to the dim idle ring carries no
+   delay. So the ring livens only once the session has stayed busy for the full
+   delay (a flush that clears sooner is interrupted mid-delay and never livens)
+   and it settles back the instant work finishes. */
 .blockr-navbar-spinner {
-  visibility: hidden;
-  opacity: 0;
   width: 16px;
   height: 16px;
   border: 2px solid var(--blockr-color-text-muted);
   border-right-color: transparent;
   border-radius: 50%;
-  animation: blockr-navbar-spin 0.7s linear infinite;
-  transition: opacity 0s, visibility 0s;
+  opacity: 0.35;
+  transition: opacity 0s;
 }
 
 html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinner {
-  visibility: visible;
   opacity: 1;
+  animation: blockr-navbar-spin 0.7s linear infinite;
+  animation-delay: var(--blockr-spinner-delay, 0ms);
   transition-delay: var(--blockr-spinner-delay, 0ms);
 }
 
@@ -1218,7 +1219,7 @@ html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinne
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .blockr-navbar-spinner {
+  html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinner {
     animation: none;
   }
 }

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -137,7 +137,7 @@ test_that("locked mode renders a navbar lock indicator", {
   expect_match(locked_html, ">Read-only<", fixed = TRUE)
 })
 
-test_that("navbar busy spinner is leftmost and announced (#345, #355)", {
+test_that("navbar busy spinner sits left of the gear (#345, #355, #360)", {
 
   brd <- new_dock_board(blocks = c(a = new_dataset_block()))
 
@@ -161,15 +161,11 @@ test_that("navbar busy spinner is leftmost and announced (#345, #355)", {
   expect_identical(xml2::xml_attr(spinner, "role"), "status")
   expect_identical(xml2::xml_attr(spinner, "aria-label"), "Busy")
 
-  # Leftmost in the right-anchored navbar group: the group packs rightward, so
-  # a leftmost item's width is absorbed at its left edge and revealing the
-  # spinner shifts no visible control (#355).
-  navbar_right <- by_class(doc, "blockr-navbar-right")[[1]]
-  expect_match(
-    xml2::xml_attr(xml2::xml_children(navbar_right)[[1]], "class"),
-    "blockr-navbar-spinner",
-    fixed = TRUE
-  )
+  # Sits immediately left of the board-options gear. It no longer toggles on
+  # and off (always painted, dim when idle), so it need not hide at the group's
+  # left edge -- it rests beside the gear instead.
+  gear <- xml2::xml_find_first(spinner[[1]], "following-sibling::*[1]")
+  expect_identical(xml2::xml_attr(gear, "aria-label"), "Board options")
 
   # Blocks still evaluate while read-only, so the spinner survives locked mode
   # (unlike the editing chrome it sits beside).

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -842,7 +842,7 @@ test_that("single-page board renders one auto-named view (#236)", {
   expect_identical(docks$id, nav$id)
 })
 
-test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355)", {
+test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355, #360)", {
 
   skip_on_cran()
 
@@ -862,13 +862,14 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355)", {
   # visibility report and layout fold round-trips) without recomputing a visible
   # output, so gating on `.shiny-busy` alone would spin for what is only layout
   # bookkeeping; block evaluation marks its output `.recalculating` inside the
-  # view container. The reveal toggles `visibility` (not `display`) and is held
-  # by a `transition-delay`, so drive the two busy states directly and read the
-  # spinner's computed `visibility` (`hidden` when idle-scoped, `visible` when
-  # computing) with transitions disabled -- otherwise the delayed reveal would
-  # not have landed by the time the synchronous probe reads it. The
-  # recalculating element is placed outside the view container (a hidden block
-  # still pending evaluation in the offcanvas pool) versus inside it (real
+  # view container. The ring is always visible: the busy scope raises its
+  # contrast (dim when idle, full opacity when busy) rather than toggling its
+  # presence, and the raise is held by a `transition-delay`, so drive the two
+  # busy states directly and read the spinner's computed `opacity` (dim when
+  # idle-scoped, full when computing) with transitions disabled -- otherwise the
+  # delayed raise would not have landed by the time the synchronous probe reads
+  # it. The recalculating element is placed outside the view container (a hidden
+  # block still pending evaluation in the offcanvas pool) versus inside it (real
   # visible work) to pin the scope.
   probe <- jsonlite::fromJSON(
     app$get_js(
@@ -876,8 +877,8 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355)", {
         var html = document.documentElement;
         var spinner = document.querySelector('.blockr-navbar-spinner');
         if (spinner) spinner.style.transition = 'none';
-        var vis = function () {
-          return spinner ? getComputedStyle(spinner).visibility : null;
+        var opacity = function () {
+          return spinner ? parseFloat(getComputedStyle(spinner).opacity) : null;
         };
         var mark = function (parent) {
           var el = document.createElement('div');
@@ -901,11 +902,11 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355)", {
         real.forEach(function (el) { el.classList.remove('recalculating'); });
 
         var hidden = mark(document.body);
-        var bookkeeping = vis();
+        var bookkeeping = opacity();
         hidden.remove();
 
         var visible = mark(container);
-        var computing = vis();
+        var computing = opacity();
         visible.remove();
 
         real.forEach(function (el) { el.classList.add('recalculating'); });
@@ -928,9 +929,11 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355)", {
   expect_true(probe$hasContainer)
 
   # Busy with a recalculating output only outside the view container (a bare
-  # panel switch, or a hidden block still pending in the offcanvas) keeps the
-  # spinner hidden; busy with a recalculating output inside it (block
-  # evaluation) shows it.
-  expect_identical(probe$bookkeeping, "hidden")
-  expect_identical(probe$computing, "visible")
+  # panel switch, or a hidden block still pending in the offcanvas) leaves the
+  # always-present ring painted but dim; busy with a recalculating output inside
+  # it (block evaluation) lifts it to full contrast. The idle ring stays visible
+  # (opacity > 0) rather than toggling off -- the always-on behaviour.
+  expect_gt(probe$bookkeeping, 0)
+  expect_lt(probe$bookkeeping, 1)
+  expect_equal(probe$computing, 1)
 })


### PR DESCRIPTION
## Summary

- The navbar busy spinner no longer toggles between hidden and shown. It always occupies its slot as a dim, static ring and only raises contrast and spins while a block is genuinely recalculating in the visible view, so it never blinks in or out (the #360 ask, following #356).
- The minimum-busy delay (`blockr.spinner_delay_ms`) now holds both the contrast raise (a 0s `opacity` transition) and the spin start (an `animation-delay`), so a sub-threshold flush shows no change at all; the return to the dim idle ring is instant.
- `prefers-reduced-motion` is respected: the busy state raises contrast without the spin.
- With the appear/disappear gone, the leftmost placement (#355, chosen only to hide the layout shift) is no longer needed. The spinner moves to sit just left of the board-options gear.
- One consequence of always-rendering: the `role="status"` span now stays in the accessibility tree when idle, matching the always-present lock indicator it sits beside.

Fixes #360
