### PR TITLE
Apply a pending select on a view's first dock build

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* A `select` verb in a view's `views$mod` update is now applied when
+  that view's dock is built for the first time in the same update that
+  carries the select -- for instance an update that activates a
+  never-opened view. Previously the panel-op observer took the select as
+  its `ignoreInit` value and dropped it, so the board switched to the
+  view but the requested tab was not brought to the front. The pending
+  select is now folded into the grid the fresh dock restores from, so the
+  tab is fronted on first paint (#324).
+
 * New exports for downstream consumers that translate between bare
   block / extension ids and dock's panel-id scheme: the class predicates
   `is_dock_panel_id()`, `is_block_panel_id()` and `is_ext_panel_id()`,

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -687,6 +687,17 @@ manage_dock <- function(
   init_blocks <- coal(blocks, board_blocks(init_board))
   init_exts <- coal(extensions, dock_extensions(init_board))
 
+  # A pending `select` for this view rides the grid: fold it into the layout the
+  # first build restores from, so `restore_layout()` fronts that tab and the
+  # settled-echo mirror then persists it -- the path a tab click already takes.
+  # The panel-op observer skips this select as its `ignoreInit` value, and there
+  # is no live dock yet to set active on.
+  init_select <- isolate(update()$views$mod[[id]][["select"]])
+
+  if (not_null(init_select)) {
+    init_layout <- set_grid_active(init_layout, init_select)
+  }
+
   # Block/ext cards live at the board (parent) namespace level
   board_ns <- get_session()$ns
 

--- a/R/dock-grid.R
+++ b/R/dock-grid.R
@@ -362,6 +362,40 @@ append_default_leaves <- function(grid, pids) {
   )
 }
 
+# Front `pid`'s tab in the grid: set the `active` of the leaf that holds it and
+# focus its group, so a restore opens on that tab. A no-op when `pid` is not
+# placed -- a pending select may name a panel the view does not carry.
+set_grid_active <- function(grid, pid) {
+
+  pid <- as.character(pid)
+
+  if (!pid %in% grid_panel_ids(grid)) {
+    return(grid)
+  }
+
+  front <- function(node) {
+
+    if (is_grid_leaf(node)) {
+
+      if (pid %in% node[["panels"]]) {
+        node[["active"]] <- pid
+      }
+
+      return(node)
+    }
+
+    node[["children"]] <- lapply(node[["children"]], front)
+    node
+  }
+
+  new_dock_grid(
+    children = lapply(grid[["children"]], front),
+    sizes = grid[["sizes"]],
+    orientation = grid[["orientation"]],
+    focus = pid
+  )
+}
+
 new_dock_grids <- function(x = list()) {
   structure(x, class = "dock_grids")
 }

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -292,6 +292,59 @@ test_that("a stale close of an already-removed panel emits no rm (#362)", {
   expect_null(isolate(upd()))
 })
 
+test_that("a pending select fronts its tab on the first dock build (#324)", {
+
+  # A deferred view's dock is built during the reconcile that activates it, so
+  # the update carrying `active <- view` also carries its `select`. The panel-op
+  # observer can't apply that select (it is its `ignoreInit` value) and there is
+  # no live dock yet, so it is folded into the grid the first build restores
+  # from -- restore then fronts the tab.
+  brd <- board_args(
+    blocks = c(a = new_dataset_block(), b = new_dataset_block())
+  )
+
+  mod_input <- function(name) paste0("dock_main-", name)
+
+  ms <- new_mock_session()
+  withr::defer(if (!ms$isClosed()) ms$close())
+
+  upd <- reactiveVal(
+    list(
+      views = list(
+        mod = list(dock_main = list(select = as_block_panel_id("b")))
+      )
+    )
+  )
+
+  restored <- NULL
+
+  local_mocked_bindings(
+    restore_layout = function(layout, proxy, ...) {
+      restored <<- as_dock_grid(layout)
+      invisible()
+    }
+  )
+
+  with_mock_context(ms, {
+    manage_dock("dock_main", brd, visibility = fake_visibility(c("a", "b")),
+                update = upd)
+  })
+
+  ms$flushReact()
+
+  # restore_layout runs only once the client reports the dock initialized.
+  expect_null(restored)
+
+  do.call(
+    ms$setInputs,
+    set_names(list(TRUE), mod_input(dock_input("initialized")))
+  )
+
+  # The default two-block grid tabs a and b in one group, fronting a; the
+  # pending select fronts b instead.
+  expect_identical(restored[["children"]][[1L]][["active"]], "block_panel-b")
+})
+
 test_that("an extension key never leaks into core's plugin args (#318)", {
 
   # `edit` is a prefix of core's `edit_block` block-server formal; returned as

--- a/tests/testthat/test-views-delta.R
+++ b/tests/testthat/test-views-delta.R
@@ -872,6 +872,20 @@ test_that("restrict_grid resets the active tab when it is dropped", {
   expect_identical(leaf[["active"]], "a")
 })
 
+test_that("set_grid_active fronts a panel's leaf and focuses its group", {
+
+  grid <- dock_grid(panels("a", "b"), panels("c", "d"))
+
+  res <- set_grid_active(grid, "d")
+
+  expect_identical(res[["children"]][[1L]][["active"]], "a")
+  expect_identical(res[["children"]][[2L]][["active"]], "d")
+  expect_identical(res[["focus"]], "d")
+
+  # A select for a panel the grid doesn't place leaves it untouched.
+  expect_identical(set_grid_active(grid, "z"), grid)
+})
+
 test_that("the add / tab-close gestures emit authoritative deltas", {
 
   # The modal and tab close emit these payloads (in place of mutating the dock


### PR DESCRIPTION
## Summary

- A `select` in `views$mod[[view]]` was dropped when that view's dock was built for the first time in the same `update()` that carried it — for instance an update that activates a never-opened view. The board switched to the view, but the requested tab was not brought to the front.
- A deferred view's dock is built lazily during the reconcile that activates it, so `manage_dock()`'s panel-op observer (`observeEvent(update()$views$mod[[id]], …, ignoreInit = TRUE)`) is created with the `select` already present in `update()`, and `ignoreInit` takes it as the baseline and never applies it. Unlike `add` / `rm`, a `select` writes no board state that `restore_layout()` could recover it from on the fresh build, so the verb is simply lost.
- The dock's `initialized` observer now snapshots any pending `select` for the view at construction (`init_select`, alongside `init_layout`) and applies it via `op_select_panel()` once `restore_layout()` has placed the panels. `op_select_panel()` already no-ops a target that is not a live member of the view.
- Surfaced by blockr.assistant's `focus_panel(view, panel)`, which stages a `select` plus `active <- view` for an inactive target: for a never-opened view the board switched but the tab never fronted.
- Regression test in `test-board-server.R` drives `manage_dock` with a pending select, fires the `initialized` observer, and asserts the select reaches `op_select_panel`; it fails against the unfixed code.

Fixes #324
