### PR TITLE
Style block card sections from CSS instead of per-card tagQuery

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # blockr.dock (development version)
 
+* Block card sections (inputs / outputs / control) are styled from the
+  stylesheet, keyed on each panel's stable `data-value`, rather than
+  rebuilt per card with `htmltools::tagQuery()` at UI-build time. The
+  markup renders identically but the cards build about a third faster --
+  a cost that scales with the number of blocks on the active view, so it
+  cuts noticeably into the initial app render (#214).
+
 * Blocks on a dock group's background tabs render again. dockView mounts a
   group's non-front tabs lazily, so a block card's `move-element` could arrive
   before its panel existed and be dropped, stranding the card in the offcanvas;

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -351,59 +351,21 @@ block_card_dropdown <- function(ns, info, blk_id) {
 
 block_card_content <- function(ns, expr_ui, block_ui, ctrl_ui = NULL) {
 
-  inputs_panel <- htmltools::tagQuery(
-    accordion_panel(
-      icon = icon("sliders"),
-      title = "Block inputs",
-      value = "inputs"
-    )
-  )$find(
-    ".accordion-header"
-  )$addAttrs(
-    style = "display: none;"
-  )$reset(
-  )$find(
-    ".accordion-body"
-  )$addAttrs(
-    style = paste0(
-      "background-color: white;",
-      "border-radius: 0;",
-      "margin: 0 -16px 10px -16px;",
-      "padding: 16px 16px 10px 16px;",
-      "border-top: 1px solid var(--blockr-grey-300);",
-      "border-bottom: 1px solid var(--blockr-grey-300);"
-    )
-  )$append(
+  inputs_panel <- accordion_panel(
+    icon = icon("sliders"),
+    title = "Block inputs",
+    value = "inputs",
     expr_ui
-  )$allTags()
+  )
 
-  inputs_panel$attribs$style <- "border: none; border-radius: 0;"
-
-  outputs_panel <- htmltools::tagQuery(
-    accordion_panel(
-      icon = icon("chart-simple"),
-      title = "Block output(s)",
-      value = "outputs",
-      style = "max-width: 100%; overflow-x: auto;"
-    )
-  )$find(
-    ".accordion-header"
-  )$addAttrs(
-    style = "display: none;"
-  )$reset(
-  )$find(
-    ".accordion-body"
-  )$addAttrs(
-    style = "padding: 0;"
-  )$append(
-    tagList(
-      block_ui,
-      uiOutput(ns("status_note")),
-      block_issues_ui(ns)
-    )
-  )$allTags()
-
-  outputs_panel$attribs$style <- "border: none; border-radius: 0;"
+  outputs_panel <- accordion_panel(
+    icon = icon("chart-simple"),
+    title = "Block output(s)",
+    value = "outputs",
+    block_ui,
+    uiOutput(ns("status_note")),
+    block_issues_ui(ns)
+  )
 
   ctrl_panel <- if (!is.null(ctrl_ui)) build_ctrl_panel(ctrl_ui)
 
@@ -411,6 +373,7 @@ block_card_content <- function(ns, expr_ui, block_ui, ctrl_ui = NULL) {
     div(id = ns("errors_block"), class = "mt-4"),
     accordion(
       id = ns("blk_accordion"),
+      class = "blockr-block-accordion",
       multiple = TRUE,
       open = c("inputs", "outputs"),
       ctrl_panel,
@@ -421,35 +384,11 @@ block_card_content <- function(ns, expr_ui, block_ui, ctrl_ui = NULL) {
 }
 
 build_ctrl_panel <- function(ctrl_ui) {
-
-  panel <- htmltools::tagQuery(
-    accordion_panel(
-      title = "Control",
-      value = "ctrl"
-    )
-  )$find(
-    ".accordion-header"
-  )$addAttrs(
-    style = "display: none;"
-  )$reset(
-  )$find(
-    ".accordion-body"
-  )$addAttrs(
-    style = paste0(
-      "background-color: white;",
-      "border-radius: 0;",
-      "margin: 0 -16px 10px -16px;",
-      "padding: 16px 16px 10px 16px;",
-      "border-top: 1px solid var(--blockr-grey-300);",
-      "border-bottom: 1px solid var(--blockr-grey-300);"
-    )
-  )$append(
+  accordion_panel(
+    title = "Control",
+    value = "ctrl",
     ctrl_ui
-  )$allTags()
-
-  panel$attribs$style <- "border: none; border-radius: 0;"
-
-  panel
+  )
 }
 
 ctrl_btn_label <- function(fn) coal(attr(fn, "ctrl_label"), "Control")

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -533,6 +533,37 @@ label:has(input[type="file"]) {
   box-shadow: none;
 }
 
+/* Block card sections (inputs / outputs / control) render as an always-open,
+   header-less accordion. These selectors carry the per-panel styling that used
+   to be applied per card at build time. Keyed on the stable panel data-value
+   and scoped with child combinators so they never reach a block's own nested
+   accordions -- and unscoped by .offcanvas so they hold once a card is moved
+   into a dock panel. */
+.blockr-block-accordion > .accordion-item {
+  border: none;
+  border-radius: 0;
+}
+
+.blockr-block-accordion > .accordion-item > .accordion-header {
+  display: none;
+}
+
+.blockr-block-accordion > .accordion-item[data-value="inputs"] > .accordion-collapse > .accordion-body,
+.blockr-block-accordion > .accordion-item[data-value="ctrl"] > .accordion-collapse > .accordion-body {
+  background-color: white;
+  border-radius: 0;
+  margin: 0 -16px 10px -16px;
+  padding: 16px 16px 10px 16px;
+  border-top: 1px solid var(--blockr-grey-300);
+  border-bottom: 1px solid var(--blockr-grey-300);
+}
+
+.blockr-block-accordion > .accordion-item[data-value="outputs"] > .accordion-collapse > .accordion-body {
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 0;
+}
+
 /* Export button adjustments */
 .offcanvas .shiny-download-link i,
 .offcanvas .shiny-download-link svg,

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -239,6 +239,54 @@ test_that("locked dock keeps block_card_toggles hidden (#122)", {
   expect_false(grepl("<script", locked_html, fixed = TRUE))
 })
 
+test_that("block card sections carry the css-styling contract (#214)", {
+
+  has_class <- function(token) {
+    sprintf(
+      "contains(concat(' ', normalize-space(@class), ' '), ' %s ')",
+      token
+    )
+  }
+
+  card <- block_card_content(
+    NS("blk"),
+    expr_ui = div(id = "blk-expr"),
+    block_ui = div(id = "blk-out")
+  )
+
+  root <- xml2::read_html(as.character(htmltools::tagList(card)))
+
+  # The stylesheet keys the per-panel styling off this class and the stable
+  # panel data-value, so both must be present for the cards to render styled.
+  acc <- xml2::xml_find_all(
+    root,
+    paste0("//div[", has_class("blockr-block-accordion"), "]")
+  )
+  expect_length(acc, 1L)
+
+  values <- xml2::xml_attr(
+    xml2::xml_find_all(acc, "./div[@data-value]"),
+    "data-value"
+  )
+  expect_setequal(values, c("inputs", "outputs"))
+
+  # The header-hide and body frame now live in the stylesheet: the panel's own
+  # header and body must not inline the styles tagQuery used to bake in per card
+  # (a revert to that would silently detach them from the css contract above).
+  inputs_item <- "./div[@data-value='inputs']"
+
+  header <- xml2::xml_find_first(
+    acc,
+    paste0(inputs_item, "/div[", has_class("accordion-header"), "]")
+  )
+  body <- xml2::xml_find_first(
+    acc,
+    paste0(inputs_item, "//div[", has_class("accordion-body"), "]")
+  )
+  expect_true(is.na(xml2::xml_attr(header, "style")))
+  expect_true(is.na(xml2::xml_attr(body, "style")))
+})
+
 test_that("block_cond_buckets drops status-phase rows from warnings (#290)", {
 
   df <- data.frame(


### PR DESCRIPTION
## Summary

`block_card_content()` rebuilt each card's inputs / outputs / control panels with three `htmltools::tagQuery()` passes at UI-build time -- cloning and rewriting the tag tree just to hide the accordion headers and reframe the bodies. Profiling `blockr_app_ui()` put that `tagQuery` work at ~14% of the whole initial request and about a third of per-card build cost, and it scales linearly with the number of blocks on the active view. (The issue's other candidates profiled small by comparison: `bs_theme()` ~4.5%, the settings-sidebar options UI ~2%.)

- Build the panels directly with `accordion_panel()` and move the header-hide / item-border / body-frame styling to the stylesheet, keyed on each panel's stable `data-value` plus a `blockr-block-accordion` class on the accordion. Child combinators scope the rules to the card's own panels (never a block's nested accordions), and leaving them unscoped by `.offcanvas` keeps them applied once a card is moved into a dock panel.
- Card building drops ~33% (measured at 3 / 10 / 20 blocks: 106→70, 348→235, 696→459 ms). The rendered markup and computed styles are unchanged -- verified in a real browser (`getComputedStyle` on the panel header and body) and by screenshot.
- A regression test locks the class / `data-value` contract the CSS now depends on; it fails against the old `tagQuery` structure.

Fixes #214