### PR TITLE
Keep the navbar busy spinner turning under reduced motion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,13 @@
   as the free-text summary; the earlier `extension_description()` accessor is
   deprecated in favour of `ext_desc()` (#359).
 
+* The navbar busy spinner keeps turning when the browser reports
+  `prefers-reduced-motion: reduce`, at a slower 1.6s turn instead of 0.7s.
+  It previously dropped the animation entirely, which left a fully styled
+  ring frozen in the navbar and reading as a hung session. Windows maps its
+  "Animation effects: off" setting (a common managed / VDI default) onto that
+  preference, so on those machines the spinner never moved.
+
 * Views (pages) can now be reordered from the nav dropdown: each item carries
   up / down controls beside its rename and remove actions. Order is board
   content, so the move travels through the update lifecycle as a new

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,11 @@
   "Animation effects: off" setting (a common managed / VDI default) onto that
   preference, so on those machines the spinner never moved.
 
+* Idle, the navbar busy spinner is now a faint, closed ring rather than a
+  gapped three-quarter circle that read as an oversized "C" wherever it sits.
+  The darker arc that signals motion is painted on only while the board is
+  busy; at rest the ring is a single muted colour and recedes into the navbar.
+
 * Views (pages) can now be reordered from the nav dropdown: each item carries
   up / down controls beside its rename and remove actions. Order is board
   content, so the move travels through the update lifecycle as a new

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -47,6 +47,26 @@ board_ui.dock_board <- function(
       ),
       div(
         class = "blockr-navbar-right",
+        # Busy spinner. Always rendered and always visible, driven purely by CSS
+        # off the `.shiny-busy` class Shiny toggles on <html> during a flush --
+        # no server observer. Idle it is a faint, closed ring; a flush scoped to
+        # real block evaluation (a bare panel switch does not qualify) paints a
+        # darker arc onto it and spins it. It leads this right group (ahead of
+        # the view nav), where its 16px ring is not juxtaposed against the
+        # smaller gear; because it is always painted (never shown/hidden) its
+        # constant slot shifts no neighbour. The busy appearance is held for
+        # `--blockr-spinner-delay` ms (set on the navbar above), so a
+        # sub-threshold flush never flickers it. The ring spins inside a static
+        # slot that carries a hover tooltip naming the state (idle / computing),
+        # so the label does not turn with it. Announced like the lock indicator.
+        tags$span(
+          class = "blockr-navbar-spinner-slot",
+          tags$span(
+            class = "blockr-navbar-spinner",
+            role = "status",
+            `aria-label` = "Busy"
+          )
+        ),
         v_nav,
         if (is_dock_locked()) {
           tags$span(
@@ -61,20 +81,6 @@ board_ui.dock_board <- function(
             )
           )
         },
-        # Busy spinner. Always rendered and always visible, driven purely by CSS
-        # off the `.shiny-busy` class Shiny toggles on <html> during a flush --
-        # no server observer. Idle it is a dim, static ring; a flush scoped to
-        # real block evaluation (a bare panel switch does not qualify) raises it
-        # to full contrast and spins it. It sits just left of the gear; because
-        # it is always painted (never shown/hidden) its constant slot shifts no
-        # neighbour. The switch to the busy appearance is held for
-        # `--blockr-spinner-delay` ms (set on the navbar above) so a sub-
-        # threshold flush never flickers it. Announced like the lock indicator.
-        tags$span(
-          class = "blockr-navbar-spinner",
-          role = "status",
-          `aria-label` = "Busy"
-        ),
         # Pure-JS open trigger via `data-blockr-sidebar-target`. The
         # settings sidebar's body is pre-rendered into its mount below, so
         # no server observer is needed: clicking the gear toggles the

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -1218,8 +1218,19 @@ html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinne
   }
 }
 
