### PR TITLE
Compose apply_board_update.dock_board() via NextMethod()

### DIFF
--- a/R/dock-board.R
+++ b/R/dock-board.R
@@ -350,6 +350,9 @@ add_block_panels_to_view <- function(board, block_ids) {
 #' @export
 apply_board_update.dock_board <- function(board, upd, ...) {
 
+  # Apply the core delta (blocks, links, stacks) first, then layer views on top.
+  board <- NextMethod()
+
   if (length(upd$blocks$add)) {
     board <- add_block_panels_to_view(board, names(upd$blocks$add))
   }


### PR DESCRIPTION
## Summary

- blockr.core#311 turns `apply_board_update()` into a real reducer, so `board_server()` routes the whole update through it instead of applying the core delta inline first. `apply_board_update.dock_board()` now calls `NextMethod()` to run the core apply (blocks, links, stacks) before adding the new block panels to the active view and applying the view deltas — one `apply_board_update()` call yields the full dock board.
- Temporarily pins `blockr.core@311-pure-apply` in `Remotes:` so CI builds against the unmerged core API; drop once core#311 lands.

Fixes #382