### PR TITLE
Gate block-mount e2e tests on the client-confirmed panel tab

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -364,6 +364,50 @@ wait_active_block_tabs <- function(app, view, expected, board_id = "my_board",
   wait_js(app, js, diagnose, timeout)
 }
 
+# Wait until the dock's block-panel tab strip has settled to exactly `expected`
+# `block_panel-<id>` tabs. A block add / remove commits server-side, then the
+# dockview client mounts (or drops) the panel's tab asynchronously -- so a bare
+# `block_panel_tabs()` read straight after `wait_for_idle()` (server idle, the
+# client render still in flight) can sample an empty or stale strip and eject a
+# green PR. The tab element is created when the panel is added, independent of
+# the card's lazy content mount, so it is the client-confirmed "panel is in the
+# dock" signal the tab-identity assertions actually need -- unlike the
+# `block_handle-<id>` card, which is inserted synchronously into the offcanvas
+# pool (present before, and regardless of, its panel mounting). Poll it with a
+# generous bounded budget so a slow-runner post-connect assembly window is
+# ridden out rather than timing out on a fixed one; a residual timeout dumps the
+# shell state so it is actionable -- zero block handles is the add never
+# landing, a handle with no tab is the panel mount lagging. `expected` is the
+# settled `block_panel-<id>` set, matched exactly and sorted (like
+# active_block_panel_tabs).
+wait_block_panel_tabs <- function(app, expected, board_id = "my_board",
+                                  timeout = 45 * 1000) {
+  want <- paste(sort(expected), collapse = ",")
+
+  js <- sprintf(
+    paste0(
+      "(function(){",
+      "var c=document.querySelector('#%s-view_container');if(!c)return false;",
+      "var a=Array.from(c.querySelectorAll('[id*=\"-tab-block_panel-\"]'))",
+      ".map(function(e){return e.id",
+      ".replace(/.*-tab-(block_panel-.+)$/,'$1');});",
+      "return Array.from(new Set(a)).sort().join(',')==='%s';})()"
+    ),
+    board_id, want
+  )
+
+  diagnose <- function() {
+    sprintf(
+      "[block-panel-tabs] want=[%s] got=[%s] shell=%s",
+      want,
+      paste(block_panel_tabs(app, board_id), collapse = ","),
+      dock_shell_diag(app, board_id)
+    )
+  }
+
+  wait_js(app, js, diagnose, timeout)
+}
+
 # Shared helpers for the edit-board extension e2e tests (links, stacks). The
 # extension namespaces its inputs under `my_board-ext_edit_board-`. The
 # extension panel stays active in those tests (pre-seeded fixtures, no block

