### PR TITLE
Adopt core's logical visible channel as the card-build ledger

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # blockr.dock (development version)
 
+* "Show code" on a deferred board
+  (`background_construction_delay = Inf`) no longer permanently blanks
+  the cards of a view first visited after it. The exporter marks every
+  block required so the script covers the whole board, and the dock's
+  card ledger -- read off that same `required` channel -- mistook the
+  export's demand for a built card, so the first visit to the view
+  skipped the build and left its panels empty. The dock now reads its
+  build ledger off core's `visible` channel, which blockr.core makes a
+  logical three-state axis (`NA` never built / `FALSE` built off screen
+  / `TRUE` painted), so a `required` write can no longer masquerade as a
+  built card (#377).
+
 * New `edit_inputs_action`: a per-block sidebar listing every incoming link
   as an ordered list, so a block's inputs can be managed together rather than
   one edge at a time. For a variadic block each row is a positional slot -

--- a/R/block-ui.R
+++ b/R/block-ui.R
@@ -121,38 +121,42 @@ insert_block_ui.dock_board <- function(id, x, blocks, dock, ...,
   invisible(x)
 }
 
-# The dock's build ledger and per-block visibility both live on the `visibility`
-# channel core hands the board callback: two per-block reactiveVal environments
-# (`required`, `visible`), one slot per board block, all core-owned. A card is
-# built once the dock writes its `required` slot (non-NA), so `built_cards()`
-# reads the built set straight off it -- there is no second ledger. The dock
-# writes `required[[id]]` FALSE when it builds a card (off screen) and TRUE when
-# on screen, and `visible[[id]]` the view id once the client paints it. Block
-# removal needs no dock write: core drops the slot, dropping the card too.
-
-# The blocks whose cards are built: those with a non-NA required slot.
+# The dock's build ledger is core's `visible` axis: a per-block reactiveVal,
+# logical (NA never built / FALSE built off screen / TRUE painted now) like
+# `required`, so `built_cards()` reads `!is.na(visible)`. It once read
+# `required` non-NA, but that axis is a multi-writer construction-demand
+# channel -- core's "Show code" marks every block required to export the whole
+# script -- so a demand with no card masqueraded as built and blanked the view
+# on its first visit. `visible` is written only where the dock builds, paints
+# or reconciles a card. The dock still writes `required[[id]]` FALSE off screen
+# / TRUE on screen (construction demand); block removal needs no dock write --
+# core drops the slot, dropping the card from the ledger too.
 built_cards <- function(visibility) {
-  ids <- ls(visibility$required)
-  ids[lgl_ply(ids, slot_built, visibility$required)]
+  ids <- ls(visibility$visible)
+  ids[lgl_ply(ids, slot_built, visibility$visible)]
 }
 
-slot_built <- function(id, required) {
-  !is.na(isolate(required[[id]]()))
+slot_built <- function(id, visible) {
+  !is.na(isolate(visible[[id]]()))
 }
 
-# Record `new` cards as built: their required slot goes FALSE (off screen until
-# the report observer places them). Slots pre-exist -- core seeds every block's
-# slots before any block plugin runs.
+# Record `new` cards as built off screen: `visible` FALSE enters them in the
+# ledger (built, not yet painted), `required` FALSE holds no construction
+# demand until a view switch or the report observer places them. Slots
+# pre-exist: core seeds every block's before any block plugin runs.
 mark_cards_built <- function(visibility, new) {
   for (id in new) {
+    visibility$visible[[id]](FALSE)
     visibility$required[[id]](FALSE)
   }
 }
 
 # Reconcile the required axis over `built` from an on-screen set: on screen ->
-# TRUE, off screen -> FALSE. A card leaving the screen also clears its visible
-# slot (no longer painted); the arrange observer owns setting it. Seeds the
-# channel too, with `built` the active view's membership.
+# TRUE, off screen -> FALSE. A card leaving the screen keeps its ledger entry --
+# `visible` goes FALSE (built, off screen), never NA (never built), or its view
+# blanks on the next visit. The arrange observer owns marking a card painted
+# (visible TRUE). Seeds the required axis too, with `built` the active view's
+# membership.
 show_cards <- function(visibility, built, on_screen) {
   for (id in built) {
     on <- id %in% on_screen
@@ -161,18 +165,18 @@ show_cards <- function(visibility, built, on_screen) {
       visibility$required[[id]](on)
     }
 
-    if (!on && !is.na(isolate(visibility$visible[[id]]()))) {
-      visibility$visible[[id]](NA_character_)
+    if (!on && isTRUE(isolate(visibility$visible[[id]]()))) {
+      visibility$visible[[id]](FALSE)
     }
   }
 }
 
-# Mark a view's on-screen blocks painted: write the view id into their visible
-# slot -- the client-confirmed paint core's construction gate waits for.
-mark_cards_rendered <- function(visibility, on_screen, view) {
+# Mark a view's on-screen blocks painted: `visible` TRUE -- the client-confirmed
+# paint core's render gate (is_visible = isTRUE) waits for.
+mark_cards_rendered <- function(visibility, on_screen) {
   for (id in on_screen) {
-    if (!identical(isolate(visibility$visible[[id]]()), view)) {
-      visibility$visible[[id]](view)
+    if (!isTRUE(isolate(visibility$visible[[id]]()))) {
+      visibility$visible[[id]](TRUE)
     }
   }
 }

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -57,9 +57,9 @@ board_server_callback <- function(board, update, visibility, ...,
   client_views <- reactiveVal(seed_view_state(board_views(initial_board)))
 
   # The `visibility` channel core hands us (per-block `required` / `visible` /
-  # `frozen` reactiveVal slots) is the single store: its `required` axis doubles
-  # as the dock's build ledger, read back via built_cards(). Stash it on
-  # active_dock -- the dock handle every card-touching path receives (view
+  # `frozen` reactiveVal slots) is the single store: its `visible` axis is the
+  # dock's build ledger (!is.na = ever built), read via built_cards(). Stash it
+  # on active_dock -- the dock handle every card-touching path receives (view
   # switch, panel-op apply, core insert / remove) -- so they read and write the
   # one channel.
   active_dock$visibility <- visibility
@@ -95,11 +95,13 @@ board_server_callback <- function(board, update, visibility, ...,
 
   # Gate off-screen blocks from the first flush, before the client reports its
   # layout (else core's all-visible default evaluates every block at startup).
-  # Seed the channel to what board_ui rendered: the active view's whole
-  # membership is built (required non-NA), its front panels required TRUE and
-  # its background tabs FALSE. Off-screen views' cards are built on first visit
-  # by switch_active_view. Core holds its background-construction gate until the
-  # active view reports its blocks rendered on the visible axis.
+  # Seed to what board_ui rendered: the active view's whole membership is built
+  # (visible FALSE -- built, not yet painted), its front panels required TRUE
+  # and background tabs FALSE. Off-screen views' cards are built on first visit
+  # by switch_active_view. Core holds its render gate (is_visible = isTRUE)
+  # until the active view reports its blocks painted (visible TRUE).
+  mark_cards_built(visibility, active_view_block_ids(initial_board))
+
   show_cards(
     visibility,
     active_view_block_ids(initial_board),
@@ -275,10 +277,10 @@ report_visible_observer <- function(visibility, client_active, docks) {
   observeEvent(
     on_screen(),
     {
-      view <- req(client_active())
+      req(client_active())
 
       show_cards(visibility, built_cards(visibility), on_screen())
-      mark_cards_rendered(visibility, on_screen(), view)
+      mark_cards_rendered(visibility, on_screen())
     }
   )
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -53,9 +53,10 @@ board_args <- function(...) {
 # Stand-in for the `visibility` channel blockr.core hands the board callback:
 # three environments of per-block reactiveVals (`required`, `visible`,
 # `frozen`), one slot per block, mirroring core's add_vis_slots at construction
-# (which seeds every board block before the callback runs). The dock writes
-# values into these slots; core owns their lifecycle in the real thing. Pass the
-# block ids to seed, or a board handle to seed from its blocks.
+# (which seeds every board block before the callback runs). `visible` is logical
+# (the dock's build ledger: !is.na = ever built), matching core's slot. The dock
+# writes values into these slots; core owns their lifecycle in the real thing.
+# Pass the block ids to seed, or a board handle to seed from its blocks.
 fake_visibility <- function(x = character()) {
   ids <- if (is.character(x)) x else board_block_ids(shiny::isolate(x$board))
 
@@ -66,7 +67,7 @@ fake_visibility <- function(x = character()) {
   )
   for (id in ids) {
     vis$required[[id]] <- shiny::reactiveVal(NA)
-    vis$visible[[id]] <- shiny::reactiveVal(NA_character_)
+    vis$visible[[id]] <- shiny::reactiveVal(NA)
     vis$frozen[[id]] <- shiny::reactiveVal(FALSE)
   }
   vis

--- a/tests/testthat/test-block-ui.R
+++ b/tests/testthat/test-block-ui.R
@@ -61,13 +61,20 @@ test_that("dummy block ui test", {
   expect_s3_class(ui[[1L]], "shiny.tag")
 })
 
-test_that("built_cards reads the built set off the required channel", {
+test_that("built_cards reads the dock ledger, not raw required writes (#377)", {
 
   vis <- fake_visibility(c("a", "b", "c"))
   expect_identical(built_cards(vis), character())
 
+  # A non-dock writer (core's "Show code") marks blocks required without ever
+  # building a card. That must not read back as a built card -- else the first
+  # visit to their view skips the build and leaves the panels blank.
   vis$required[["a"]](FALSE)
   vis$required[["b"]](TRUE)
+  expect_identical(built_cards(vis), character())
+
+  # The dock's own build is what enters the ledger.
+  mark_cards_built(vis, c("a", "b"))
   expect_setequal(built_cards(vis), c("a", "b"))
 })
 
@@ -78,17 +85,19 @@ test_that("built_cards on an empty bundle is empty (no crash)", {
   expect_identical(built_cards(fake_visibility()), character())
 })
 
-test_that("mark_cards_built marks new cards built (required FALSE)", {
+test_that("mark_cards_built enters new cards in the ledger (visible FALSE)", {
 
   vis <- fake_visibility(c("a", "b", "c"))
 
   mark_cards_built(vis, c("a", "b"))
 
-  expect_identical(isolate(vis$required[["a"]]()), FALSE)
-  expect_identical(isolate(vis$required[["b"]]()), FALSE)
+  # The ledger is the `visible` axis: built off screen -> FALSE, not painted.
+  expect_identical(isolate(vis$visible[["a"]]()), FALSE)
+  expect_identical(isolate(vis$visible[["b"]]()), FALSE)
   expect_setequal(built_cards(vis), c("a", "b"))
-  # An untouched slot stays NA (never built).
-  expect_true(is.na(isolate(vis$required[["c"]]())))
+  # Demand goes FALSE too; an untouched slot stays NA (never built).
+  expect_identical(isolate(vis$required[["a"]]()), FALSE)
+  expect_true(is.na(isolate(vis$visible[["c"]]())))
 })
 
 test_that("show_cards sets required TRUE on screen, FALSE off, over built", {
@@ -103,40 +112,43 @@ test_that("show_cards sets required TRUE on screen, FALSE off, over built", {
   expect_identical(isolate(vis$required[["c"]]()), FALSE)
 })
 
-test_that("show_cards clears the visible slot of a block leaving the screen", {
+test_that("show_cards keeps built-ness when a block leaves the screen (#377)", {
 
   vis <- fake_visibility(c("a", "b"))
   # a was painted into a view; it now leaves the screen.
   vis$required[["a"]](TRUE)
-  vis$visible[["a"]]("main")
+  vis$visible[["a"]](TRUE)
 
   show_cards(vis, built = c("a", "b"), on_screen = "b")
 
   expect_identical(isolate(vis$required[["a"]]()), FALSE)
-  expect_true(is.na(isolate(vis$visible[["a"]]())))
+  # visible goes FALSE (built, off screen), never NA -- erasing it would blank
+  # the view on its next visit.
+  expect_identical(isolate(vis$visible[["a"]]()), FALSE)
+  expect_true("a" %in% built_cards(vis))
 })
 
 test_that("show_cards leaves the visible axis alone for on-screen blocks", {
 
   vis <- fake_visibility("a")
   vis$required[["a"]](TRUE)
-  vis$visible[["a"]]("main")
+  vis$visible[["a"]](TRUE)
 
   # a stays on screen: its paint (visible) is the arrange observer's to own.
   show_cards(vis, built = "a", on_screen = "a")
 
-  expect_identical(isolate(vis$visible[["a"]]()), "main")
+  expect_identical(isolate(vis$visible[["a"]]()), TRUE)
 })
 
-test_that("mark_cards_rendered writes the view id into on-screen slots", {
+test_that("mark_cards_rendered marks on-screen slots painted (visible TRUE)", {
 
   vis <- fake_visibility(c("a", "b", "c"))
 
-  # The client arranged view "v1"; c is off screen (another view).
-  mark_cards_rendered(vis, on_screen = c("a", "b"), view = "v1")
+  # The client painted a and b; c is off screen (another view).
+  mark_cards_rendered(vis, on_screen = c("a", "b"))
 
-  expect_identical(isolate(vis$visible[["a"]]()), "v1")
-  expect_identical(isolate(vis$visible[["b"]]()), "v1")
+  expect_identical(isolate(vis$visible[["a"]]()), TRUE)
+  expect_identical(isolate(vis$visible[["b"]]()), TRUE)
   expect_true(is.na(isolate(vis$visible[["c"]]())))
 })
 
@@ -166,7 +178,7 @@ test_that("build_block_ui inserts the unbuilt cards and marks them built", {
   expect_identical(isolate(vis$required[["a"]]()), FALSE)
   expect_length(inserted, 2L)
 
-  # A card already built is not re-inserted: the required channel is the guard.
+  # A card already built is not re-inserted: the visible ledger is the guard.
   inserted <- character()
   again <- build_block_ui(
     "test", board, board_blocks(board), vis,
@@ -192,9 +204,9 @@ test_that("build_block_ui inserts the incremental card only", {
     blocks = c(a = new_dataset_block(), b = new_head_block())
   )
   vis <- fake_visibility(c("a", "b"))
-  # a is already built and painted.
+  # a is already built and painted on screen.
   vis$required[["a"]](TRUE)
-  vis$visible[["a"]]("main")
+  vis$visible[["a"]](TRUE)
 
   new <- build_block_ui(
     "test", board, board_blocks(board), vis,
@@ -205,9 +217,41 @@ test_that("build_block_ui inserts the incremental card only", {
   expect_setequal(built_cards(vis), c("a", "b"))
   # The pre-existing card keeps its state; only the new one is added.
   expect_identical(isolate(vis$required[["a"]]()), TRUE)
-  expect_identical(isolate(vis$visible[["a"]]()), "main")
+  expect_identical(isolate(vis$visible[["a"]]()), TRUE)
   expect_identical(isolate(vis$required[["b"]]()), FALSE)
   expect_length(inserted, 1L)
+})
+
+test_that("a bare required write does not suppress the card build (#377)", {
+
+  # Reproduces the "Show code" blank-view bug: core force-marks every block
+  # required (to export the whole script) though the dock built no card for the
+  # off-screen ones. The first visit to their view must still build the cards --
+  # a required write is not a ledger entry.
+  inserted <- character()
+
+  local_mocked_bindings(
+    insertUI = function(selector, ...) {
+      inserted <<- c(inserted, as.character(selector))
+      invisible()
+    }
+  )
+
+  board <- new_dock_board(
+    blocks = c(a = new_dataset_block(), b = new_head_block())
+  )
+  vis <- fake_visibility(c("a", "b"))
+
+  vis$required[["a"]](TRUE)
+  vis$required[["b"]](TRUE)
+
+  new <- build_block_ui(
+    "test", board, board_blocks(board), vis,
+    edit_ui = edit_block_ui, session = MockShinySession$new()
+  )
+
+  expect_setequal(new, c("a", "b"))
+  expect_length(inserted, 2L)
 })
 
 test_that("ensure_block_ui short-circuits when every card is built", {

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -701,12 +701,10 @@ test_that("visible axis follows the client's painted front tab (#328)", {
   )
   ms$flushReact()
 
-  page <- with_mock_context(ms, vid(board_rv$board, "Page"))
-
-  # Before the client reports a painted layout, the server side alone marks
-  # nothing on the visible axis.
-  expect_true(is.na(isolate(vis$visible[["a"]]())))
-  expect_true(is.na(isolate(vis$visible[["b"]]())))
+  # Before the client reports a painted layout, the seed marks the active view's
+  # cards built but not yet painted (visible FALSE) -- none TRUE yet.
+  expect_identical(isolate(vis$visible[["a"]]()), FALSE)
+  expect_identical(isolate(vis$visible[["b"]]()), FALSE)
 
   reported_front <- function(active) {
     grid <- as_dock_grid(
@@ -724,22 +722,23 @@ test_that("visible axis follows the client's painted front tab (#328)", {
   do.call(ms$setInputs, set_names(list(TRUE), "Page-dock_initialized"))
   ms$flushReact()
 
-  expect_identical(isolate(vis$visible[["b"]]()), page)
+  expect_identical(isolate(vis$visible[["b"]]()), TRUE)
   expect_identical(isolate(vis$required[["b"]]()), TRUE)
-  expect_true(is.na(isolate(vis$visible[["a"]]())))
+  expect_identical(isolate(vis$visible[["a"]]()), FALSE)
   expect_identical(isolate(vis$required[["a"]]()), FALSE)
 
   # Switching the front tab to a re-marks the visible axis -- the mark is live,
-  # not a one-shot that leaves the newly fronted tab blank.
+  # not a one-shot that leaves the newly fronted tab blank. b parks: built, off
+  # screen (visible FALSE), not erased.
   do.call(
     ms$setInputs,
     set_names(list(reported_front("block_panel-a")), "Page-dock_state")
   )
   ms$flushReact()
 
-  expect_identical(isolate(vis$visible[["a"]]()), page)
+  expect_identical(isolate(vis$visible[["a"]]()), TRUE)
   expect_identical(isolate(vis$required[["a"]]()), TRUE)
-  expect_true(is.na(isolate(vis$visible[["b"]]())))
+  expect_identical(isolate(vis$visible[["b"]]()), FALSE)
   expect_identical(isolate(vis$required[["b"]]()), FALSE)
 })
 
@@ -803,27 +802,27 @@ test_that("report_visible_observer drives the required axis over built cards", {
   expect_identical(isolate(env$vis$required[["d"]]()), FALSE)
 
   # Driving a and b required also paints them: report_visible marks the active
-  # view's on-screen fronts on the visible axis off the same layout report.
-  expect_identical(isolate(env$vis$visible[["a"]]()), "A")
-  expect_identical(isolate(env$vis$visible[["b"]]()), "A")
+  # view's on-screen fronts painted (visible TRUE) off the same layout report.
+  expect_identical(isolate(env$vis$visible[["a"]]()), TRUE)
+  expect_identical(isolate(env$vis$visible[["b"]]()), TRUE)
 
   # A layout change on inactive B leaves A's required set alone, and must not
   # clear the paint of on-screen a/b (report_visible tracks only A's layout).
   with_mock_context(ms, env$b(dock_grid(panels("block_panel-d"))))
   ms$flushReact()
   expect_identical(isolate(env$vis$required[["a"]]()), TRUE)
-  expect_identical(isolate(env$vis$visible[["a"]]()), "A")
+  expect_identical(isolate(env$vis$visible[["a"]]()), TRUE)
 
   # A drops a (its slot is now an extension panel): a parks (required FALSE, its
-  # paint cleared), b stays required TRUE with its paint intact.
+  # paint cleared to FALSE = built, off screen), b required TRUE, painted.
   with_mock_context(ms, env$a(
     dock_grid(panels("ext_panel-editor"), panels("block_panel-b"))
   ))
   ms$flushReact()
   expect_identical(isolate(env$vis$required[["a"]]()), FALSE)
-  expect_true(is.na(isolate(env$vis$visible[["a"]]())))
+  expect_identical(isolate(env$vis$visible[["a"]]()), FALSE)
   expect_identical(isolate(env$vis$required[["b"]]()), TRUE)
-  expect_identical(isolate(env$vis$visible[["b"]]()), "A")
+  expect_identical(isolate(env$vis$visible[["b"]]()), TRUE)
 
   # Switching to the not-yet-arranged B: its block required, a/b off screen.
   with_mock_context(ms, env$active("B"))
@@ -862,7 +861,7 @@ test_that("report_visible_observer coalesces set-equal reports", {
   expect_identical(isolate(env$vis$required[["b"]]()), TRUE)
 
   # report_visible painted a and b as it drove them required.
-  expect_identical(isolate(env$vis$visible[["a"]]()), "A")
+  expect_identical(isolate(env$vis$visible[["a"]]()), TRUE)
 
   # Re-report a set-equal (reordered) layout: the observer re-runs (reactive()
   # does not dedupe), but the on-screen set is unchanged -- the required axis
@@ -874,7 +873,7 @@ test_that("report_visible_observer coalesces set-equal reports", {
   ms$flushReact()
 
   expect_identical(isolate(env$vis$required[["a"]]()), TRUE)
-  expect_identical(isolate(env$vis$visible[["a"]]()), "A")
+  expect_identical(isolate(env$vis$visible[["a"]]()), TRUE)
 })
 
 test_that("report_visible_observer follows the live active panel (#361)", {
@@ -918,17 +917,17 @@ test_that("report_visible_observer follows the live active panel (#361)", {
 
   with_mock_context(ms, env$layout(layout_ab))
   ms$flushReact()
-  expect_identical(isolate(env$vis$visible[["a"]]()), "A")
-  expect_true(is.na(isolate(env$vis$visible[["b"]]())))
+  expect_identical(isolate(env$vis$visible[["a"]]()), TRUE)
+  expect_identical(isolate(env$vis$visible[["b"]]()), FALSE)
 
   # The client switches to b with no fresh layout echo (`layout` unchanged): the
   # active-panel signal alone must front b and park a -- the tab-switch repaint.
   with_mock_context(ms, env$active_panel("block_panel-b"))
   ms$flushReact()
   expect_identical(isolate(env$vis$required[["b"]]()), TRUE)
-  expect_identical(isolate(env$vis$visible[["b"]]()), "A")
+  expect_identical(isolate(env$vis$visible[["b"]]()), TRUE)
   expect_identical(isolate(env$vis$required[["a"]]()), FALSE)
-  expect_true(is.na(isolate(env$vis$visible[["a"]]())))
+  expect_identical(isolate(env$vis$visible[["a"]]()), FALSE)
 })
 
 test_that("board_server_callback seeds visibility before the client reports", {
@@ -942,7 +941,7 @@ test_that("board_server_callback seeds visibility before the client reports", {
     board_server_callback(board_rv, update = reactiveVal(), visibility = vis)
 
     # a is the fronted tab (required TRUE); b its back tab, built but off screen
-    # (required FALSE). Both are built (on the required channel as the ledger).
+    # (required FALSE). Both are in the dock's build ledger (visible non-NA).
     expect_setequal(built_cards(vis), c("a", "b"))
     expect_identical(isolate(vis$required[["a"]]()), TRUE)
     expect_identical(isolate(vis$required[["b"]]()), FALSE)
@@ -965,7 +964,7 @@ test_that("the visibility seed reads the active view's open tabs", {
     board_server_callback(board_rv, update = reactiveVal(), visibility = vis)
 
     # b and d front their groups (required TRUE); a is b's back tab (FALSE). All
-    # three are built (on the required channel as the ledger).
+    # three are in the dock's build ledger (visible non-NA).
     expect_setequal(built_cards(vis), c("a", "b", "d"))
     expect_identical(isolate(vis$required[["a"]]()), FALSE)
     expect_identical(isolate(vis$required[["b"]]()), TRUE)


### PR DESCRIPTION
## Summary

- On a deferred board (`background_construction_delay = Inf`), opening "Show code" before visiting a view left that view's cards permanently blank on the first visit.
- Root cause: `built_cards()` read the block's `required` slot as the dock's build ledger, but `required` is a multi-writer construction-demand channel. Core's "Show code" (`require_all_blocks`) marks every block required to export the whole script, so an off-screen block's demand read back as a built card and the view switch skipped its build.
- Reworked to the agreed cross-package fix, superseding the earlier `visibility$built` dock-side ledger: blockr.core#306 makes `visible` a logical three-state channel — `NA` never built / `FALSE` built off screen / `TRUE` painted, with `is_visible <- isTRUE` — and the dock folds its build ledger onto `!is.na(visible)` with no parallel axis.
- Dock changes: `built_cards()` reads `!is.na(visible)`; `mark_cards_rendered` writes `TRUE`; `show_cards` writes `FALSE` off screen — the persistence that fixes the bug, since a card leaving the screen keeps its ledger entry instead of being erased to `NA`; and the startup seed marks the active view's cards built (`FALSE`). Core's `require_all_blocks` is untouched.
- blockr.core#306 (the logical `visible` channel) has now merged to `main`, so the interim `blockr.core@306-visible-logical` pin has been dropped — this depends on plain `blockr.core`. Rebased onto current `main`.

Fixes #377.
