### PR TITLE
Render blocks on non-front dock tabs again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
 Remotes:
     rstudio/shinytest2,
     BristolMyersSquibb/blockr.core,
-    cynkra/dockViewR@92-retire-state-source
+    cynkra/dockViewR@95-panel-mount-event
 Config/testthat/edition: 3
 Collate:
     'action-class.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* Blocks on a dock group's background tabs render again. dockView mounts a
+  group's non-front tabs lazily, so a block card's `move-element` could arrive
+  before its panel existed and be dropped, stranding the card in the offcanvas;
+  and a bare tab switch did not mark the newly-fronted block visible. Both left
+  non-front tabs blank. A dropped move is now stashed and replayed when dockView
+  reports the panel active (dockViewR's `dockview:active-panel` event), and the
+  visible mark follows the client's live active-panel signal, so selecting a tab
+  paints its block (#361).
+
 * Dock extensions can now carry structured, model-facing metadata: the
   `description` argument of `new_dock_extension()` accepts a `new_ext_meta()`
   object documenting each externally controllable variable (with an optional

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -253,23 +253,23 @@ switch_view_observer <- function(session, update, client_active, board, docks,
 
 report_visible_observer <- function(visibility, client_active, docks) {
 
-  # Drives both visibility axes off one live client signal: the active view's
-  # settled `_state` layout echo (`dock$layout()`), the arrangement dockView
-  # actually painted. Over the built cards, the front panels go required TRUE
-  # and are marked painted on the visible axis (the client-confirmed paint
-  # core's render gate waits for); everything else built goes required FALSE
-  # with its visible slot cleared. Sourcing the visible mark here, off the same
-  # live echo the required axis tracks, is what lets it follow a front tab the
-  # client owns -- which can differ from the grid's stored active -- and re-mark
-  # when the user switches tabs, instead of naming a one-shot `init_layout`
-  # snapshot that never recovers.
-  # `req(layout())` waits for the client's report (NULL before then).
+  # Drives both visibility axes off two live client signals: the active view's
+  # settled `_state` layout echo (`dock$layout()`, the arrangement dockView
+  # painted) and its live active panel (`dock$active_panel()`). Over the built
+  # cards, the front panels go required TRUE and are marked painted on the
+  # visible axis (the client-confirmed paint core's render gate waits for);
+  # everything else built goes required FALSE with its visible slot cleared.
+  # A bare tab switch does not reliably re-echo `_state` (only structural
+  # gestures do), so the active panel is folded in as the front of its group --
+  # otherwise a newly-fronted tab is never marked visible and its block stays
+  # blank until a structural change. `req(layout())` waits for the client's
+  # first report (NULL before then); `active_panel()` is NULL until a switch.
   on_screen <- reactive({
     active <- req(client_active())
     dock <- req(docks[[active]])
     layout <- req(dock$layout())
 
-    sort(visible_block_ids(layout))
+    sort(visible_block_ids(layout, dock$active_panel()))
   })
 
   observeEvent(
@@ -707,6 +707,7 @@ manage_dock <- function(
       board_ns = board_ns,
       live_panels = live_panels,
       layout = reactive(dockViewR::get_dock(proxy)),
+      active_panel = reactive(input[[dock_input("active-panel")]]),
       n_panels = n_panels,
       prev_active_group = prev_active_group,
       active_group_trail = active_group_trail,

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -44,7 +44,7 @@ move_dom_element <- function(from, to, session = get_session()) {
   )
 }
 
-determine_active_views <- function(layout) {
+determine_active_views <- function(layout, active_panel = NULL) {
 
   if (is.null(layout)) {
     return(character())
@@ -52,7 +52,9 @@ determine_active_views <- function(layout) {
 
   # The dockView tree, keyed by group id: a compact `dock_grid` is expanded
   # (assigning ids), while a raw dockView `_state` echo already carries its
-  # tree at `$grid`. A group's active view is its open tab.
+  # tree at `$grid`. A group's active view is its open tab -- but a bare tab
+  # switch does not always refresh the echo's `activeView`, so the client's
+  # live `active_panel` overrides the front of whichever group lists it.
   tree <- if (is_dock_grid(layout)) grid_to_tree(layout) else layout[["grid"]]
 
   root <- tree[["root"]]
@@ -64,10 +66,15 @@ determine_active_views <- function(layout) {
   xtr_leaf <- function(x) {
 
     if (identical(x[["type"]], "leaf")) {
-      return(
-        set_names(coal(x[["data"]][["activeView"]], "", fail_all = FALSE),
-                  x[["data"]][["id"]])
-      )
+
+      front <- if (not_null(active_panel) &&
+                     active_panel %in% x[["data"]][["views"]]) {
+        active_panel
+      } else {
+        coal(x[["data"]][["activeView"]], "", fail_all = FALSE)
+      }
+
+      return(set_names(front, x[["data"]][["id"]]))
     }
 
     lapply(x[["data"]], xtr_leaf)
@@ -76,9 +83,9 @@ determine_active_views <- function(layout) {
   rapply(xtr_leaf(root), identity, "character")
 }
 
-visible_block_ids <- function(layout) {
+visible_block_ids <- function(layout, active_panel = NULL) {
 
-  front_panels <- as.character(determine_active_views(layout))
+  front_panels <- as.character(determine_active_views(layout, active_panel))
   block_panels <- front_panels[maybe_block_panel_id(front_panels)]
 
   as_obj_id(new_block_panel_id(block_panels))

--- a/inst/assets/js/show-block.js
+++ b/inst/assets/js/show-block.js
@@ -1,23 +1,49 @@
 $(function () {
+  // Moves whose target panel is not in the DOM yet. dockView mounts a group's
+  // background tabs lazily (onlyWhenVisible), so a card's move-element can
+  // arrive before its panel's content element exists; dropping it then strands
+  // the card in the offcanvas and the tab stays blank. Stash such a move and
+  // replay it when dockView reports the panel active -- the same client tick its
+  // content element mounts, before paint.
+  var pending = [];
+
+  function applyMove(m) {
+    var $to = $(m.to);
+
+    // Target not mounted yet -- caller should stash and replay on activation.
+    if ($to.length === 0) {
+      return false;
+    }
+
+    // Don't move into an inactive view dock: an off-screen view whose card
+    // isn't built is skipped silently rather than warning about a missing
+    // 'from'.
+    var $wsDock = $to.closest('.blockr-view-dock');
+    if ($wsDock.length > 0 && !$wsDock.hasClass('blockr-view-dock-active')) {
+      return true;
+    }
+
+    if ($(m.from).length === 0) {
+      console.warn(`move-element: 'from' selector ${m.from} not found in DOM`);
+      return true;
+    }
+
+    $to.append($(m.from));
+    return true;
+  }
+
   Shiny.addCustomMessageHandler(
     'move-element', (m) => {
-      var $to = $(m.to);
-      // Don't move elements into inactive view docks. Checked first so an
-      // off-screen view whose card isn't built yet is skipped silently rather
-      // than warning about a missing 'from'.
-      var $wsDock = $to.closest('.blockr-view-dock');
-      if ($wsDock.length > 0 && !$wsDock.hasClass('blockr-view-dock-active')) {
-        return;
+      if (!applyMove(m)) {
+        pending.push(m);
       }
-      if ($(m.from).length === 0) {
-        console.warn(`move-element: 'from' selector ${m.from} not found in DOM`);
-        return;
-      }
-      if ($to.length === 0) {
-        console.warn(`move-element: 'to' selector ${m.to} not found in DOM`);
-        return;
-      }
-      $to.append($(m.from));
     }
   )
+
+  // dockViewR re-broadcasts panel activation as this bubbling DOM event; the
+  // panel's content element exists by the time it fires, so replay any stashed
+  // move whose target has now appeared.
+  document.addEventListener('dockview:active-panel', () => {
+    pending = pending.filter((m) => !applyMove(m));
+  })
 })

--- a/inst/assets/js/show-block.js
+++ b/inst/assets/js/show-block.js
@@ -7,6 +7,13 @@ $(function () {
   // content element mounts, before paint.
   var pending = [];
 
+  // A stashed move is dead once its card has left the DOM: the block was removed
+  // before its target panel ever mounted. Drop those so `pending` holds only
+  // moves that can still land, rather than growing with every removed block.
+  function alive(m) {
+    return $(m.from).length > 0;
+  }
+
   function applyMove(m) {
     var $to = $(m.to);
 
@@ -34,6 +41,7 @@ $(function () {
 
   Shiny.addCustomMessageHandler(
     'move-element', (m) => {
+      pending = pending.filter(alive);
       if (!applyMove(m)) {
         pending.push(m);
       }
@@ -42,8 +50,8 @@ $(function () {
 
   // dockViewR re-broadcasts panel activation as this bubbling DOM event; the
   // panel's content element exists by the time it fires, so replay any stashed
-  // move whose target has now appeared.
+  // move whose target has now appeared, dropping any whose block was removed.
   document.addEventListener('dockview:active-panel', () => {
-    pending = pending.filter((m) => !applyMove(m));
+    pending = pending.filter((m) => alive(m) && !applyMove(m));
   })
 })

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -693,8 +693,8 @@ test_that("report_visible_observer drives the required axis over built cards", {
     layout_b <- reactiveVal(NULL)
 
     docks <- new.env(parent = emptyenv())
-    docks[["A"]] <- list(layout = layout_a)
-    docks[["B"]] <- list(layout = layout_b)
+    docks[["A"]] <- list(layout = layout_a, active_panel = reactiveVal(NULL))
+    docks[["B"]] <- list(layout = layout_b, active_panel = reactiveVal(NULL))
 
     # a, b and d are all built (required non-NA); a/b are A's fronts, d lives
     # in B. Nothing reported on screen yet, so all parked (required FALSE).
@@ -760,7 +760,7 @@ test_that("report_visible_observer coalesces set-equal reports", {
     layout <- reactiveVal(NULL)
 
     docks <- new.env(parent = emptyenv())
-    docks[["A"]] <- list(layout = layout)
+    docks[["A"]] <- list(layout = layout, active_panel = reactiveVal(NULL))
 
     # a and b are built, both A's fronts.
     vis <- fake_visibility(c("a", "b"))
@@ -794,6 +794,60 @@ test_that("report_visible_observer coalesces set-equal reports", {
 
   expect_identical(isolate(env$vis$required[["a"]]()), TRUE)
   expect_identical(isolate(env$vis$visible[["a"]]()), "A")
+})
+
+test_that("report_visible_observer follows the live active panel (#361)", {
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  # A settled `_state` echo fronting a; `views` lists the group's tab members so
+  # a live active panel can override its front without a fresh echo.
+  leaf <- function(id, active, members) {
+    list(
+      type = "leaf",
+      data = list(id = id, activeView = active, views = members)
+    )
+  }
+  layout_ab <- list(
+    grid = list(
+      root = list(
+        type = "branch",
+        data = list(
+          leaf("1", "block_panel-a", c("block_panel-a", "block_panel-b"))
+        )
+      )
+    )
+  )
+
+  env <- with_mock_context(ms, {
+    layout <- reactiveVal(NULL)
+    active_panel <- reactiveVal(NULL)
+
+    docks <- new.env(parent = emptyenv())
+    docks[["A"]] <- list(layout = layout, active_panel = active_panel)
+
+    vis <- fake_visibility(c("a", "b"))
+    mark_cards_built(vis, c("a", "b"))
+    client_active <- reactiveVal("A")
+
+    report_visible_observer(vis, client_active, docks)
+
+    list(layout = layout, active_panel = active_panel, vis = vis)
+  })
+
+  with_mock_context(ms, env$layout(layout_ab))
+  ms$flushReact()
+  expect_identical(isolate(env$vis$visible[["a"]]()), "A")
+  expect_true(is.na(isolate(env$vis$visible[["b"]]())))
+
+  # The client switches to b with no fresh layout echo (`layout` unchanged): the
+  # active-panel signal alone must front b and park a -- the tab-switch repaint.
+  with_mock_context(ms, env$active_panel("block_panel-b"))
+  ms$flushReact()
+  expect_identical(isolate(env$vis$required[["b"]]()), TRUE)
+  expect_identical(isolate(env$vis$visible[["b"]]()), "A")
+  expect_identical(isolate(env$vis$required[["a"]]()), FALSE)
+  expect_true(is.na(isolate(env$vis$visible[["a"]]())))
 })
 
 test_that("board_server_callback seeds visibility before the client reports", {

--- a/tests/testthat/test-utils-ui.R
+++ b/tests/testthat/test-utils-ui.R
@@ -21,6 +21,48 @@ test_that("determine_active_views handles an uninitialised layout", {
   )
 })
 
+test_that("a live active panel overrides its group's stale front (#361)", {
+
+  leaf <- function(id, view, members) {
+    list(
+      type = "leaf",
+      data = list(id = id, activeView = view, views = members)
+    )
+  }
+
+  layout <- list(
+    grid = list(
+      root = list(
+        type = "branch",
+        data = list(
+          leaf("grp1", "ext_panel-dag", "ext_panel-dag"),
+          leaf(
+            "grp2",
+            "block_panel-a",
+            c("block_panel-a", "block_panel-b", "block_panel-c")
+          )
+        )
+      )
+    )
+  )
+
+  # The echo alone fronts only block a -- the tab-switch-stays-blank bug: a bare
+  # switch to b or c does not re-echo `_state`, so its block is never marked
+  # visible.
+  expect_identical(as.character(visible_block_ids(layout)), "a")
+
+  # Folding in the client's live active panel fronts the selected block instead,
+  # and only for the group that lists it.
+  expect_identical(
+    as.character(visible_block_ids(layout, "block_panel-c")),
+    "c"
+  )
+  expect_identical(
+    determine_active_views(layout, "block_panel-c"),
+    c(grp1 = "ext_panel-dag", grp2 = "block_panel-c")
+  )
+})
+
 test_that("determine_panel_pos places freely before the dock initialises", {
 
   dock <- list(


### PR DESCRIPTION
## Summary

- A regression from #344 left blocks on a group's non-front tabs blank. dockView mounts background tabs lazily (`onlyWhenVisible`), so a block card's `move-element` arrived before its panel's content element existed and was dropped — the card stranded in the offcanvas — and a bare tab switch never marked the newly-fronted block visible, so core's render gate held it.
- `show-block.js` now stashes a dropped move and replays it on dockViewR's `dockview:active-panel` event (cynkra/dockViewR#96), which fires the same client tick the panel mounts: before paint, no flash, no DOM-wide observer.
- `report_visible_observer()` folds the client's live active panel (`dock$active_panel()`) into the on-screen set, so a bare tab switch marks the fronted block visible even when the settled `_state` echo doesn't carry it.
- Pins `cynkra/dockViewR@95-panel-mount-event` for the event. Stacked on #349, whose settle-focus removal changes which panels activate at restore — the signal this replay keys on.

Fixes #361