--- a/tests/testthat/test-commit-sentinel.R
+++ b/tests/testthat/test-commit-sentinel.R
@@ -25,15 +25,15 @@ test_that("a settled gesture commits a bounded amount, quiescence adds none", {
   expect_false(is.na(baseline))
 
   # One gesture: add a block through the edit-board extension (its panel is
-  # active on load). The board update mounts the panel -- a stable
-  # block_handle-<id> DOM id marks the commit landing.
+  # active on load). The board update mounts the panel into the dock -- its
+  # client-confirmed tab marks the commit landing.
   app$set_inputs(
     `my_board-ext_edit_board-registry_select` = "dataset_block",
     `my_board-ext_edit_board-block_id` = "a"
   )
   app$click("my_board-ext_edit_board-confirm_add")
 
-  app$wait_for_js("document.getElementById('my_board-block_handle-a') !== null")
+  wait_block_panel_tabs(app, "block_panel-a")
   app$wait_for_idle()
 
   after_gesture <- app$get_value(export = "commit_count")

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -163,9 +163,11 @@ test_that("dock app renders a block added via the extension (#191)", {
   )
   app$click("my_board-ext_edit_board-confirm_add")
 
-  # The block card carries a stable `block_handle-<id>` DOM id; its presence
-  # is the add-block -> dock-render seam -- the board update mounting a panel.
-  app$wait_for_js("document.getElementById('my_board-block_handle-a') !== null")
+  # The add-block -> dock-render seam is the panel mounting into the dock, with
+  # its tab client-confirmed; the block card then lives inside that panel. The
+  # `block_handle-<id>` card alone is inserted into the offcanvas pool ahead of
+  # (and regardless of) the mount, so the tab is the signal that it landed.
+  wait_block_panel_tabs(app, "block_panel-a")
 
   expect_equal(
     app$get_js(
@@ -218,7 +220,7 @@ test_that("adding a second block keeps both block panels (#196)", {
     name = "panel-visibility",
     seed = 42,
     load_timeout = 30 * 1000,
-    timeout = 20 * 1000
+    timeout = 30 * 1000
   )
   withr::defer(app$stop())
 
@@ -234,12 +236,16 @@ test_that("adding a second block keeps both block panels (#196)", {
   }
 
   add_block("dataset_block", "a")
+  wait_block_panel_tabs(app, "block_panel-a")
   expect_identical(block_panel_tabs(app), "block_panel-a")
 
   # Pre-fix, the second add fired reconcile_views against a board that
   # lagged the live dock, restoring it and wiping both block panels -- leaving
-  # only the extension (#196). Both block tabs must survive.
+  # only the extension (#196). Both block tabs must survive; gating on the
+  # settled strip first makes the assertion deterministic (a permanent wipe
+  # never reaches the target set, so the wait times out and still catches it).
   add_block("head_block", "b")
+  wait_block_panel_tabs(app, c("block_panel-a", "block_panel-b"))
   expect_identical(block_panel_tabs(app), c("block_panel-a", "block_panel-b"))
 })
 
@@ -472,12 +478,13 @@ test_that("deleting a block via its card menu drops the panel and its link", {
     name = "remove-block",
     seed = 42,
     load_timeout = 30 * 1000,
-    timeout = 20 * 1000
+    timeout = 30 * 1000
   )
   withr::defer(app$stop())
 
   app$wait_for_idle()
 
+  wait_block_panel_tabs(app, c("block_panel-a", "block_panel-b"))
   expect_identical(block_panel_tabs(app), c("block_panel-a", "block_panel-b"))
   expect_identical(field(app, "ab_from"), "a")
 
@@ -493,7 +500,11 @@ test_that("deleting a block via its card menu drops the panel and its link", {
   app$wait_for_idle()
 
   # The board update removes b's dock panel and cascade-removes the dependent
-  # link, whose row then leaves the extension's links table.
+  # link, whose row then leaves the extension's links table. Gate on the panel
+  # actually dropping (client-confirmed) before asserting the strip and reading
+  # the link field: the same board update has cleared both by the time the tab
+  # is gone.
+  wait_block_panel_tabs(app, "block_panel-a")
   expect_identical(block_panel_tabs(app), "block_panel-a")
   expect_null(field(app, "ab_from"))
 })


### PR DESCRIPTION
## Summary

- The block add / remove e2e tests (`test-utils-serve.R`, `test-commit-sentinel.R`) waited on the `block_handle-<id>` card — which `build_block_ui()` inserts into the offcanvas pool *ahead of, and regardless of,* its panel mounting — or read the tab strip straight after `wait_for_idle()` (server idle, the dockview client mount still in flight). On a loaded runner the post-connect assembly window outran the fixed 30s budget, so `wait_for_js` timed out and the panel-count reads sampled an empty dock, ejecting green `ci / smoke` and `ci / coverage`.
- Add `wait_block_panel_tabs()`: gate on the dockview panel **tab** (created when the panel is added — the client-confirmed "panel is in the dock" signal the assertions actually check) with a bounded budget, then assert the strip. A residual timeout dumps the shell state (block-handle count, nav) so it is actionable — zero handles is the add never landing, a handle with no tab is the panel mount lagging.
- Route the five flaky assertions plus the commit-sentinel gate through it, and normalize the two outlier 20s app timeouts to the suite-standard 30s. The `#196` regression is still caught: a permanent wipe never reaches the target set, so the gate times out.
- Test-only; no package code changed. The deeper post-connect assembly latency (#215) remains separate — the new diagnostics now distinguish it from a test-side race.

Fixes #384