### PR TITLE
Stamp the writing action as a sidebar panel's owner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # blockr.dock (development version)
 
+* A sidebar panel now reports which action wrote the body it is showing.
+  Every `show_sidebar()` stamps the writing action's id on the panel, so
+  the stamp follows the write rather than the gesture: it covers paths no
+  consumer can observe, such as a holder of the trigger bundle firing a
+  shared-panel action directly. The stamp comes back as `owner` beside
+  `open` and `pinned` in the panel's input value, letting a consumer that
+  re-fires an editor on a selection tell whether the content it put there
+  is still on screen. Filling a panel takes it over, so nothing has to
+  declare which panel it writes to release it. dock's own auto-close
+  handlers (edit stack / link / inputs, which close when their target
+  leaves the board) now gate on this, and no longer close a form another
+  action has since written into the shared panel (#391).
+
 * A pinned stack / link sidebar now refreshes in place after a commit
   rather than being torn down and rebuilt, so search text, scroll
   position and anything the user entered that the commit did not consume

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,17 +1,19 @@
 # blockr.dock (development version)
 
-* A sidebar panel now reports which action wrote the body it is showing.
-  Every `show_sidebar()` stamps the writing action's id on the panel, so
-  the stamp follows the write rather than the gesture: it covers paths no
-  consumer can observe, such as a holder of the trigger bundle firing a
-  shared-panel action directly. The stamp comes back as `owner` beside
-  `open` and `pinned` in the panel's input value, letting a consumer that
-  re-fires an editor on a selection tell whether the content it put there
-  is still on screen. Filling a panel takes it over, so nothing has to
-  declare which panel it writes to release it. dock's own auto-close
-  handlers (edit stack / link / inputs, which close when their target
-  leaves the board) now gate on this, and no longer close a form another
-  action has since written into the shared panel (#391).
+* A sidebar panel now reports which module wrote the body it is showing.
+  Every `show_sidebar()` stamps the writing module's namespaced id on the
+  panel -- `NS(<board id>, <action id>)` for a board action -- taken from
+  the session the call runs in, so the stamp follows the write rather than
+  the gesture and covers paths no consumer can observe, such as a holder
+  of the trigger bundle firing a shared-panel action directly. It comes
+  back as `owner` beside `open` and `pinned` in the panel's input value,
+  letting a consumer that re-fires an editor on a selection tell whether
+  the content it put there is still on screen. Filling a panel takes it
+  over, so nothing has to declare which panel it writes to release it.
+  dock's own auto-close handlers (edit stack / link / inputs, which close
+  when their target leaves the board) now gate on this, and no longer
+  close a form another action has since written into the shared panel
+  (#391).
 
 * A pinned stack / link sidebar now refreshes in place after a commit
   rather than being torn down and rebuilt, so search text, scroll

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -1,7 +1,4 @@
 add_block_action <- function(trigger, board, update, ...) {
-
-  action <- "add_block_action"
-
   new_action(
     function(input, output, session) {
       # The add browser's catalogue never varies, so its body is
@@ -16,7 +13,7 @@ add_block_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         log_debug("opening pre-rendered add block sidebar")
-        show_sidebar(sidebar_id, title = "Add new block", owner = action)
+        show_sidebar(sidebar_id, title = "Add new block")
       })
 
       observeEvent(added(), {
@@ -27,20 +24,17 @@ add_block_action <- function(trigger, board, update, ...) {
         # Re-open without `ui` keeps the pre-rendered body in place (no
         # re-render) when the user pinned the panel; otherwise it hides.
         keep_or_hide_sidebar(
-          sidebar_id, ui = NULL, title = "Add new block", owner = action
+          sidebar_id, ui = NULL, title = "Add new block"
         )
       })
 
       NULL
     },
-    id = action
+    id = "add_block_action"
   )
 }
 
 append_block_action <- function(trigger, board, update, ...) {
-
-  action <- "append_block_action"
-
   new_action(
     function(input, output, session) {
       # The append catalogue (linkable blocks) is registry-based, not
@@ -59,7 +53,7 @@ append_block_action <- function(trigger, board, update, ...) {
       title <- function() paste0("Append from ", trigger())
 
       observeEvent(trigger(), {
-        show_sidebar(sidebar_id, title = title(), owner = action)
+        show_sidebar(sidebar_id, title = title())
       })
 
       observeEvent(added(), {
@@ -72,20 +66,17 @@ append_block_action <- function(trigger, board, update, ...) {
         ))
 
         keep_or_hide_sidebar(
-          sidebar_id, ui = NULL, title = title(), owner = action
+          sidebar_id, ui = NULL, title = title()
         )
       })
 
       NULL
     },
-    id = action
+    id = "append_block_action"
   )
 }
 
 prepend_block_action <- function(trigger, board, update, ...) {
-
-  action <- "prepend_block_action"
-
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
@@ -104,8 +95,7 @@ prepend_block_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = "Prepend new block", ui = browser_ui(),
-          owner = action
+          sidebar_id, title = "Prepend new block", ui = browser_ui()
         )
       })
 
@@ -117,14 +107,13 @@ prepend_block_action <- function(trigger, board, update, ...) {
         ))
 
         keep_or_hide_sidebar(
-          sidebar_id, title = "Prepend new block", ui = browser_ui(),
-          owner = action
+          sidebar_id, title = "Prepend new block", ui = browser_ui()
         )
       })
 
       NULL
     },
-    id = action
+    id = "prepend_block_action"
   )
 }
 

--- a/R/action-block.R
+++ b/R/action-block.R
@@ -1,4 +1,7 @@
 add_block_action <- function(trigger, board, update, ...) {
+
+  action <- "add_block_action"
+
   new_action(
     function(input, output, session) {
       # The add browser's catalogue never varies, so its body is
@@ -13,7 +16,7 @@ add_block_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         log_debug("opening pre-rendered add block sidebar")
-        show_sidebar(sidebar_id, title = "Add new block")
+        show_sidebar(sidebar_id, title = "Add new block", owner = action)
       })
 
       observeEvent(added(), {
@@ -24,17 +27,20 @@ add_block_action <- function(trigger, board, update, ...) {
         # Re-open without `ui` keeps the pre-rendered body in place (no
         # re-render) when the user pinned the panel; otherwise it hides.
         keep_or_hide_sidebar(
-          sidebar_id, ui = NULL, title = "Add new block"
+          sidebar_id, ui = NULL, title = "Add new block", owner = action
         )
       })
 
       NULL
     },
-    id = "add_block_action"
+    id = action
   )
 }
 
 append_block_action <- function(trigger, board, update, ...) {
+
+  action <- "append_block_action"
+
   new_action(
     function(input, output, session) {
       # The append catalogue (linkable blocks) is registry-based, not
@@ -53,7 +59,7 @@ append_block_action <- function(trigger, board, update, ...) {
       title <- function() paste0("Append from ", trigger())
 
       observeEvent(trigger(), {
-        show_sidebar(sidebar_id, title = title())
+        show_sidebar(sidebar_id, title = title(), owner = action)
       })
 
       observeEvent(added(), {
@@ -66,17 +72,20 @@ append_block_action <- function(trigger, board, update, ...) {
         ))
 
         keep_or_hide_sidebar(
-          sidebar_id, ui = NULL, title = title()
+          sidebar_id, ui = NULL, title = title(), owner = action
         )
       })
 
       NULL
     },
-    id = "append_block_action"
+    id = action
   )
 }
 
 prepend_block_action <- function(trigger, board, update, ...) {
+
+  action <- "prepend_block_action"
+
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
@@ -95,7 +104,8 @@ prepend_block_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = "Prepend new block", ui = browser_ui()
+          sidebar_id, title = "Prepend new block", ui = browser_ui(),
+          owner = action
         )
       })
 
