### PR TITLE
Abort on an unresolvable panel id in a grid or view

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* A panel id in a `dock_grid()` or view that resolves to no block or
+  extension on the board now aborts at `new_dock_board()` rather than
+  being dropped in silence. Such an id -- a typo, or an extension's old
+  class-derived name (extensions are keyed by their mount name since the
+  ids became container-owned) -- used to empty the view, booting the
+  board blank with no error, warning, or log entry. Restoring a saved
+  board is unchanged: a member or grid leaf whose block is genuinely gone
+  still self-heals (#375).
+
 * Block card sections (inputs / outputs / control) are styled from the
   stylesheet, keyed on each panel's stable `data-value`, rather than
   rebuilt per card with `htmltools::tagQuery()` at UI-build time. The

--- a/R/dock-grid.R
+++ b/R/dock-grid.R
@@ -696,21 +696,19 @@ default_layout <- function(blocks, extensions) {
 }
 
 # Rewrite a grid's bare leaf ids to canonical panel ids via `id_map`, per
-# element (like `resolve_panel_ids()`): a bare key is mapped and an
-# already-canonical panel id passes through, so a `blk()` / `ext()` ref can sit
-# beside a bare id in the same grid. A name clash between an extension and a
-# block is ambiguous, so bare resolution falls back to a default two-group grid.
+# element (like `resolve_panel_ids()`): a bare key is mapped and an already-
+# canonical panel id passes through, so a `blk()` / `ext()` ref can sit beside a
+# bare id in the same grid. A leaf resolving to no panel on the board is an
+# authoring bug and aborts (`check_panel_refs()`). A name clash between an
+# extension and a block is ambiguous, so bare resolution falls back to a default
+# two-group grid.
 resolve_grid <- function(grid, id_map) {
 
   grid <- as_dock_grid(grid)
 
-  panel_ids <- layout_panel_ids(grid)
+  uses_bare <- any(layout_panel_ids(grid) %in% names(id_map))
 
-  if (!any(panel_ids %in% names(id_map))) {
-    return(grid)
-  }
-
-  if (anyDuplicated(names(id_map)) > 0L) {
+  if (uses_bare && anyDuplicated(names(id_map)) > 0L) {
 
     blockr_warn(
       "Cannot use extension names that overlap with block names.",
@@ -720,7 +718,13 @@ resolve_grid <- function(grid, id_map) {
     return(clash_default_grid(id_map))
   }
 
-  rewrite_grid_leaves(grid, id_map)
+  if (uses_bare) {
+    grid <- rewrite_grid_leaves(grid, id_map)
+  }
+
+  check_panel_refs(layout_panel_ids(grid), id_map)
+
+  grid
 }
 
 clash_default_grid <- function(id_map) {

--- a/R/dock-view.R
+++ b/R/dock-view.R
@@ -463,8 +463,10 @@ board_views <- function(x) {
   invisible(x)
 }
 
-# resolves ergonomic `views` / `grids` inputs. Extension keys and class ids
-# both resolve to the extension's panel id.
+# The id map that resolves ergonomic `views` / `grids` inputs: each block name
+# and each extension mount key maps to its canonical panel id. An extension is
+# keyed by its mount name, not its class, so a class-derived name no longer
+# resolves.
 panel_id_map <- function(blocks, extensions) {
 
   blocks <- as_blocks(blocks)
@@ -477,15 +479,46 @@ panel_id_map <- function(blocks, extensions) {
 }
 
 # Map bare object ids to canonical panel ids, per element: a key of the map is
-# rewritten, an already-canonical panel id (or an unknown id) passes through.
-# Resolving element-wise lets a `blk()` / `ext()` ref (already canonical) sit
-# beside a bare id in the same view.
+# rewritten, an already-canonical panel id passes through. Resolving element-
+# wise lets a `blk()` / `ext()` ref (already canonical) sit beside a bare id in
+# the same view. An id resolving to no panel on the board is an authoring bug --
+# `check_panel_refs()` makes it loud rather than dropping it in silence.
 resolve_panel_ids <- function(ids, id_map) {
 
   hit <- ids %in% names(id_map)
   ids[hit] <- unname(id_map[ids[hit]])
 
+  check_panel_refs(ids, id_map)
+
   ids
+}
+
+# Every panel a view or grid names must back a block or extension on the board.
+# Bare object ids resolve through `id_map`; a `blk()` / `ext()` reference is
+# already canonical and passes through. An id resolving to neither -- a typo, or
+# a stale class-derived extension name (an extension is keyed by its mount name
+# now, not its class) -- would otherwise be dropped in silence, emptying the
+# view; it is an authoring bug in every case, so it aborts here. Restore takes a
+# separate route: it feeds already-typed `dock_views` / `dock_grids` that skip
+# this resolution, so a genuinely stale saved id still self-heals (via
+# `drop_unknown_members()`) rather than aborting.
+check_panel_refs <- function(ids, id_map) {
+
+  bad <- setdiff(ids, unname(id_map))
+
+  if (!length(bad)) {
+    return(invisible(ids))
+  }
+
+  bad <- panel_obj_ids(bad)
+
+  blockr_abort(
+    paste(
+      "{cli::qty(bad)}Layout references unknown panel{?s} {bad}.",
+      "Available: {names(id_map)}."
+    ),
+    class = "dock_layout_panel_unknown"
+  )
 }
 
 coerce_dock_views <- function(views, id_map) {

--- a/tests/testthat/test-view-class.R
+++ b/tests/testthat/test-view-class.R
@@ -210,18 +210,103 @@ test_that("view_grid renders a member the grid omits, defaulting its spot", {
   )
 })
 
-test_that("construction drops members with no backing block or extension", {
+test_that("restore self-heals a member with no backing block or extension", {
 
-  # The block / extension set is authoritative. A member referencing a block
-  # that is not on the board (e.g. dropped since the board was saved) is pruned
-  # at construction rather than rejected -- restore of a stale board self-heals.
-  brd <- new_dock_board(
-    blocks = c(a = new_dataset_block()),
-    views = list(A = dock_view(c("block_panel-a", "block_panel-gone")))
+  # Restore hands the constructor already-typed `dock_views`, which skip
+  # ergonomic resolution. A member referencing a block not on the board (e.g.
+  # dropped since the board was saved) is pruned at construction rather than
+  # rejected, so a stale saved board self-heals. An unresolved *authoring*
+  # reference aborts instead (below).
+  views <- reconstruct_dock_views(
+    list(A = dock_view(c("block_panel-a", "block_panel-gone")))
   )
+
+  brd <- new_dock_board(blocks = c(a = new_dataset_block()), views = views)
 
   expect_identical(view_members(board_views(brd)[["A"]]), "block_panel-a")
   expect_s3_class(validate_board(brd), "dock_board")
+})
+
+test_that("restore self-heals a grid leaf with no backing block", {
+
+  # A typed `dock_grids` (the restore currency) likewise skips resolution: a
+  # leaf for a since-removed block is restricted away, not aborted.
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    views = reconstruct_dock_views(list(A = dock_view("block_panel-a"))),
+    grids = new_dock_grids(
+      list(A = as_dock_grid(dock_grid("block_panel-a", "block_panel-gone")))
+    )
+  )
+
+  expect_identical(layout_panel_ids(board_grids(brd)[["A"]]), "block_panel-a")
+  expect_s3_class(validate_board(brd), "dock_board")
+})
+
+test_that("an unresolvable grid panel id aborts at construction", {
+
+  # The regression: an extension is keyed by its mount name (`edit_board`), so
+  # the old class-derived name no longer resolves. It used to be dropped in
+  # silence, booting the view empty; now it is a loud authoring error.
+  expect_error(
+    new_dock_board(
+      extensions = new_edit_board_extension(),
+      grids = list(Main = dock_grid("edit_board_extension"))
+    ),
+    class = "dock_layout_panel_unknown"
+  )
+})
+
+test_that("an unresolvable view member aborts at construction", {
+
+  expect_error(
+    new_dock_board(
+      blocks = c(a = new_dataset_block()),
+      views = list(A = dock_view("gone"))
+    ),
+    class = "dock_layout_panel_unknown"
+  )
+})
+
+test_that("a typo in an ext() / blk() reference aborts at construction", {
+
+  # The endorsed reference form is not exempt: `ext("edit_typo")` is a canonical
+  # but unbacked panel id, so it aborts rather than silently emptying the view.
+  expect_error(
+    new_dock_board(
+      extensions = new_edit_board_extension(),
+      grids = list(Main = dock_grid(ext("edit_typo")))
+    ),
+    class = "dock_layout_panel_unknown"
+  )
+})
+
+test_that("the unknown-panel error names the bad id and the available ones", {
+
+  expect_error(
+    new_dock_board(
+      blocks = c(a = new_dataset_block(), b = new_head_block()),
+      views = list(A = dock_view(c("a", "nope")))
+    ),
+    regexp = "unknown panel nope.+Available.+a.+b",
+    class = "dock_layout_panel_unknown"
+  )
+})
+
+test_that("bare ids and blk() / ext() references coexist in one view", {
+
+  # A valid mix must still construct -- the check rejects only ids that back
+  # nothing, never the canonical reference forms.
+  brd <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block()),
+    extensions = new_edit_board_extension(),
+    views = list(V = list(blk("a"), "b", ext("edit_board")))
+  )
+
+  expect_setequal(
+    view_members(board_views(brd)[["V"]]),
+    c("block_panel-a", "block_panel-b", "ext_panel-edit_board")
+  )
 })
 
 test_that("construction restricts a grid to its view's members", {


### PR DESCRIPTION
## Summary

- A `dock_grid()` / view panel id that resolves to no block or extension on the board now aborts at `new_dock_board()`, naming the unresolved id and the available ones — instead of being dropped in silence, which emptied the view and booted the board blank with no error, warning, or log.
- The trap is an extension's old class-derived name: since ids became container-owned (`c326741`) an extension is keyed by its mount name (`dag`), so `dock_grid("dag_extension")` — or a typo in the endorsed `ext("dag")` form — resolves to nothing. This bit six blockr.cloud gallery demos, two of which opened completely blank.
- Scoped to the ergonomic authoring path (the `resolve_*` coercion). Restore is untouched: it feeds already-typed `dock_views` / `dock_grids` that skip resolution, so a genuinely stale saved id still self-heals via `drop_unknown_members()`.

Fixes #375