+/* Reduced motion slows the ring, it does not stop it. Stopping it leaves a
+   fully styled ring frozen in the navbar, which reads as a hung session --
+   the exact opposite of what a busy indicator is for -- and it is the only
+   state the indicator can be seen in, since it is hidden when idle. A 16px
+   ring turning in place carries none of the vestibular risk the preference
+   exists to avoid (it is not page-level or parallax motion), so the honest
+   reading of the preference here is "calmer", not "gone".
+
+   This is not a rare corner: Windows maps "Animation effects: off" (a common
+   managed / VDI default) onto `prefers-reduced-motion: reduce`, so on those
+   machines every Edge user saw a spinner that never moved. */
 @media (prefers-reduced-motion: reduce) {
   html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinner {
-    animation: none;
+    animation-duration: 1.6s;
   }
 }

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -1187,26 +1187,24 @@ label:has(input[type="file"]) {
 
    The slot is always laid out and always painted -- there is no show/hide, so
    nothing ever blinks in or out and it reflows no neighbour wherever it sits;
-   it rests just left of the navbar gear. Idle it is a dim, static ring; a busy
-   flush raises it to full contrast and spins it. Both the contrast raise (a 0s
-   `opacity` transition) and the spin (an `animation-delay`) are held by
-   `var(--blockr-spinner-delay)` -- set on `.blockr-navbar` from the
-   `spinner_delay_ms` option -- while the return to the dim idle ring carries no
-   delay. So the ring livens only once the session has stayed busy for the full
-   delay (a flush that clears sooner is interrupted mid-delay and never livens)
-   and it settles back the instant work finishes. */
+   it rests just left of the navbar gear. Idle it is a faint, closed ring (a
+   track in one muted colour); a busy flush paints a darker arc onto that ring
+   and spins it. Both the arc (a 0s `border-top-color` transition) and the spin
+   (an `animation-delay`) are held by `var(--blockr-spinner-delay)` -- set on
+   `.blockr-navbar` from the `spinner_delay_ms` option -- while the return to the
+   bare idle ring carries no delay. So the arc appears only once the session has
+   stayed busy for the full delay (a flush that clears sooner is interrupted
+   mid-delay and never shows one) and it clears the instant work finishes. */
 .blockr-navbar-spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid var(--blockr-color-text-muted);
-  border-right-color: transparent;
+  border: 2px solid color-mix(in srgb, var(--blockr-color-text-muted) 30%, transparent);
   border-radius: 50%;
-  opacity: 0.35;
-  transition: opacity 0s;
+  transition: border-top-color 0s;
 }
 
 html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinner {
-  opacity: 1;
+  border-top-color: var(--blockr-color-text-muted);
   animation: blockr-navbar-spin 0.7s linear infinite;
   animation-delay: var(--blockr-spinner-delay, 0ms);
   transition-delay: var(--blockr-spinner-delay, 0ms);

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -1187,7 +1187,8 @@ label:has(input[type="file"]) {
 
    The slot is always laid out and always painted -- there is no show/hide, so
    nothing ever blinks in or out and it reflows no neighbour wherever it sits;
-   it rests just left of the navbar gear. Idle it is a faint, closed ring (a
+   it leads the navbar's right group, ahead of the view nav. Idle it is a
+   faint, closed ring (a
    track in one muted colour); a busy flush paints a darker arc onto that ring
    and spins it. Both the arc (a 0s `border-top-color` transition) and the spin
    (an `animation-delay`) are held by `var(--blockr-spinner-delay)` -- set on
@@ -1208,6 +1209,43 @@ html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinne
   animation: blockr-navbar-spin 0.7s linear infinite;
   animation-delay: var(--blockr-spinner-delay, 0ms);
   transition-delay: var(--blockr-spinner-delay, 0ms);
+}
+
+/* Hover tooltip. The ring spins, so its label hangs off the static slot that
+   wraps it -- on the ring itself the spin transform would turn the text too.
+   CSS-only, like the ring: the label switches on the same busy scope that paints
+   the arc, so it needs no server observer. */
+.blockr-navbar-spinner-slot {
+  display: inline-flex;
+  position: relative;
+}
+
+.blockr-navbar-spinner-slot::after {
+  content: "Idle";
+  position: absolute;
+  top: calc(100% + 7px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--blockr-grey-900);
+  color: #fff;
+  font-size: var(--blockr-font-size-xs);
+  line-height: 1.5;
+  white-space: nowrap;
+  box-shadow: var(--blockr-shadow);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  z-index: 1080;
+}
+
+html.shiny-busy:has(.blockr-view-container .recalculating) .blockr-navbar-spinner-slot::after {
+  content: "Computing";
+}
+
+.blockr-navbar-spinner-slot:hover::after {
+  opacity: 1;
 }
 
 @keyframes blockr-navbar-spin {

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -137,7 +137,7 @@ test_that("locked mode renders a navbar lock indicator", {
   expect_match(locked_html, ">Read-only<", fixed = TRUE)
 })
 
-test_that("navbar busy spinner sits left of the gear (#345, #355, #360)", {
+test_that("navbar busy spinner leads the right group (#345, #355, #360)", {
 
   brd <- new_dock_board(blocks = c(a = new_dataset_block()))
 
@@ -161,14 +161,18 @@ test_that("navbar busy spinner sits left of the gear (#345, #355, #360)", {
   expect_identical(xml2::xml_attr(spinner, "role"), "status")
   expect_identical(xml2::xml_attr(spinner, "aria-label"), "Busy")
 
-  # Sits immediately left of the board-options gear. It no longer toggles on
-  # and off (always painted, dim when idle), so it need not hide at the group's
-  # left edge -- it rests beside the gear instead.
-  gear <- xml2::xml_find_first(spinner[[1]], "following-sibling::*[1]")
-  expect_identical(xml2::xml_attr(gear, "aria-label"), "Board options")
+  # The ring sits in a static slot (which carries the hover tooltip); the slot
+  # leads the navbar's right group, ahead of the view nav, so the ring is not
+  # juxtaposed against the smaller gear. Always painted, no edge to hide at.
+  slot <- by_class(doc, "blockr-navbar-spinner-slot")
+  expect_length(slot, 1)
+  expect_length(by_class(slot[[1]], "blockr-navbar-spinner"), 1)
+  expect_length(xml2::xml_find_all(slot[[1]], "preceding-sibling::*"), 0)
+  group_class <- xml2::xml_attr(xml2::xml_parent(slot[[1]]), "class")
+  expect_match(group_class, "blockr-navbar-right", fixed = TRUE)
 
   # Blocks still evaluate while read-only, so the spinner survives locked mode
-  # (unlike the editing chrome it sits beside).
+  # (unlike the editing chrome in that group).
   locked <- withr::with_options(
     list(blockr.locked = TRUE),
     by_class(
@@ -252,6 +256,43 @@ test_that("the idle navbar spinner is a closed ring, the arc is busy-only", {
   expect_length(base, 1L)
   expect_no_match(base, "border-\\w+-color:\\s*transparent")
   expect_match(busy, "border-top-color", fixed = TRUE)
+})
+
+test_that("the spinner's hover tooltip names its state", {
+
+  # CSS-only, like the ring: on hover the slot names its state, switching from
+  # "Idle" to "Computing" on the busy scope -- on the busy selector, not the
+  # base rule.
+  css <- paste(
+    readLines(
+      system.file(
+        "assets", "css", "blockr-dock.css",
+        package = "blockr.dock",
+        mustWork = TRUE
+      ),
+      warn = FALSE
+    ),
+    collapse = "\n"
+  )
+
+  idle <- regmatches(
+    css,
+    regexpr(
+      "(?m)^\\.blockr-navbar-spinner-slot::after \\{[^}]*\\}",
+      css, perl = TRUE
+    )
+  )
+
+  busy <- regmatches(
+    css,
+    regexpr(
+      "(?s)html\\.shiny-busy:has[^{]*-slot::after \\{[^}]*\\}",
+      css, perl = TRUE
+    )
+  )
+
+  expect_match(idle, "content: \"Idle\"", fixed = TRUE)
+  expect_match(busy, "content: \"Computing\"", fixed = TRUE)
 })
 
 test_that("navbar carries the spinner display delay from the option (#355)", {

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -217,6 +217,43 @@ test_that("the busy spinner still turns under reduced motion", {
   expect_no_match(reduced, "animation:\\s*none")
 })
 
+test_that("the idle navbar spinner is a closed ring, the arc is busy-only", {
+
+  # Same rationale as the reduced-motion assertion: the spinner's states are
+  # only ever seen mid-flush. Idle must be a full ring -- no transparent gap,
+  # or it reads as an oversized "C" -- and the darker arc that signals motion
+  # belongs on the busy selector, not the base rule.
+  css <- paste(
+    readLines(
+      system.file(
+        "assets", "css", "blockr-dock.css",
+        package = "blockr.dock",
+        mustWork = TRUE
+      ),
+      warn = FALSE
+    ),
+    collapse = "\n"
+  )
+
+  base <- regmatches(
+    css,
+    regexpr("(?m)^\\.blockr-navbar-spinner \\{[^}]*\\}", css, perl = TRUE)
+  )
+
+  busy <- regmatches(
+    css,
+    regexpr(
+      "(?s)html\\.shiny-busy:has[^{]*\\.blockr-navbar-spinner \\{[^}]*\\}",
+      css,
+      perl = TRUE
+    )
+  )
+
+  expect_length(base, 1L)
+  expect_no_match(base, "border-\\w+-color:\\s*transparent")
+  expect_match(busy, "border-top-color", fixed = TRUE)
+})
+
 test_that("navbar carries the spinner display delay from the option (#355)", {
 
   brd <- new_dock_board(blocks = c(a = new_dataset_block()))

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -179,6 +179,44 @@ test_that("navbar busy spinner sits left of the gear (#345, #355, #360)", {
   expect_length(locked, 1)
 })
 
+test_that("the busy spinner still turns under reduced motion", {
+
+  # A stylesheet assertion because nothing else can catch this: the spinner is
+  # only ever seen mid-flush, and CI never runs with the preference set. When
+  # the reduced-motion block killed the animation outright, the ring rendered
+  # perfectly and sat frozen -- indistinguishable from a hung session -- for
+  # every user whose OS reports the preference (Windows does so whenever
+  # "Animation effects" is off). Slower is fine here; stopped is not.
+  css <- paste(
+    readLines(
+      system.file(
+        "assets", "css", "blockr-dock.css",
+        package = "blockr.dock",
+        mustWork = TRUE
+      ),
+      warn = FALSE
+    ),
+    collapse = "\n"
+  )
+
+  reduced <- regmatches(
+    css,
+    regexpr(
+      "(?s)@media \\(prefers-reduced-motion: reduce\\).*?\\n\\}",
+      css,
+      perl = TRUE
+    )
+  )
+
+  expect_length(reduced, 1L)
+
+  # Must slow the busy selector that carries the spin; on the bare
+  # `.blockr-navbar-spinner` the override is outspecified and does nothing.
+  expect_match(reduced, "html.shiny-busy:has", fixed = TRUE)
+  expect_match(reduced, "animation-duration: 1.6s", fixed = TRUE)
+  expect_no_match(reduced, "animation:\\s*none")
+})
+
 test_that("navbar carries the spinner display delay from the option (#355)", {
 
   brd <- new_dock_board(blocks = c(a = new_dataset_block()))

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -899,12 +899,13 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355, #360)", {
   # visibility report and layout fold round-trips) without recomputing a visible
   # output, so gating on `.shiny-busy` alone would spin for what is only layout
   # bookkeeping; block evaluation marks its output `.recalculating` inside the
-  # view container. The ring is always visible: the busy scope raises its
-  # contrast (dim when idle, full opacity when busy) rather than toggling its
-  # presence, and the raise is held by a `transition-delay`, so drive the two
-  # busy states directly and read the spinner's computed `opacity` (dim when
-  # idle-scoped, full when computing) with transitions disabled -- otherwise the
-  # delayed raise would not have landed by the time the synchronous probe reads
+  # view container. The ring is always painted: the busy scope adds a darker arc
+  # (a `border-top-color` distinct from the faint track the other sides carry)
+  # rather than toggling its presence, and the arc is held by a
+  # `transition-delay`, so drive the two busy states directly and read whether
+  # the top border differs from a side border (arc present when computing,
+  # absent when only bookkeeping) with transitions disabled -- otherwise the
+  # delayed arc would not have landed by the time the synchronous probe reads
   # it. The recalculating element is placed outside the view container (a hidden
   # block still pending evaluation in the offcanvas pool) versus inside it (real
   # visible work) to pin the scope.
@@ -914,8 +915,10 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355, #360)", {
         var html = document.documentElement;
         var spinner = document.querySelector('.blockr-navbar-spinner');
         if (spinner) spinner.style.transition = 'none';
-        var opacity = function () {
-          return spinner ? parseFloat(getComputedStyle(spinner).opacity) : null;
+        var arc = function () {
+          if (!spinner) return null;
+          var cs = getComputedStyle(spinner);
+          return { top: cs.borderTopColor, side: cs.borderRightColor };
         };
         var mark = function (parent) {
           var el = document.createElement('div');
@@ -939,21 +942,25 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355, #360)", {
         real.forEach(function (el) { el.classList.remove('recalculating'); });
 
         var hidden = mark(document.body);
-        var bookkeeping = opacity();
+        var bookkeeping = arc();
         hidden.remove();
 
         var visible = mark(container);
-        var computing = opacity();
+        var computing = arc();
         visible.remove();
 
         real.forEach(function (el) { el.classList.add('recalculating'); });
         html.classList.remove('shiny-busy');
         if (spinner) spinner.style.transition = '';
 
+        var painted = bookkeeping && bookkeeping.side !== 'rgba(0, 0, 0, 0)';
+        var bkArc = bookkeeping && bookkeeping.top !== bookkeeping.side;
+        var coArc = computing && computing.top !== computing.side;
+
         return {
           pulseOff: pulseOff, hasSpinner: spinner !== null,
           hasContainer: container !== null,
-          bookkeeping: bookkeeping, computing: computing
+          trackPainted: painted, bookkeepingArc: bkArc, computingArc: coArc
         };
       })()))"
     )
@@ -967,10 +974,10 @@ test_that("navbar spinner: real work vs bookkeeping (#285, #345, #355, #360)", {
 
   # Busy with a recalculating output only outside the view container (a bare
   # panel switch, or a hidden block still pending in the offcanvas) leaves the
-  # always-present ring painted but dim; busy with a recalculating output inside
-  # it (block evaluation) lifts it to full contrast. The idle ring stays visible
-  # (opacity > 0) rather than toggling off -- the always-on behaviour.
-  expect_gt(probe$bookkeeping, 0)
-  expect_lt(probe$bookkeeping, 1)
-  expect_equal(probe$computing, 1)
+  # ring as a bare track -- no arc; busy with a recalculating output inside it
+  # (block evaluation) paints the darker arc on. The track itself stays painted
+  # rather than toggling off -- the always-on behaviour.
+  expect_true(probe$trackPainted)
+  expect_false(probe$bookkeepingArc)
+  expect_true(probe$computingArc)
 })


### PR DESCRIPTION
The reduced-motion block dropped the ring's animation outright. Since the spinner is hidden when idle, "frozen" was the only state those users ever saw it in: a fully styled ring sitting still in the navbar, reading as a hung session rather than a busy one.

Windows maps its "Animation effects: off" setting -- a common managed / VDI default -- onto prefers-reduced-motion: reduce, so this hit every Edge user on such a machine while spinning fine on a developer laptop.

Slow the turn to 1.6s instead of stopping it. A 16px ring turning in place is not the page-level motion the preference exists to suppress.

Guarded by a stylesheet assertion, because nothing else can catch it: the spinner is only ever seen mid-flush and CI never runs with the preference set.