@@ -107,13 +117,14 @@ prepend_block_action <- function(trigger, board, update, ...) {
         ))
 
         keep_or_hide_sidebar(
-          sidebar_id, title = "Prepend new block", ui = browser_ui()
+          sidebar_id, title = "Prepend new block", ui = browser_ui(),
+          owner = action
         )
       })
 
       NULL
     },
-    id = "prepend_block_action"
+    id = action
   )
 }
 

--- a/R/action-inputs.R
+++ b/R/action-inputs.R
@@ -1,4 +1,7 @@
 edit_inputs_action <- function(trigger, board, update, ...) {
+
+  action <- "edit_inputs_action"
+
   new_action(
     function(input, output, session) {
 
@@ -21,16 +24,19 @@ edit_inputs_action <- function(trigger, board, update, ...) {
       sidebar_title <- function() paste0("Edit inputs ", trigger())
 
       observeEvent(trigger(), {
-        show_sidebar(sidebar_id, title = sidebar_title(), ui = menu_ui())
+        show_sidebar(
+          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
+        )
       })
 
       # Close the sidebar the moment the block leaves the board (removed
-      # elsewhere). Guarded on an edit being in progress and the sidebar open.
+      # elsewhere). Guarded on an edit being in progress and on this action
+      # still owning the open panel.
       observeEvent(board$board, {
         id <- trigger()
         if (length(id) == 1L && !is.na(id) && nzchar(id) &&
               !id %in% board_block_ids(board$board) &&
-              isTRUE(sidebar_state(sidebar_id)$open)) {
+              owns_open_sidebar(sidebar_id, action)) {
           hide_sidebar(sidebar_id)
         }
       }, ignoreInit = TRUE)
@@ -44,6 +50,6 @@ edit_inputs_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = "edit_inputs_action"
+    id = action
   )
 }

--- a/R/action-inputs.R
+++ b/R/action-inputs.R
@@ -1,7 +1,4 @@
 edit_inputs_action <- function(trigger, board, update, ...) {
-
-  action <- "edit_inputs_action"
-
   new_action(
     function(input, output, session) {
 
@@ -24,9 +21,7 @@ edit_inputs_action <- function(trigger, board, update, ...) {
       sidebar_title <- function() paste0("Edit inputs ", trigger())
 
       observeEvent(trigger(), {
-        show_sidebar(
-          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
-        )
+        show_sidebar(sidebar_id, title = sidebar_title(), ui = menu_ui())
       })
 
       # Close the sidebar the moment the block leaves the board (removed
@@ -36,7 +31,7 @@ edit_inputs_action <- function(trigger, board, update, ...) {
         id <- trigger()
         if (length(id) == 1L && !is.na(id) && nzchar(id) &&
               !id %in% board_block_ids(board$board) &&
-              owns_open_sidebar(sidebar_id, action)) {
+              owns_open_sidebar(sidebar_id)) {
           hide_sidebar(sidebar_id)
         }
       }, ignoreInit = TRUE)
@@ -50,6 +45,6 @@ edit_inputs_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = action
+    id = "edit_inputs_action"
   )
 }

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -1,7 +1,5 @@
 add_link_action <- function(trigger, board, update, ...) {
 
-  action <- "add_link_action"
-
   new_action(
     function(input, output, session) {
 
@@ -33,7 +31,7 @@ add_link_action <- function(trigger, board, update, ...) {
         # NULL-check / notification here anymore: a block that can't be
         # linked still opens the sidebar with an in-place empty message.
         show_sidebar(
-          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
+          sidebar_id, title = sidebar_title(), ui = menu_ui()
         )
       })
 
@@ -50,14 +48,11 @@ add_link_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = action
+    id = "add_link_action"
   )
 }
 
 edit_link_action <- function(trigger, board, update, ...) {
-
-  action <- "edit_link_action"
-
   new_action(
     function(input, output, session) {
 
@@ -82,7 +77,7 @@ edit_link_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
+          sidebar_id, title = sidebar_title(), ui = menu_ui()
         )
       })
 
@@ -95,7 +90,7 @@ edit_link_action <- function(trigger, board, update, ...) {
         id <- trigger()
         if (length(id) == 1L && !is.na(id) && nzchar(id) &&
               !id %in% board_link_ids(board$board) &&
-              owns_open_sidebar(sidebar_id, action)) {
+              owns_open_sidebar(sidebar_id)) {
           hide_sidebar(sidebar_id)
         }
       }, ignoreInit = TRUE)
@@ -129,7 +124,7 @@ edit_link_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = action
+    id = "edit_link_action"
   )
 }
 

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -1,5 +1,7 @@
 add_link_action <- function(trigger, board, update, ...) {
 
+  action <- "add_link_action"
+
   new_action(
     function(input, output, session) {
 
@@ -31,7 +33,7 @@ add_link_action <- function(trigger, board, update, ...) {
         # NULL-check / notification here anymore: a block that can't be
         # linked still opens the sidebar with an in-place empty message.
         show_sidebar(
-          sidebar_id, title = sidebar_title(), ui = menu_ui()
+          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
         )
       })
 
@@ -48,11 +50,14 @@ add_link_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = "add_link_action"
+    id = action
   )
 }
 
 edit_link_action <- function(trigger, board, update, ...) {
+
+  action <- "edit_link_action"
+
   new_action(
     function(input, output, session) {
 
@@ -77,19 +82,20 @@ edit_link_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = sidebar_title(), ui = menu_ui()
+          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
         )
       })
 
       # Close the sidebar the moment the edited link leaves the board
       # (removed elsewhere): editing a link that no longer exists makes no
-      # sense, so don't wait for an "Update" click. Guarded on the sidebar
-      # being open and on an edit actually being in progress.
+      # sense, so don't wait for an "Update" click. Guarded on an edit
+      # actually being in progress and on this action still owning the
+      # open panel.
       observeEvent(board$board, {
         id <- trigger()
         if (length(id) == 1L && !is.na(id) && nzchar(id) &&
               !id %in% board_link_ids(board$board) &&
-              isTRUE(sidebar_state(sidebar_id)$open)) {
+              owns_open_sidebar(sidebar_id, action)) {
           hide_sidebar(sidebar_id)
         }
       }, ignoreInit = TRUE)
@@ -123,7 +129,7 @@ edit_link_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = "edit_link_action"
+    id = action
   )
 }
 

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -1,4 +1,7 @@
 add_stack_action <- function(trigger, board, update, ...) {
+
+  action <- "add_stack_action"
+
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
@@ -16,7 +19,8 @@ add_stack_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = "Create new stack", ui = menu_ui()
+          sidebar_id, title = "Create new stack", ui = menu_ui(),
+          owner = action
         )
       })
 
@@ -33,11 +37,14 @@ add_stack_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = "add_stack_action"
+    id = action
   )
 }
 
 edit_stack_action <- function(trigger, board, update, ...) {
+
+  action <- "edit_stack_action"
+
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
@@ -60,17 +67,16 @@ edit_stack_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = sidebar_title(), ui = menu_ui()
+          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
         )
       })
 
       # Close the sidebar the moment the edited stack leaves the board
       # (removed elsewhere): editing a stack that no longer exists makes
