### PR TITLE
Drop a stale tab-close instead of aborting the board update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,12 @@
   a cost that scales with the number of blocks on the active view, so it
   cuts noticeably into the initial app render (#214).
 
+* Closing a dock panel no longer aborts the board update when the same tab is
+  closed twice in quick succession. The manual-close plugin leaves a tab's `x`
+  in place until the server round-trip removes it, so a rapid double click
+  re-fires the close for a panel that is already gone; that stale removal is
+  now dropped rather than failing view-membership validation (#362).
+
 * Blocks on a dock group's background tabs render again. dockView mounts a
   group's non-front tabs lazily, so a block card's `move-element` could arrive
   before its panel existed and be dropped, stranding the card in the offcanvas;

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -796,9 +796,21 @@ manage_dock <- function(
     # server) emits an `rm` panel-op; the apply observer above removes it.
     # Membership is authoritative from the update, so no later reconcile can
     # restore a view still listing the closed panel (#217).
+    #
+    # The emit carries `priority = "event"`, and the manual plugin leaves the
+    # tab `x` in place until the server round-trip removes it, so rapid clicks
+    # re-fire the same panel id. Skip an emit whose panel is no longer live:
+    # its `rm` would validate against the already-reduced membership and abort
+    # the whole update.
     observeEvent(
       input[[dock_input("panel-to-remove")]],
-      update(remove_panel_delta(id, input[[dock_input("panel-to-remove")]]))
+      {
+        pid <- input[[dock_input("panel-to-remove")]]
+
+        if (panel_is_live(pid, dock)) {
+          update(remove_panel_delta(id, pid))
+        }
+      }
     )
 
     observeEvent(

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -211,6 +211,87 @@ test_that("board server", {
   expect_identical(panel_lookups, 1L)
 })
 
+test_that("re-closing a removed panel aborts the reducer (#362)", {
+
+  # The symptom the gesture guard below prevents: once a close has reduced a
+  # view's membership, a duplicate `rm` of the same panel no longer matches a
+  # member and the delta grammar rejects the whole update.
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    views = list(A = c("a", "b"))
+  )
+
+  reduced <- apply_board_update(
+    brd, augment_board_update(remove_panel_delta("A", "block_panel-b"), brd)
+  )
+  expect_identical(view_members(board_views(reduced)[["A"]]), "block_panel-a")
+
+  expect_error(
+    augment_board_update(remove_panel_delta("A", "block_panel-b"), reduced),
+    class = "dock_views_mod_rm_unknown"
+  )
+})
+
+test_that("a stale close of an already-removed panel emits no rm (#362)", {
+
+  # Rapid clicks on a manual-close tab re-fire `panel-to-remove` (an
+  # event-priority emit) before the server round-trip removes the tab, so the
+  # duplicate arrives after the panel has left the live set. Forwarding it as an
+  # `rm` would abort the update (see the reducer test above); the gesture must
+  # drop it instead.
+  brd <- board_args(
+    blocks = c(a = new_dataset_block()),
+    extensions = new_edit_board_extension()
+  )
+
+  mod_input <- function(name) paste0("dock_main-", name)
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  upd <- reactiveVal()
+
+  res <- with_mock_context(ms, {
+    manage_dock("dock_main", brd, visibility = fake_visibility("a"),
+                update = upd)
+  })
+
+  ms$flushReact()
+
+  do.call(
+    ms$setInputs,
+    set_names(list(TRUE), mod_input(dock_input("initialized")))
+  )
+
+  close_tab <- function(pid) {
+    do.call(
+      ms$setInputs,
+      set_names(list(pid), mod_input(dock_input("panel-to-remove")))
+    )
+  }
+
+  expect_identical(isolate(res$n_panels()), 2L)
+
+  close_tab(as_block_panel_id("a"))
+
+  expect_identical(isolate(res$n_panels()), 1L)
+  expect_identical(
+    as.character(isolate(upd())$views$mod$dock_main$rm), "block_panel-a"
+  )
+
+  upd(NULL)
+  close_tab(as_ext_panel_id("edit_board"))
+
+  expect_identical(isolate(res$n_panels()), 0L)
+
+  # The dead block tab is closed a second time (its `x` outlives the panel under
+  # the manual plugin). Its panel has left the live set, so no `rm` goes out.
+  upd(NULL)
+  close_tab(as_block_panel_id("a"))
+
+  expect_null(isolate(upd()))
+})
+
 test_that("an extension key never leaks into core's plugin args (#318)", {
 
   # `edit` is a prefix of core's `edit_block` block-server formal; returned as


### PR DESCRIPTION
## Summary

- Rapidly closing a dock tab aborted the whole board update with `Panel(s) in views$mod$<view>$rm are not view members`. The manual-close plugin leaves a tab's `x` in place until the server round-trip removes the panel, so a rapid double-click re-fires the event-priority `panel-to-remove` for a panel that is already gone.
- That duplicate reaches the reducer *after* the first close reduced the view's membership, so `validate_view_mod()` rejects the stale `rm` and drops the update. Confirmed in a browser against a default-grid board: the exact error logs on `main` and is gone with this change.
- Fix: the close gesture skips emitting an `rm` when its panel is no longer live (`panel_is_live()`), so the stale duplicate never reaches the reducer. The grammar validation stays strict, so a genuine `views$mod$…$rm` of a non-member still errors.
- Tests: a reducer-level test that a stale `rm` still aborts, plus a mock-session test that the gesture drops the duplicate (fails without the guard).

Fixes #362