### PR TITLE
Adopt renamed arg-spec API from blockr.core

### DIFF
--- a/R/ext-meta.R
+++ b/R/ext-meta.R
@@ -15,13 +15,13 @@
 #'
 #' Per-variable `arguments` reuse blockr.core's block-argument specification:
 #' pass a named character vector (variable to description) for the common case,
-#' or a [new_block_args()] object to attach a machine-readable `type` (via the
+#' or a [new_arg_specs()] object to attach a machine-readable `type` (via the
 #' `arg_*()` constructors) and a worked `example` to each variable.
 #'
 #' @param description Free-text summary of what the extension is
 #' @param arguments Per-variable documentation for the externally controllable
 #'   variables, either a named character vector (variable to description) or a
-#'   [new_block_args()] object; keyed by controllable variable
+#'   [new_arg_specs()] object; keyed by controllable variable
 #' @param examples List of worked configurations, each a named list keyed by
 #'   controllable variable (a `modify_extension`-shaped payload)
 #' @param guidance Free-text steering on how to drive the extension, distinct
@@ -41,7 +41,7 @@
 #' `description`, `arguments`, `examples` and `guidance`), `is_ext_meta()` a
 #' boolean and `ext_meta()` the normalized `ext_meta` an extension carries. The
 #' per-component accessors return that component: `ext_desc()` a string or
-#' `NULL`, `ext_args()` a `block_args`, `ext_examples()` a list and
+#' `NULL`, `ext_args()` an `arg_specs`, `ext_examples()` a list and
 #' `ext_guidance()` a string or `NULL`.
 #'
 #' @name ext-meta
@@ -143,25 +143,22 @@ extension_description <- function(x) {
 as_ext_arguments <- function(x) {
 
   if (is.null(x)) {
-    return(new_block_args())
+    return(new_arg_specs())
   }
 
-  if (inherits(x, "block_args")) {
+  if (is_arg_specs(x)) {
     return(x)
   }
 
   if (!is.character(x) || is.null(names(x)) || any(!nzchar(names(x)))) {
     blockr_abort(
-      "`ext_meta` arguments must be a named character vector or a ",
-      "`block_args` object.",
+      "`ext_meta` arguments must be a named character vector or an ",
+      "`arg_specs` object.",
       class = "ext_meta_arguments_invalid"
     )
   }
 
-  do.call(
-    new_block_args,
-    set_names(lapply(x, new_block_arg), names(x))
-  )
+  as_arg_specs(x)
 }
 
 validate_ext_meta <- function(x, ctrl) {

--- a/man/ext-meta.Rd
+++ b/man/ext-meta.Rd
@@ -38,7 +38,7 @@ extension_description(x)
 
 \item{arguments}{Per-variable documentation for the externally controllable
 variables, either a named character vector (variable to description) or a
-\code{\link[blockr.core:new_block_args]{new_block_args()}} object; keyed by controllable variable}
+\code{\link[blockr.core:new_arg_specs]{new_arg_specs()}} object; keyed by controllable variable}
 
 \item{examples}{List of worked configurations, each a named list keyed by
 controllable variable (a \code{modify_extension}-shaped payload)}
@@ -54,7 +54,7 @@ from the human-facing \code{description}}
 \code{description}, \code{arguments}, \code{examples} and \code{guidance}), \code{is_ext_meta()} a
 boolean and \code{ext_meta()} the normalized \code{ext_meta} an extension carries. The
 per-component accessors return that component: \code{ext_desc()} a string or
-\code{NULL}, \code{ext_args()} a \code{block_args}, \code{ext_examples()} a list and
+\code{NULL}, \code{ext_args()} an \code{arg_specs}, \code{ext_examples()} a list and
 \code{ext_guidance()} a string or \code{NULL}.
 }
 \description{
@@ -74,7 +74,7 @@ components are read with \code{ext_desc()}, \code{ext_args()}, \code{ext_example
 \details{
 Per-variable \code{arguments} reuse blockr.core's block-argument specification:
 pass a named character vector (variable to description) for the common case,
-or a \code{\link[blockr.core:new_block_args]{new_block_args()}} object to attach a machine-readable \code{type} (via the
+or a \code{\link[blockr.core:new_arg_specs]{new_arg_specs()}} object to attach a machine-readable \code{type} (via the
 \verb{arg_*()} constructors) and a worked \code{example} to each variable.
 }
 \examples{

--- a/tests/testthat/test-ext-class.R
+++ b/tests/testthat/test-ext-class.R
@@ -291,7 +291,7 @@ test_that("new_ext_meta assembles and validates its fields", {
   expect_true(is_ext_meta(meta))
   expect_identical(meta[["description"]], "Workflow diagram.")
   expect_identical(meta[["guidance"]], "Drive via modify_extension.")
-  expect_s3_class(meta[["arguments"]], "block_args")
+  expect_true(is_arg_specs(meta[["arguments"]]))
   expect_identical(names(meta[["arguments"]]), "positions")
 
   expect_error(
@@ -313,8 +313,8 @@ test_that("new_ext_meta normalizes the arguments field", {
   expect_identical(names(new_ext_meta()[["arguments"]]), NULL)
   expect_length(new_ext_meta()[["arguments"]], 0L)
 
-  spec <- new_block_args(
-    positions = new_block_arg("Coords.", type = arg_string())
+  spec <- new_arg_specs(
+    positions = new_arg_spec("Coords.", type = arg_string())
   )
   expect_identical(new_ext_meta(arguments = spec)[["arguments"]], spec)
 
@@ -342,7 +342,7 @@ test_that("per-component accessors read the extension metadata", {
 
   bare <- ctrl_ext()
   expect_null(ext_guidance(bare))
-  expect_s3_class(ext_args(bare), "block_args")
+  expect_true(is_arg_specs(ext_args(bare)))
   expect_length(ext_args(bare), 0L)
   expect_identical(ext_examples(bare), list())
 


### PR DESCRIPTION
## Summary

- Read and coerce extension `arguments` through blockr.core's newly exported `is_arg_specs()` / `as_arg_specs()` / `new_arg_specs()` in `R/ext-meta.R`, instead of the `block_args` class name and a hand-rolled `new_block_arg` / `new_block_args` normalization.
- The upstream rename (the `block_args` class became `arg_specs`) flips dock's `inherits(x, "block_args")` check to `FALSE` — which is what fails blockr.core#296's revdep against dock. Reading through the exported predicate and coercion means a future rename can't break dock again.
- `Remotes:` temporarily pins `blockr.core@295-arg-spec-rename` so CI resolves the branch that exports these; drop the pin once blockr.core#296 lands on `main`.

Merge coordination: pin blockr.core#296's revdep at this branch (deps block in that PR's body), merge blockr.core#296 first, then this.

Fixes #368