-      # no sense, so don't wait for an "Update" click. Guarded on the
-      # sidebar being open. (If another action had since taken over the
-      # shared slot this could close that form too - a rare
-      # edit-then-switch-then-remove sequence; revisit with sidebar
-      # ownership if it ever bites.)
+      # no sense, so don't wait for an "Update" click. Guarded on this
+      # action still owning the open panel, so an edit-then-switch-then-
+      # remove sequence closes nothing another action has since written
+      # into the shared slot.
       observeEvent(board$board, {
         id <- trigger()
         # No-op unless an edit is actually in progress (a valid stack id);
@@ -78,7 +84,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
         # mutates the board) and the membership test would error.
         if (length(id) == 1L && !is.na(id) && nzchar(id) &&
               !id %in% board_stack_ids(board$board) &&
-              isTRUE(sidebar_state(sidebar_id)$open)) {
+              owns_open_sidebar(sidebar_id, action)) {
           hide_sidebar(sidebar_id)
         }
       }, ignoreInit = TRUE)
@@ -123,7 +129,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = "edit_stack_action"
+    id = action
   )
 }
 

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -1,7 +1,4 @@
 add_stack_action <- function(trigger, board, update, ...) {
-
-  action <- "add_stack_action"
-
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
@@ -19,8 +16,7 @@ add_stack_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = "Create new stack", ui = menu_ui(),
-          owner = action
+          sidebar_id, title = "Create new stack", ui = menu_ui()
         )
       })
 
@@ -37,14 +33,11 @@ add_stack_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = action
+    id = "add_stack_action"
   )
 }
 
 edit_stack_action <- function(trigger, board, update, ...) {
-
-  action <- "edit_stack_action"
-
   new_action(
     function(input, output, session) {
       sidebar_id <- NS(isolate(board$board_id), "actions_sidebar")
@@ -67,7 +60,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
 
       observeEvent(trigger(), {
         show_sidebar(
-          sidebar_id, title = sidebar_title(), ui = menu_ui(), owner = action
+          sidebar_id, title = sidebar_title(), ui = menu_ui()
         )
       })
 
@@ -84,7 +77,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
         # mutates the board) and the membership test would error.
         if (length(id) == 1L && !is.na(id) && nzchar(id) &&
               !id %in% board_stack_ids(board$board) &&
-              owns_open_sidebar(sidebar_id, action)) {
+              owns_open_sidebar(sidebar_id)) {
           hide_sidebar(sidebar_id)
         }
       }, ignoreInit = TRUE)
@@ -129,7 +122,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
 
       NULL
     },
-    id = action
+    id = "edit_stack_action"
   )
 }
 

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -134,6 +134,12 @@ board_ui.dock_board <- function(
     # silently swap a pinned panel's body, since the JS replaces content in
     # place and never inspects the pin class. Splitting by concern keeps
     # pin semantics intuitive without multi-pin machinery on the JS side.
+    # For "actions_sidebar", which cannot be split (its handlers ship
+    # trigger-dependent forms), the equivalent guarantee is the ownership
+    # stamp: every `show_sidebar()` records the writing action's id on the
+    # panel, reported back as `owner` alongside `open` / `pinned` in the
+    # panel's input value, so a holder of a trigger bundle can tell whose
+    # form is currently on screen.
     sidebar_ui(
       NS(id, "actions_sidebar"),
       mode = "overlay",

--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -136,10 +136,11 @@ board_ui.dock_board <- function(
     # pin semantics intuitive without multi-pin machinery on the JS side.
     # For "actions_sidebar", which cannot be split (its handlers ship
     # trigger-dependent forms), the equivalent guarantee is the ownership
-    # stamp: every `show_sidebar()` records the writing action's id on the
-    # panel, reported back as `owner` alongside `open` / `pinned` in the
-    # panel's input value, so a holder of a trigger bundle can tell whose
-    # form is currently on screen.
+    # stamp: every `show_sidebar()` records the writing module's namespaced
+    # id on the panel -- `NS(<board id>, <action id>)` for a board action --
+    # reported back as `owner` alongside `open` / `pinned` in the panel's
+    # input value, so a holder of a trigger bundle can tell whose form is
+    # currently on screen.
     sidebar_ui(
       NS(id, "actions_sidebar"),
       mode = "overlay",

--- a/R/sidebar-server.R
+++ b/R/sidebar-server.R
@@ -79,11 +79,12 @@ sidebar_dep <- function() {
   )
 }
 
-show_sidebar <- function(id, ui = NULL, title = NULL,
+show_sidebar <- function(id, ui = NULL, title = NULL, owner = NULL,
                          session = get_session()) {
   stopifnot(
     is.character(id), length(id) == 1L, nzchar(id),
-    is.null(title) || (is.character(title) && length(title) == 1L)
+    is.null(title) || (is.character(title) && length(title) == 1L),
+    is.null(owner) || is_string(owner)
   )
   root <- root_session(session)
 
@@ -105,6 +106,14 @@ show_sidebar <- function(id, ui = NULL, title = NULL,
   if (!is.null(title)) {
     payload$title <- title
   }
+
+  # Ownership rides along unconditionally (`[` assignment, so `NULL` stays
+  # in the payload and serializes as JSON null rather than dropping out):
+  # a show sets the panel's owner to whoever declared it and clears it
+  # otherwise. Undeclared writers therefore leave no stale stamp behind,
+  # which is the point of stamping here rather than at the trigger.
+  payload["owner"] <- list(owner)
+
   root$sendInputMessage(id, payload)
   invisible(NULL)
 }
@@ -125,16 +134,25 @@ sidebar_state <- function(id, session = get_session()) {
   # want the current value without creating a reactive dependency on it.
   state <- isolate(root$input[[id]])
   if (is.null(state)) {
-    list(open = FALSE, pinned = FALSE)
+    list(open = FALSE, pinned = FALSE, owner = NULL)
   } else {
     state
   }
 }
 
-keep_or_hide_sidebar <- function(id, ui, title = NULL,
+# Whether `owner` still holds an open panel. The auto-close handlers gate on
+# this so a handler whose target vanished closes its own form and not the one
+# another action has since written into the shared slot.
+owns_open_sidebar <- function(id, owner, session = get_session()) {
+  state <- sidebar_state(id, session = session)
+
+  isTRUE(state$open) && identical(state$owner, owner)
+}
+
+keep_or_hide_sidebar <- function(id, ui, title = NULL, owner = NULL,
                                  session = get_session()) {
   if (isTRUE(sidebar_state(id, session = session)$pinned)) {
-    show_sidebar(id, ui = ui, title = title, session = session)
+    show_sidebar(id, ui = ui, title = title, owner = owner, session = session)
   } else {
     hide_sidebar(id, session = session)
   }

--- a/R/sidebar-server.R
+++ b/R/sidebar-server.R
@@ -79,12 +79,11 @@ sidebar_dep <- function() {
   )
 }
 
-show_sidebar <- function(id, ui = NULL, title = NULL, owner = NULL,
+show_sidebar <- function(id, ui = NULL, title = NULL,
                          session = get_session()) {
   stopifnot(
     is.character(id), length(id) == 1L, nzchar(id),
-    is.null(title) || (is.character(title) && length(title) == 1L),
-    is.null(owner) || is_string(owner)
+    is.null(title) || (is.character(title) && length(title) == 1L)
   )
   root <- root_session(session)
 
@@ -107,12 +106,13 @@ show_sidebar <- function(id, ui = NULL, title = NULL, owner = NULL,
     payload$title <- title
   }
 
-  # Ownership rides along unconditionally (`[` assignment, so `NULL` stays
-  # in the payload and serializes as JSON null rather than dropping out):
-  # a show sets the panel's owner to whoever declared it and clears it
-  # otherwise. Undeclared writers therefore leave no stale stamp behind,
-  # which is the point of stamping here rather than at the trigger.
-  payload["owner"] <- list(owner)
+  # The panel's owner is whoever wrote the body: the module this call runs
+  # in, read off the calling session before the walk to the root. Every write
+  # therefore stamps by construction, with nothing declared at the call site
+  # and nothing to keep in step with the action's id. It does bind the stamp
+  # to where the call is written -- a write deferred into a flush callback
+  # would run under the root session and stamp that instead.
+  payload$owner <- session$ns(NULL)
 
   root$sendInputMessage(id, payload)
   invisible(NULL)
@@ -140,19 +140,20 @@ sidebar_state <- function(id, session = get_session()) {
   }
 }
 
-# Whether `owner` still holds an open panel. The auto-close handlers gate on
-# this so a handler whose target vanished closes its own form and not the one
-# another action has since written into the shared slot.
-owns_open_sidebar <- function(id, owner, session = get_session()) {
+# Whether the calling module still holds an open panel, asked the same way a
+# write stamps it. The auto-close handlers gate on this so a handler whose
+# target vanished closes its own form and not the one another action has
+# since written into the shared slot.
+owns_open_sidebar <- function(id, session = get_session()) {
   state <- sidebar_state(id, session = session)
 
-  isTRUE(state$open) && identical(state$owner, owner)
+  isTRUE(state$open) && identical(state$owner, session$ns(NULL))
 }
 
-keep_or_hide_sidebar <- function(id, ui, title = NULL, owner = NULL,
+keep_or_hide_sidebar <- function(id, ui, title = NULL,
                                  session = get_session()) {
   if (isTRUE(sidebar_state(id, session = session)$pinned)) {
-    show_sidebar(id, ui = ui, title = title, owner = owner, session = session)
+    show_sidebar(id, ui = ui, title = title, session = session)
   } else {
     hide_sidebar(id, session = session)
   }

--- a/inst/assets/js/sidebar-server.js
+++ b/inst/assets/js/sidebar-server.js
@@ -12,6 +12,11 @@
 
   var STATE_EVENT = "blockr-sidebar:state";
   var INIT_FLAG = "blockrSidebarInit";
+  // Who wrote the body currently in the panel, stamped by
+  // `show_sidebar(owner = )` and reported back in the input value. Kept as
+  // an attribute rather than a JS property so it survives in the DOM and is
+  // readable by anything inspecting the panel.
+  var OWNER_ATTR = "data-blockr-sidebar-owner";
 
   function getBody(panel) {
     return panel.querySelector(".blockr-sidebar-body");
@@ -230,6 +235,17 @@
       }
     }
 
+    // Owner is stamped before opening so the state event that `openPanel`
+    // dispatches already carries it. A `null` owner clears the stamp: the
+    // writer did not declare itself, so the previous one no longer holds.
+    if (typeof data.owner !== "undefined") {
+      if (data.owner === null) {
+        panel.removeAttribute(OWNER_ATTR);
+      } else {
+        panel.setAttribute(OWNER_ATTR, String(data.owner));
+      }
+    }
+
     openPanel(panel);
   }
 
@@ -329,7 +345,8 @@
     getValue: function (el) {
       return {
         open: el.classList.contains("blockr-sidebar-open"),
-        pinned: el.classList.contains("blockr-sidebar-pinned")
+        pinned: el.classList.contains("blockr-sidebar-pinned"),
+        owner: el.getAttribute(OWNER_ATTR)
       };
     },
     receiveMessage: function (el, data) {

--- a/inst/assets/js/sidebar-server.js
+++ b/inst/assets/js/sidebar-server.js
@@ -236,14 +236,9 @@
     }
 
     // Owner is stamped before opening so the state event that `openPanel`
-    // dispatches already carries it. A `null` owner clears the stamp: the
-    // writer did not declare itself, so the previous one no longer holds.
+    // dispatches already carries it.
     if (typeof data.owner !== "undefined") {
-      if (data.owner === null) {
-        panel.removeAttribute(OWNER_ATTR);
-      } else {
-        panel.setAttribute(OWNER_ATTR, String(data.owner));
-      }
+      panel.setAttribute(OWNER_ATTR, String(data.owner));
     }
 
     openPanel(panel);

--- a/inst/examples/sidebar-owner/app.R
+++ b/inst/examples/sidebar-owner/app.R
@@ -1,0 +1,45 @@
+library(shiny)
+library(blockr.core)
+library(blockr.dock)
+
+# Two buttons firing shared-panel actions straight off the trigger bundle -
+# the path a consumer's context menu takes, and the one that declares nothing
+# about which panel the action fills.
+fire_ui <- function(id, board) {
+  div(
+    actionButton(NS(id, "add_link"), "Connect a"),
+    actionButton(NS(id, "edit_stack"), "Edit s1")
+  )
+}
+
+fire_srv <- function(id, board, update, actions, ...) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+
+      observeEvent(input$add_link, actions[["add_link_action"]]("a"))
+      observeEvent(input$edit_stack, actions[["edit_stack_action"]]("s1"))
+
+      list(state = list())
+    }
+  )
+}
+
+new_fire_action_extension <- function(...) {
+  new_dock_extension(
+    fire_srv,
+    fire_ui,
+    name = "Fire actions",
+    class = "fire_action_extension",
+    ...
+  )
+}
+
+serve(
+  new_dock_board(
+    c(a = new_dataset_block("iris"), b = new_head_block()),
+    stacks = stacks(s1 = "a"),
+    extensions = list(fire = new_fire_action_extension())
+  ),
+  "my_board"
+)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -53,12 +53,14 @@ board_args <- function(...) {
 # Run an action generator's server against a fixed trigger value, long enough
 # for its trigger-driven observers to fire once. For assertions on what an
 # action does on the way in (opening a sidebar, stamping its owner) rather
-# than on what it commits.
+# than on what it commits. Mounted under the action's own id, the way
+# `register_action()` mounts it, so the module namespace the sidebar owner is
+# read from matches production.
 fire_action <- function(gen, trigger, board) {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        action_id(gen),
         gen(
           trigger = reactive(trigger),
           board = board,

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -50,6 +50,26 @@ board_args <- function(...) {
   )[["board"]]
 }
 
+# Run an action generator's server against a fixed trigger value, long enough
+# for its trigger-driven observers to fire once. For assertions on what an
+# action does on the way in (opening a sidebar, stamping its owner) rather
+# than on what it commits.
+fire_action <- function(gen, trigger, board) {
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        gen(
+          trigger = reactive(trigger),
+          board = board,
+          update = reactiveVal(list())
+        )
+      )
+    },
+    session$flushReact()
+  )
+}
+
 # Stand-in for the `visibility` channel blockr.core hands the board callback:
 # three environments of per-block reactiveVals (`required`, `visible`,
 # `frozen`), one slot per block, mirroring core's add_vis_slots at construction

--- a/tests/testthat/test-action-block.R
+++ b/tests/testthat/test-action-block.R
@@ -267,11 +267,15 @@ test_that("prepend block action: target_input picks the link slot", {
   )
 })
 
-test_that("block actions stamp themselves as the panel owner", {
-  show_calls <- list()
+test_that("block actions write the sidebar from their own module", {
+  # `show_sidebar()` reads the panel's owner off the session it is called
+  # with, so a write has to happen in the action's own reactive domain. A
+  # write deferred into a flush callback would run under the root session
+  # and stamp that instead, which this records.
+  wrote_from <- list()
   local_mocked_bindings(
-    show_sidebar = function(id, ..., owner = NULL) {
-      show_calls[[length(show_calls) + 1L]] <<- owner
+    show_sidebar = function(...) {
+      wrote_from[[length(wrote_from) + 1L]] <<- get_session()$ns(NULL)
       invisible(NULL)
     },
     keep_or_hide_sidebar = function(...) invisible(NULL),
@@ -288,7 +292,7 @@ test_that("block actions stamp themselves as the panel owner", {
   fire_action(prepend_block_action, "m", r_board)
 
   expect_identical(
-    show_calls,
+    wrote_from,
     list("add_block_action", "append_block_action", "prepend_block_action")
   )
 })

--- a/tests/testthat/test-action-block.R
+++ b/tests/testthat/test-action-block.R
@@ -267,6 +267,32 @@ test_that("prepend block action: target_input picks the link slot", {
   )
 })
 
+test_that("block actions stamp themselves as the panel owner", {
+  show_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(id, ..., owner = NULL) {
+      show_calls[[length(show_calls) + 1L]] <<- owner
+      invisible(NULL)
+    },
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar         = function(...) invisible(NULL)
+  )
+
+  r_board <- reactiveValues(
+    board = new_board(c(a = new_dataset_block("iris"), m = new_merge_block())),
+    board_id = "b"
+  )
+
+  fire_action(add_block_action, TRUE, r_board)
+  fire_action(append_block_action, "a", r_board)
+  fire_action(prepend_block_action, "m", r_board)
+
+  expect_identical(
+    show_calls,
+    list("add_block_action", "append_block_action", "prepend_block_action")
+  )
+})
+
 test_that("append block action: a name field names the variadic slot", {
   r_board <- reactiveValues(
     board = new_board(blocks = c(a = new_dataset_block())),

--- a/tests/testthat/test-action-inputs.R
+++ b/tests/testthat/test-action-inputs.R
@@ -158,7 +158,7 @@ test_that("edit inputs action: reorder commits a from-permutation mod", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"), board = r_board, update = r_update
         )
@@ -191,7 +191,7 @@ test_that("edit inputs action: an identity reorder issues no update", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"), board = r_board, update = r_update
         )
@@ -214,7 +214,7 @@ test_that("edit inputs action: rename commits an input mod", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"), board = r_board, update = r_update
         )
@@ -244,7 +244,7 @@ test_that("edit inputs action: a duplicate input name is rejected", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"), board = r_board, update = r_update
         )
@@ -269,7 +269,7 @@ test_that("edit inputs action: remove commits a links rm", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"), board = r_board, update = r_update
         )
@@ -307,7 +307,7 @@ test_that("edit inputs action: removing the block closes the sidebar", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"), board = r_board, update = r_update
         )
@@ -346,7 +346,7 @@ test_that("edit inputs action: a form written by another action stays open", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"),
           board = r_board,
@@ -365,11 +365,15 @@ test_that("edit inputs action: a form written by another action stays open", {
   )
 })
 
-test_that("edit inputs action stamps itself as the panel owner", {
-  show_calls <- list()
+test_that("edit inputs action writes the sidebar from its own module", {
+  # `show_sidebar()` reads the panel's owner off the session it is called
+  # with, so a write has to happen in the action's own reactive domain. A
+  # write deferred into a flush callback would run under the root session
+  # and stamp that instead, which this records.
+  wrote_from <- list()
   local_mocked_bindings(
-    show_sidebar = function(id, ..., owner = NULL) {
-      show_calls[[length(show_calls) + 1L]] <<- owner
+    show_sidebar = function(...) {
+      wrote_from[[length(wrote_from) + 1L]] <<- get_session()$ns(NULL)
       invisible(NULL)
     },
     keep_or_hide_sidebar = function(...) invisible(NULL),
@@ -378,7 +382,7 @@ test_that("edit inputs action stamps itself as the panel owner", {
 
   fire_action(edit_inputs_action, "r", inputs_board(variadic_links()))
 
-  expect_identical(show_calls, list("edit_inputs_action"))
+  expect_identical(wrote_from, list("edit_inputs_action"))
 })
 
 test_that("edit inputs menu server renders the row list", {
@@ -591,7 +595,7 @@ test_that("edit inputs action: a redirect that would cycle is rejected", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("m"), board = r_board, update = r_update
         )
@@ -638,7 +642,7 @@ test_that("edit inputs action: an add command commits a new link", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_inputs_action",
         edit_inputs_action(
           trigger = reactive("r"), board = r_board, update = r_update
         )

--- a/tests/testthat/test-action-inputs.R
+++ b/tests/testthat/test-action-inputs.R
@@ -295,7 +295,10 @@ test_that("edit inputs action: removing the block closes the sidebar", {
       hide_calls[[length(hide_calls) + 1L]] <<- id
       invisible(NULL)
     },
-    sidebar_state = function(id, ...) list(open = TRUE, pinned = TRUE)
+    # The auto-close is gated on this action owning the open panel.
+    sidebar_state = function(id, ...) {
+      list(open = TRUE, pinned = TRUE, owner = "edit_inputs_action")
+    }
   )
 
   r_board <- inputs_board(variadic_links())
@@ -322,6 +325,60 @@ test_that("edit inputs action: removing the block closes the sidebar", {
       expect_identical(hide_calls[[1L]], "b-actions_sidebar")
     }
   )
+})
+
+test_that("edit inputs action: a form written by another action stays open", {
+  hide_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(id, ...) {
+      hide_calls[[length(hide_calls) + 1L]] <<- id
+      invisible(NULL)
+    },
+    sidebar_state = function(id, ...) {
+      list(open = TRUE, pinned = TRUE, owner = "edit_stack_action")
+    }
+  )
+
+  r_board <- inputs_board(variadic_links())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_inputs_action(
+          trigger = reactive("r"),
+          board = r_board,
+          update = reactiveVal(list())
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      r_board$board <- new_board(board_blocks(r_board$board)["a"])
+      session$flushReact()
+
+      expect_length(hide_calls, 0L)
+    }
+  )
+})
+
+test_that("edit inputs action stamps itself as the panel owner", {
+  show_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(id, ..., owner = NULL) {
+      show_calls[[length(show_calls) + 1L]] <<- owner
+      invisible(NULL)
+    },
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(...) invisible(NULL)
+  )
+
+  fire_action(edit_inputs_action, "r", inputs_board(variadic_links()))
+
+  expect_identical(show_calls, list("edit_inputs_action"))
 })
 
 test_that("edit inputs menu server renders the row list", {

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -757,7 +757,10 @@ test_that("edit link action: removing the edited link closes the sidebar", {
       hide_calls[[length(hide_calls) + 1L]] <<- id
       invisible(NULL)
     },
-    sidebar_state = function(id, ...) list(open = TRUE, pinned = TRUE)
+    # The auto-close is gated on this action owning the open panel.
+    sidebar_state = function(id, ...) {
+      list(open = TRUE, pinned = TRUE, owner = "edit_link_action")
+    }
   )
 
   r_board <- edit_link_env(links(l1 = new_link("a", "h", "data")))
@@ -784,6 +787,63 @@ test_that("edit link action: removing the edited link closes the sidebar", {
       expect_identical(hide_calls[[1L]], "b-actions_sidebar")
     }
   )
+})
+
+test_that("edit link action: a form written by another action stays open", {
+  hide_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(id, ...) {
+      hide_calls[[length(hide_calls) + 1L]] <<- id
+      invisible(NULL)
+    },
+    sidebar_state = function(id, ...) {
+      list(open = TRUE, pinned = TRUE, owner = "edit_stack_action")
+    }
+  )
+
+  r_board <- edit_link_env(links(l1 = new_link("a", "h", "data")))
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_link_action(
+          trigger = reactive("l1"),
+          board = r_board,
+          update = reactiveVal(list())
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      r_board$board <- new_board(board_blocks(r_board$board))
+      session$flushReact()
+
+      expect_length(hide_calls, 0L)
+    }
+  )
+})
+
+test_that("link actions stamp themselves as the panel owner", {
+  show_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(id, ..., owner = NULL) {
+      show_calls[[length(show_calls) + 1L]] <<- owner
+      invisible(NULL)
+    },
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(...) invisible(NULL)
+  )
+
+  r_board <- edit_link_env(links(l1 = new_link("a", "h", "data")))
+
+  fire_action(add_link_action, "a", r_board)
+  fire_action(edit_link_action, "l1", r_board)
+
+  expect_identical(show_calls, list("add_link_action", "edit_link_action"))
 })
 
 test_that("edit link menu ui holds the endpoint / input slots and confirm", {

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -546,7 +546,7 @@ test_that("edit link action: redirecting the target commits a mod delta", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -570,7 +570,7 @@ test_that("edit link action: switching the input slot commits only input", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -593,7 +593,7 @@ test_that("edit link action: naming a variadic positional slot", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -617,7 +617,7 @@ test_that("edit link action: redirecting the source commits only from", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -640,7 +640,7 @@ test_that("edit link action: an unchanged confirm issues no update", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -667,7 +667,7 @@ test_that("edit link action: a redirect that closes a cycle is rejected", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -693,7 +693,7 @@ test_that("edit link action: a self-link is rejected", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -769,7 +769,7 @@ test_that("edit link action: removing the edited link closes the sidebar", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"), board = r_board, update = r_update
         )
@@ -808,7 +808,7 @@ test_that("edit link action: a form written by another action stays open", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_link_action",
         edit_link_action(
           trigger = reactive("l1"),
           board = r_board,
@@ -827,11 +827,15 @@ test_that("edit link action: a form written by another action stays open", {
   )
 })
 
-test_that("link actions stamp themselves as the panel owner", {
-  show_calls <- list()
+test_that("link actions write the sidebar from their own module", {
+  # `show_sidebar()` reads the panel's owner off the session it is called
+  # with, so a write has to happen in the action's own reactive domain. A
+  # write deferred into a flush callback would run under the root session
+  # and stamp that instead, which this records.
+  wrote_from <- list()
   local_mocked_bindings(
-    show_sidebar = function(id, ..., owner = NULL) {
-      show_calls[[length(show_calls) + 1L]] <<- owner
+    show_sidebar = function(...) {
+      wrote_from[[length(wrote_from) + 1L]] <<- get_session()$ns(NULL)
       invisible(NULL)
     },
     keep_or_hide_sidebar = function(...) invisible(NULL),
@@ -843,7 +847,7 @@ test_that("link actions stamp themselves as the panel owner", {
   fire_action(add_link_action, "a", r_board)
   fire_action(edit_link_action, "l1", r_board)
 
-  expect_identical(show_calls, list("add_link_action", "edit_link_action"))
+  expect_identical(wrote_from, list("add_link_action", "edit_link_action"))
 })
 
 test_that("edit link menu ui holds the endpoint / input slots and confirm", {

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -146,7 +146,7 @@ test_that("edit stack action: valid commit modifies the existing stack", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_stack_action",
         edit_stack_action(
           trigger = reactive("s1"),
           board = r_board,
@@ -206,7 +206,7 @@ test_that("edit stack action: board change with no active edit is inert", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_stack_action",
         edit_stack_action(
           trigger = reactive(NULL),
           board = r_board,
@@ -257,7 +257,7 @@ test_that("edit stack action: removing the edited stack closes the sidebar", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_stack_action",
         edit_stack_action(
           trigger = reactive("s1"),
           board = r_board,
@@ -307,7 +307,7 @@ test_that("edit stack action: a form written by another action stays open", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_stack_action",
         edit_stack_action(
           trigger = reactive("s1"),
           board = r_board,
@@ -326,11 +326,15 @@ test_that("edit stack action: a form written by another action stays open", {
   )
 })
 
-test_that("stack actions stamp themselves as the panel owner", {
-  show_calls <- list()
+test_that("stack actions write the sidebar from their own module", {
+  # `show_sidebar()` reads the panel's owner off the session it is called
+  # with, so a write has to happen in the action's own reactive domain. A
+  # write deferred into a flush callback would run under the root session
+  # and stamp that instead, which this records.
+  wrote_from <- list()
   local_mocked_bindings(
-    show_sidebar = function(id, ..., owner = NULL) {
-      show_calls[[length(show_calls) + 1L]] <<- owner
+    show_sidebar = function(...) {
+      wrote_from[[length(wrote_from) + 1L]] <<- get_session()$ns(NULL)
       invisible(NULL)
     },
     keep_or_hide_sidebar = function(...) invisible(NULL),
@@ -348,7 +352,7 @@ test_that("stack actions stamp themselves as the panel owner", {
   fire_action(add_stack_action, TRUE, r_board)
   fire_action(edit_stack_action, "s1", r_board)
 
-  expect_identical(show_calls, list("add_stack_action", "edit_stack_action"))
+  expect_identical(wrote_from, list("add_stack_action", "edit_stack_action"))
 })
 
 test_that("edit stack action: invalid colour / block id short-circuit", {
@@ -365,7 +369,7 @@ test_that("edit stack action: invalid colour / block id short-circuit", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_stack_action",
         edit_stack_action(
           trigger = reactive("s1"),
           board = r_board,
@@ -515,7 +519,7 @@ test_that("edit stack action: the form follows the edited stack", {
   testServer(
     function(id, ...) {
       moduleServer(
-        id,
+        "edit_stack_action",
         edit_stack_action(
           trigger = reactive("s1"),
           board = r_board,

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -193,7 +193,9 @@ test_that("edit stack action: board change with no active edit is inert", {
       hide_calls[[length(hide_calls) + 1L]] <<- id
       invisible(NULL)
     },
-    sidebar_state = function(id, ...) list(open = TRUE, pinned = TRUE)
+    sidebar_state = function(id, ...) {
+      list(open = TRUE, pinned = TRUE, owner = "edit_stack_action")
+    }
   )
 
   r_board <- reactiveValues(
@@ -237,8 +239,10 @@ test_that("edit stack action: removing the edited stack closes the sidebar", {
       hide_calls[[length(hide_calls) + 1L]] <<- id
       invisible(NULL)
     },
-    # The auto-close is gated on the sidebar being open.
-    sidebar_state = function(id, ...) list(open = TRUE, pinned = TRUE)
+    # The auto-close is gated on this action owning the open panel.
+    sidebar_state = function(id, ...) {
+      list(open = TRUE, pinned = TRUE, owner = "edit_stack_action")
+    }
   )
 
   r_board <- reactiveValues(
@@ -273,6 +277,78 @@ test_that("edit stack action: removing the edited stack closes the sidebar", {
       expect_identical(hide_calls[[1L]], "b-actions_sidebar")
     }
   )
+})
+
+test_that("edit stack action: a form written by another action stays open", {
+  # Same removal, but the shared panel has since been filled by another
+  # action: closing it here would take down a form this handler no longer
+  # has anything in.
+  hide_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(...) invisible(NULL),
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(id, ...) {
+      hide_calls[[length(hide_calls) + 1L]] <<- id
+      invisible(NULL)
+    },
+    sidebar_state = function(id, ...) {
+      list(open = TRUE, pinned = TRUE, owner = "add_link_action")
+    }
+  )
+
+  r_board <- reactiveValues(
+    board = new_dock_board(
+      c(a = new_dataset_block("iris"), b = new_head_block()),
+      stacks = stacks(s1 = "a")
+    ),
+    board_id = "b"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_stack_action(
+          trigger = reactive("s1"),
+          board = r_board,
+          update = reactiveVal(list())
+        )
+      )
+    },
+    {
+      session$flushReact()
+
+      r_board$board <- new_dock_board(board_blocks(r_board$board))
+      session$flushReact()
+
+      expect_length(hide_calls, 0L)
+    }
+  )
+})
+
+test_that("stack actions stamp themselves as the panel owner", {
+  show_calls <- list()
+  local_mocked_bindings(
+    show_sidebar = function(id, ..., owner = NULL) {
+      show_calls[[length(show_calls) + 1L]] <<- owner
+      invisible(NULL)
+    },
+    keep_or_hide_sidebar = function(...) invisible(NULL),
+    hide_sidebar = function(...) invisible(NULL)
+  )
+
+  r_board <- reactiveValues(
+    board = new_dock_board(
+      c(a = new_dataset_block("iris")),
+      stacks = stacks(s1 = "a")
+    ),
+    board_id = "b"
+  )
+
+  fire_action(add_stack_action, TRUE, r_board)
+  fire_action(edit_stack_action, "s1", r_board)
+
+  expect_identical(show_calls, list("add_stack_action", "edit_stack_action"))
 })
 
 test_that("edit stack action: invalid colour / block id short-circuit", {

--- a/tests/testthat/test-sidebar-server.R
+++ b/tests/testthat/test-sidebar-server.R
@@ -2,8 +2,10 @@
 # to the panel's input binding, the panel's own value echoed back in. Both
 # ends are stubbed here so the payload a show ships and the state a handler
 # reads can be asserted without a browser; the round trip itself is covered
-# end-to-end at the bottom of this file.
-fake_sidebar_session <- function(state = NULL) {
+# end-to-end at the bottom of this file. `ns` stands in for the writing
+# module, which is where the owner stamp is read from.
+fake_sidebar_session <- function(state = NULL,
+                                 ns = "my_board-edit_stack_action") {
 
   sent <- new.env(parent = emptyenv())
   sent$msgs <- list()
@@ -16,37 +18,25 @@ fake_sidebar_session <- function(state = NULL) {
     }
   )
 
-  list(rootScope = function() root, messages = function() sent$msgs)
+  list(
+    ns = NS(ns),
+    rootScope = function() root,
+    messages = function() sent$msgs
+  )
 }
 
-test_that("a show stamps the writing action as the panel's owner", {
+test_that("a show stamps the writing module as the panel's owner", {
   session <- fake_sidebar_session()
 
-  show_sidebar(
-    "panel",
-    title = "Edit stack s1",
-    owner = "edit_stack_action",
-    session = session
-  )
+  show_sidebar("panel", title = "Edit stack s1", session = session)
 
   msgs <- session$messages()
 
   expect_length(msgs, 1L)
   expect_identical(msgs[[1L]][["id"]], "panel")
-  expect_identical(msgs[[1L]][["message"]][["owner"]], "edit_stack_action")
-})
-
-test_that("a show without an owner clears the stamp", {
-  # Ownership rides on every show, so a writer that does not declare itself
-  # takes the previous owner off the panel rather than leaving it stale.
-  session <- fake_sidebar_session()
-
-  show_sidebar("panel", session = session)
-
-  msg <- session$messages()[[1L]][["message"]]
-
-  expect_true("owner" %in% names(msg))
-  expect_null(msg[["owner"]])
+  expect_identical(
+    msgs[[1L]][["message"]][["owner"]], "my_board-edit_stack_action"
+  )
 })
 
 test_that("a hide leaves the stamp alone", {
@@ -65,7 +55,9 @@ test_that("panel state reports the owner beside open and pinned", {
     list(open = FALSE, pinned = FALSE, owner = NULL)
   )
 
-  echoed <- list(open = TRUE, pinned = TRUE, owner = "add_link_action")
+  echoed <- list(
+    open = TRUE, pinned = TRUE, owner = "my_board-add_link_action"
+  )
 
   expect_identical(
     sidebar_state("panel", session = fake_sidebar_session(echoed)),
@@ -74,36 +66,33 @@ test_that("panel state reports the owner beside open and pinned", {
 })
 
 test_that("ownership requires an open panel and a matching stamp", {
+  # Asked from `my_board-edit_stack_action`, the fake session's module.
   owns <- function(...) {
-    owns_open_sidebar(
-      "panel", "edit_stack_action",
-      session = fake_sidebar_session(list(...))
-    )
+    owns_open_sidebar("panel", session = fake_sidebar_session(list(...)))
   }
 
-  expect_true(owns(open = TRUE, owner = "edit_stack_action"))
-  expect_false(owns(open = TRUE, owner = "add_link_action"))
-  expect_false(owns(open = FALSE, owner = "edit_stack_action"))
+  expect_true(owns(open = TRUE, owner = "my_board-edit_stack_action"))
+  expect_false(owns(open = TRUE, owner = "my_board-add_link_action"))
+  expect_false(owns(open = FALSE, owner = "my_board-edit_stack_action"))
   expect_false(owns(open = TRUE))
 })
 
 test_that("re-showing a pinned panel restamps its owner", {
   session <- fake_sidebar_session(
-    list(open = TRUE, pinned = TRUE, owner = "edit_stack_action")
+    list(open = TRUE, pinned = TRUE, owner = "my_board-edit_stack_action")
   )
 
   keep_or_hide_sidebar(
     "panel",
     ui = NULL,
     title = "Edit stack s1",
-    owner = "edit_stack_action",
     session = session
   )
 
   msg <- session$messages()[[1L]][["message"]]
 
   expect_identical(msg[["action"]], "show")
-  expect_identical(msg[["owner"]], "edit_stack_action")
+  expect_identical(msg[["owner"]], "my_board-edit_stack_action")
 })
 
 # The stamp is only useful if it survives the trip through the browser: R
@@ -143,17 +132,24 @@ test_that("a panel reports the action that wrote its body", {
   expect_null(app$get_value(input = panel)$owner)
   expect_true(is.na(stamped_owner()))
 
+  # The stamp is the writing module's namespaced id, which for a board action
+  # is `NS(<board id>, <action id>)` -- the composition a consumer matching
+  # its own entries against the owner has to make.
   app$click("my_board-ext_fire-add_link")
   app$wait_for_idle()
 
-  expect_identical(app$get_value(input = panel)$owner, "add_link_action")
-  expect_identical(stamped_owner(), "add_link_action")
+  expect_identical(
+    app$get_value(input = panel)$owner, "my_board-add_link_action"
+  )
+  expect_identical(stamped_owner(), "my_board-add_link_action")
 
   # A second surface fills the same panel. Nothing declared which panel it
   # writes, so a stale stamp here is what a consumer would re-fire into.
   app$click("my_board-ext_fire-edit_stack")
   app$wait_for_idle()
 
-  expect_identical(app$get_value(input = panel)$owner, "edit_stack_action")
-  expect_identical(stamped_owner(), "edit_stack_action")
+  expect_identical(
+    app$get_value(input = panel)$owner, "my_board-edit_stack_action"
+  )
+  expect_identical(stamped_owner(), "my_board-edit_stack_action")
 })

--- a/tests/testthat/test-sidebar-server.R
+++ b/tests/testthat/test-sidebar-server.R
@@ -1,0 +1,159 @@
+# A sidebar panel talks to the root session in both directions: a message out
+# to the panel's input binding, the panel's own value echoed back in. Both
+# ends are stubbed here so the payload a show ships and the state a handler
+# reads can be asserted without a browser; the round trip itself is covered
+# end-to-end at the bottom of this file.
+fake_sidebar_session <- function(state = NULL) {
+
+  sent <- new.env(parent = emptyenv())
+  sent$msgs <- list()
+
+  root <- list(
+    input = list(panel = state),
+    sendInputMessage = function(id, message) {
+      sent$msgs <- c(sent$msgs, list(list(id = id, message = message)))
+      invisible(NULL)
+    }
+  )
+
+  list(rootScope = function() root, messages = function() sent$msgs)
+}
+
+test_that("a show stamps the writing action as the panel's owner", {
+  session <- fake_sidebar_session()
+
+  show_sidebar(
+    "panel",
+    title = "Edit stack s1",
+    owner = "edit_stack_action",
+    session = session
+  )
+
+  msgs <- session$messages()
+
+  expect_length(msgs, 1L)
+  expect_identical(msgs[[1L]][["id"]], "panel")
+  expect_identical(msgs[[1L]][["message"]][["owner"]], "edit_stack_action")
+})
+
+test_that("a show without an owner clears the stamp", {
+  # Ownership rides on every show, so a writer that does not declare itself
+  # takes the previous owner off the panel rather than leaving it stale.
+  session <- fake_sidebar_session()
+
+  show_sidebar("panel", session = session)
+
+  msg <- session$messages()[[1L]][["message"]]
+
+  expect_true("owner" %in% names(msg))
+  expect_null(msg[["owner"]])
+})
+
+test_that("a hide leaves the stamp alone", {
+  # The body survives a close, so what is in the panel is still whoever last
+  # wrote it. Only a show can change that.
+  session <- fake_sidebar_session()
+
+  hide_sidebar("panel", session = session)
+
+  expect_false("owner" %in% names(session$messages()[[1L]][["message"]]))
+})
+
+test_that("panel state reports the owner beside open and pinned", {
+  expect_identical(
+    sidebar_state("panel", session = fake_sidebar_session()),
+    list(open = FALSE, pinned = FALSE, owner = NULL)
+  )
+
+  echoed <- list(open = TRUE, pinned = TRUE, owner = "add_link_action")
+
+  expect_identical(
+    sidebar_state("panel", session = fake_sidebar_session(echoed)),
+    echoed
+  )
+})
+
+test_that("ownership requires an open panel and a matching stamp", {
+  owns <- function(...) {
+    owns_open_sidebar(
+      "panel", "edit_stack_action",
+      session = fake_sidebar_session(list(...))
+    )
+  }
+
+  expect_true(owns(open = TRUE, owner = "edit_stack_action"))
+  expect_false(owns(open = TRUE, owner = "add_link_action"))
+  expect_false(owns(open = FALSE, owner = "edit_stack_action"))
+  expect_false(owns(open = TRUE))
+})
+
+test_that("re-showing a pinned panel restamps its owner", {
+  session <- fake_sidebar_session(
+    list(open = TRUE, pinned = TRUE, owner = "edit_stack_action")
+  )
+
+  keep_or_hide_sidebar(
+    "panel",
+    ui = NULL,
+    title = "Edit stack s1",
+    owner = "edit_stack_action",
+    session = session
+  )
+
+  msg <- session$messages()[[1L]][["message"]]
+
+  expect_identical(msg[["action"]], "show")
+  expect_identical(msg[["owner"]], "edit_stack_action")
+})
+
+# The stamp is only useful if it survives the trip through the browser: R
+# ships it with the body swap, the binding parks it on the panel and reports
+# it back in the panel's value. No unit test sees that seam, and a consumer
+# reading a stamp that never arrives cannot tell the difference between "no
+# owner" and "the mechanism is dead", so drive it through a real app. The
+# fixture fires the actions straight off the trigger bundle, which is the
+# path a consumer's context menu takes and the one that declares nothing.
+test_that("a panel reports the action that wrote its body", {
+
+  skip_on_cran()
+
+  app <- new_app_driver(
+    system.file("examples", "sidebar-owner", "app.R", package = "blockr.dock"),
+    name = "sidebar-owner",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 30 * 1000
+  )
+  withr::defer(app$stop())
+
+  app$wait_for_idle()
+
+  panel <- "my_board-actions_sidebar"
+
+  stamped_owner <- function() {
+    xml2::xml_attr(
+      xml2::xml_find_first(
+        xml2::read_html(app$get_html(paste0("#", panel))),
+        paste0("//div[@id='", panel, "']")
+      ),
+      "data-blockr-sidebar-owner"
+    )
+  }
+
+  expect_null(app$get_value(input = panel)$owner)
+  expect_true(is.na(stamped_owner()))
+
+  app$click("my_board-ext_fire-add_link")
+  app$wait_for_idle()
+
+  expect_identical(app$get_value(input = panel)$owner, "add_link_action")
+  expect_identical(stamped_owner(), "add_link_action")
+
+  # A second surface fills the same panel. Nothing declared which panel it
+  # writes, so a stale stamp here is what a consumer would re-fire into.
+  app$click("my_board-ext_fire-edit_stack")
+  app$wait_for_idle()
+
+  expect_identical(app$get_value(input = panel)$owner, "edit_stack_action")
+  expect_identical(stamped_owner(), "edit_stack_action")
+})


### PR DESCRIPTION
## Summary

- A panel's owner is now stamped where its body is written, not inferred from where a gesture started. `show_sidebar()` records the writing module's namespaced id on the panel, read off the session the call runs in, so every writer stamps by construction — including paths no consumer can observe, such as a holder of the trigger bundle calling `actions[["edit_stack_action"]](id)` directly, or the canvas drop that fills the shared panel with no menu entry behind it.
- Nothing is declared at the call site. The owner is `NS(<board id>, <action id>)`, which is the action's id and the id its module is already mounted under, so the stamp cannot drift from the action and there is no argument to forget. A consumer matching its own entries against the owner composes `NS(board_id, action_name)` — the same composition it already makes to read the panel's state.
- The stamp comes back as `owner` beside `open` and `pinned` in the panel's input value, which is the channel consumers already read for `pinned`. So the read side needs no new plumbing, and filling a panel takes it over: an action with no consumer-side re-target mapping is inert by construction.
- dock's own auto-close handlers (edit stack / link / inputs, which close when their target leaves the board) now gate on ownership, so the edit-then-switch-then-remove sequence flagged in the `edit_stack_action` comment no longer closes a form another action has since written into the shared panel. That sequence is reachable today through blockr.dag, whose context menu fires all three of the actions it needs.
- Reading the owner off the calling session binds correctness to where a write is written: a write deferred into a flush callback would run under the root session and stamp that instead. #393 removed the last such writer, and a test per action records the module each write runs in, so reintroducing one fails.

Two seams are covered beyond the unit tests. The round trip through the browser — R payload, panel attribute, echoed input value — runs against a fixture whose extension fires the actions straight off the trigger bundle; dropping the stamp in the JS fails it. And the ownership half of the auto-close guard is pinned by a negative test per handler.

Follow-up for blockr.dag: the scaffolding #391 describes can now go — the per-entry `sidebar = <panel>` declarations on non-re-targeting entries, the claim / release observers, and the canvas-drop special case, leaving the re-target opt-in and its condition.

Fixes #391
