### PR TITLE
Bind the snapshot menus to the board, drop the post-commit deferral

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* A pinned stack / link sidebar now refreshes in place after a commit
+  rather than being torn down and rebuilt, so search text, scroll
+  position and anything the user entered that the commit did not consume
+  survive it. The stack menu's name / colour / id form is server-rendered
+  against the board to make that possible -- it still offers a fresh
+  stack id after each create -- and with nothing left to rebuild, none of
+  the four post-commit paths defers its close to `session$onFlushed()`
+  (#393).
+
 * A `select` verb in a view's `views$mod` update is now applied when
   that view's dock is built for the first time in the same update that
   carries the select -- for instance an update that activates a

--- a/R/action-link.R
+++ b/R/action-link.R
@@ -43,16 +43,7 @@ add_link_action <- function(trigger, board, update, ...) {
         # Close after a single link unless the user pinned the sidebar.
         # When pinned, the menu's own board observer drops the just-wired
         # card in place (no re-render) so the user can add another link.
-        session$onFlushed(
-          function() {
-            isolate(
-              if (!isTRUE(sidebar_state(sidebar_id)$pinned)) {
-                hide_sidebar(sidebar_id)
-              }
-            )
-          },
-          once = TRUE
-        )
+        hide_unless_pinned(sidebar_id)
       })
 
       NULL
@@ -124,16 +115,10 @@ edit_link_action <- function(trigger, board, update, ...) {
           update(list(links = list(mod = set_names(list(delta), id))))
         }
 
-        session$onFlushed(
-          function() {
-            isolate(
-              keep_or_hide_sidebar(
-                sidebar_id, title = sidebar_title(), ui = menu_ui()
-              )
-            )
-          },
-          once = TRUE
-        )
+        # The endpoint pickers and the input-slot control are `uiOutput`s on
+        # the board, so a pinned panel re-renders itself against the merged
+        # state - nothing here has to rebuild it.
+        hide_unless_pinned(sidebar_id)
       })
 
       NULL

--- a/R/action-stack.R
+++ b/R/action-stack.R
@@ -26,21 +26,9 @@ add_stack_action <- function(trigger, board, update, ...) {
         # apply as-is.
         update(list(stacks = list(add = committed())))
 
-        # `update()` only sets a reactiveVal; the board state is mutated
-        # on the next reactive flush, so defer the sidebar rebuild until
-        # after the flush. Otherwise `menu_ui()` reads `board$board` from
-        # the pre-add snapshot and re-suggests the just-used stack id.
-        # `onFlushed` runs outside a reactive context, hence `isolate()`.
-        session$onFlushed(
-          function() {
-            isolate(
-              keep_or_hide_sidebar(
-                sidebar_id, title = "Create new stack", ui = menu_ui()
-              )
-            )
-          },
-          once = TRUE
-        )
+        # The form is a `uiOutput` on the board, so a pinned panel re-renders
+        # itself against the merged state and suggests a fresh stack id.
+        hide_unless_pinned(sidebar_id)
       })
 
       NULL
@@ -99,9 +87,9 @@ edit_stack_action <- function(trigger, board, update, ...) {
         id <- trigger()
 
         # Safety net for a race (board change not yet observed when the
-        # user clicks): committing for a stack that's gone would error
-        # (the `mod` update and the post-commit `menu_ui()` rebuild both
-        # look it up). Bail and close unless `id` is a present stack.
+        # user clicks): committing for a stack that's gone would error in
+        # the `mod` update, which looks it up. Bail and close unless `id`
+        # is a present stack.
         if (!(length(id) == 1L && !is.na(id) && nzchar(id) &&
                 id %in% board_stack_ids(board$board))) {
           hide_sidebar(sidebar_id)
@@ -130,20 +118,7 @@ edit_stack_action <- function(trigger, board, update, ...) {
           )
         ))
 
-        # Defer the sidebar rebuild to the next reactive flush so
-        # `menu_ui()` reads the merged board state. Without this, the
-        # rebuilt form shows the pre-edit selection (e.g. a block the
-        # user just removed still appears selected).
-        session$onFlushed(
-          function() {
-            isolate(
-              keep_or_hide_sidebar(
-                sidebar_id, title = sidebar_title(), ui = menu_ui()
-              )
-            )
-          },
-          once = TRUE
-        )
+        hide_unless_pinned(sidebar_id)
       })
 
       NULL

--- a/R/sidebar-server.R
+++ b/R/sidebar-server.R
@@ -140,6 +140,16 @@ keep_or_hide_sidebar <- function(id, ui, title = NULL,
   }
 }
 
+# Post-commit close for a panel whose menu tracks the board on its own: an
+# unpinned panel closes after the commit, a pinned one is left alone so the
+# menu refreshes itself in place.
+hide_unless_pinned <- function(id, session = getDefaultReactiveDomain()) {
+  if (!isTRUE(sidebar_state(id, session = session)$pinned)) {
+    hide_sidebar(id, session = session)
+  }
+  invisible(NULL)
+}
+
 # Inline SVG pushpin (Bootstrap-icons "pin"). Swapped in for an earlier
 # `▣` ("WHITE SQUARE WITH ROUNDED CORNERS") that no font rendered as
 # a recognisable pin. SVG keeps the icon legible across platforms with

--- a/R/sidebar-server.R
+++ b/R/sidebar-server.R
@@ -80,7 +80,7 @@ sidebar_dep <- function() {
 }
 
 show_sidebar <- function(id, ui = NULL, title = NULL,
-                         session = getDefaultReactiveDomain()) {
+                         session = get_session()) {
   stopifnot(
     is.character(id), length(id) == 1L, nzchar(id),
     is.null(title) || (is.character(title) && length(title) == 1L)
@@ -109,7 +109,7 @@ show_sidebar <- function(id, ui = NULL, title = NULL,
   invisible(NULL)
 }
 
-hide_sidebar <- function(id, session = getDefaultReactiveDomain()) {
+hide_sidebar <- function(id, session = get_session()) {
   stopifnot(is.character(id), length(id) == 1L, nzchar(id))
   root <- root_session(session)
 
@@ -117,7 +117,7 @@ hide_sidebar <- function(id, session = getDefaultReactiveDomain()) {
   invisible(NULL)
 }
 
-sidebar_state <- function(id, session = getDefaultReactiveDomain()) {
+sidebar_state <- function(id, session = get_session()) {
   stopifnot(is.character(id), length(id) == 1L, nzchar(id))
   root <- root_session(session)
 
@@ -132,7 +132,7 @@ sidebar_state <- function(id, session = getDefaultReactiveDomain()) {
 }
 
 keep_or_hide_sidebar <- function(id, ui, title = NULL,
-                                 session = getDefaultReactiveDomain()) {
+                                 session = get_session()) {
   if (isTRUE(sidebar_state(id, session = session)$pinned)) {
     show_sidebar(id, ui = ui, title = title, session = session)
   } else {
@@ -143,7 +143,7 @@ keep_or_hide_sidebar <- function(id, ui, title = NULL,
 # Post-commit close for a panel whose menu tracks the board on its own: an
 # unpinned panel closes after the commit, a pinned one is left alone so the
 # menu refreshes itself in place.
-hide_unless_pinned <- function(id, session = getDefaultReactiveDomain()) {
+hide_unless_pinned <- function(id, session = get_session()) {
   if (!isTRUE(sidebar_state(id, session = session)$pinned)) {
     hide_sidebar(id, session = session)
   }

--- a/R/sidebar-stack.R
+++ b/R/sidebar-stack.R
@@ -374,22 +374,14 @@ text_field_tag <- function(ns, key, label, value, placeholder) {
   )
 }
 
-# The swatch and the two slider positions are seeded here rather than by
-# the binding on mount: the form is re-rendered whenever the board changes,
-# and a client-side seeding pass would have to be re-run on every render.
 color_field_tag <- function(ns, value) {
   hex <- value %||% default_stack_color()
-  hsl <- hex_to_hsl(hex)
-
   tags$div(
     class = "blockr-stack-menu-field blockr-stack-menu-color",
     tags$label(`for` = ns("stack_color"), "Stack color"),
     tags$div(
       class = "blockr-stack-menu-color-preview",
-      tags$span(
-        class = "blockr-stack-menu-color-swatch",
-        style = paste0("background: ", hex, ";")
-      ),
+      tags$span(class = "blockr-stack-menu-color-swatch"),
       tags$input(
         id = ns("stack_color"),
         type = "text",
@@ -406,7 +398,7 @@ color_field_tag <- function(ns, value) {
       min = "0",
       max = "360",
       step = "1",
-      value = as.character(hsl$hue),
+      value = "0",
       `aria-label` = "Hue"
     ),
     tags$input(
@@ -415,44 +407,10 @@ color_field_tag <- function(ns, value) {
       min = "20",
       max = "85",
       step = "1",
-      value = as.character(hsl$lightness),
+      value = "60",
       `aria-label` = "Lightness"
     )
   )
-}
-
-# Hue (0-360) and lightness (0-100) of a hex colour, mirroring the
-# picker's `hexToHsl()`. Saturation is fixed by the slider model, so it
-# is not read back. An unparseable colour falls back to the seed colour.
-hex_to_hsl <- function(hex) {
-  if (!is_hex_color(hex)) {
-    hex <- default_stack_color()
-  }
-
-  digits <- substring(hex, 2L, nchar(hex))
-  if (nchar(digits) == 3L) {
-    digits <- paste0(rep(strsplit(digits, "")[[1L]], each = 2L), collapse = "")
-  }
-
-  channels <- strtoi(substring(digits, c(1L, 3L, 5L), c(2L, 4L, 6L)), 16L) / 255
-  r <- channels[[1L]]
-  g <- channels[[2L]]
-  b <- channels[[3L]]
-
-  hi <- max(channels)
-  lo <- min(channels)
-
-  hue <- if (hi == lo) {
-    0
-  } else if (hi == r) {
-    (g - b) / (hi - lo) + if (g < b) 6 else 0
-  } else if (hi == g) {
-    (b - r) / (hi - lo) + 2
-  } else {
-    (r - g) / (hi - lo) + 4
-  }
-
-  list(hue = round(hue * 60), lightness = round((hi + lo) / 2 * 100))
 }
 
 # ---- small helpers ----------------------------------------------------

--- a/R/sidebar-stack.R
+++ b/R/sidebar-stack.R
@@ -46,6 +46,35 @@ stack_menu_server <- function(id, board, target = NULL) {
         ignoreInit = TRUE
       )
 
+      # The name / colour / id form is bound to the board rather than
+      # snapshotted when the panel opens, so a commit refreshes it in place:
+      # edit mode re-reads the stack's committed values, create mode suggests
+      # an id the board has not taken.
+      output$form <- renderUI({
+        brd <- board()
+        tgt <- target_fn()
+        req(is.null(tgt) || (is_string(tgt) && tgt %in% board_stack_ids(brd)))
+
+        ctx <- resolve_stack_target(brd, tgt)
+
+        # Create mode fills the form with suggestions rather than board
+        # state, so a re-render must not discard what the user entered. The
+        # suggested id is the sentinel: while the board has not taken it,
+        # nothing was created from this form and every field is kept. Once it
+        # is taken - which is precisely what creating the stack does - the
+        # whole form is re-seeded for the next stack.
+        held_id <- isolate(input[["stack_id"]])
+
+        if (identical(ctx$mode, "create") &&
+              id_available(held_id, board_stack_ids(brd))) {
+          ctx$stack_id <- held_id
+          ctx$name <- isolate(input[["stack_name"]]) %||% ctx$name
+          ctx$color <- isolate(input[["stack_color"]]) %||% ctx$color
+        }
+
+        stack_menu_form(session$ns, ctx)
+      })
+
       eventReactive(
         input$commit,
         {
@@ -229,7 +258,6 @@ registry_entry_for <- function(blk, registry) {
 
 stack_menu_panel <- function(ns, metas, ctx) {
   groups <- category_groups(metas)
-  is_edit <- identical(ctx$mode, "edit")
 
   tags$div(
     id = ns("commit"),
@@ -255,11 +283,15 @@ stack_menu_panel <- function(ns, metas, ctx) {
       class = "blockr-block-browser-empty",
       "No blocks match your search."
     ),
-    stack_menu_form(ns, ctx, is_edit),
+    tags$h4(
+      class = "blockr-stack-menu-section-header",
+      "Stack settings"
+    ),
+    uiOutput(ns("form"), class = "blockr-stack-menu-form-slot"),
     tags$button(
       type = "button",
       class = "blockr-stack-menu-confirm",
-      if (is_edit) "Update stack" else "Create stack"
+      if (identical(ctx$mode, "edit")) "Update stack" else "Create stack"
     )
   )
 }
@@ -317,24 +349,15 @@ stack_block_card <- function(meta) {
 # top-level in create mode - the sidebar has room for them and the
 # auto-seeded id is still useful chrome (users can rename it). Edit
 # mode omits the id input entirely (the id is immutable once a stack
-# is created). The form is preceded by a small uppercase section
-# header (matching the category labels above) and rendered inside a
-# subtly-tinted panel so the configuration block reads as distinct
-# from the picker.
-stack_menu_form <- function(ns, ctx, is_edit) {
-  tagList(
-    tags$h4(
-      class = "blockr-stack-menu-section-header",
-      "Stack settings"
-    ),
-    tags$div(
-      class = "blockr-stack-menu-form",
-      text_field_tag(ns, "stack_name", "Stack name", ctx$name, "My stack"),
-      color_field_tag(ns, ctx$color),
-      if (!is_edit) {
-        text_field_tag(ns, "stack_id", "Stack id", ctx$stack_id, "stack_id")
-      }
-    )
+# is created).
+stack_menu_form <- function(ns, ctx) {
+  tags$div(
+    class = "blockr-stack-menu-form",
+    text_field_tag(ns, "stack_name", "Stack name", ctx$name, "My stack"),
+    color_field_tag(ns, ctx$color),
+    if (identical(ctx$mode, "create")) {
+      text_field_tag(ns, "stack_id", "Stack id", ctx$stack_id, "stack_id")
+    }
   )
 }
 
@@ -351,14 +374,22 @@ text_field_tag <- function(ns, key, label, value, placeholder) {
   )
 }
 
+# The swatch and the two slider positions are seeded here rather than by
+# the binding on mount: the form is re-rendered whenever the board changes,
+# and a client-side seeding pass would have to be re-run on every render.
 color_field_tag <- function(ns, value) {
   hex <- value %||% default_stack_color()
+  hsl <- hex_to_hsl(hex)
+
   tags$div(
     class = "blockr-stack-menu-field blockr-stack-menu-color",
     tags$label(`for` = ns("stack_color"), "Stack color"),
     tags$div(
       class = "blockr-stack-menu-color-preview",
-      tags$span(class = "blockr-stack-menu-color-swatch"),
+      tags$span(
+        class = "blockr-stack-menu-color-swatch",
+        style = paste0("background: ", hex, ";")
+      ),
       tags$input(
         id = ns("stack_color"),
         type = "text",
@@ -375,7 +406,7 @@ color_field_tag <- function(ns, value) {
       min = "0",
       max = "360",
       step = "1",
-      value = "0",
+      value = as.character(hsl$hue),
       `aria-label` = "Hue"
     ),
     tags$input(
@@ -384,10 +415,44 @@ color_field_tag <- function(ns, value) {
       min = "20",
       max = "85",
       step = "1",
-      value = "60",
+      value = as.character(hsl$lightness),
       `aria-label` = "Lightness"
     )
   )
+}
+
+# Hue (0-360) and lightness (0-100) of a hex colour, mirroring the
+# picker's `hexToHsl()`. Saturation is fixed by the slider model, so it
+# is not read back. An unparseable colour falls back to the seed colour.
+hex_to_hsl <- function(hex) {
+  if (!is_hex_color(hex)) {
+    hex <- default_stack_color()
+  }
+
+  digits <- substring(hex, 2L, nchar(hex))
+  if (nchar(digits) == 3L) {
+    digits <- paste0(rep(strsplit(digits, "")[[1L]], each = 2L), collapse = "")
+  }
+
+  channels <- strtoi(substring(digits, c(1L, 3L, 5L), c(2L, 4L, 6L)), 16L) / 255
+  r <- channels[[1L]]
+  g <- channels[[2L]]
+  b <- channels[[3L]]
+
+  hi <- max(channels)
+  lo <- min(channels)
+
+  hue <- if (hi == lo) {
+    0
+  } else if (hi == r) {
+    (g - b) / (hi - lo) + if (g < b) 6 else 0
+  } else if (hi == g) {
+    (b - r) / (hi - lo) + 2
+  } else {
+    (r - g) / (hi - lo) + 4
+  }
+
+  list(hue = round(hue * 60), lightness = round((hi + lo) / 2 * 100))
 }
 
 # ---- small helpers ----------------------------------------------------

--- a/inst/assets/css/sidebar-stack.css
+++ b/inst/assets/css/sidebar-stack.css
@@ -85,6 +85,13 @@
   color: #6b7280;
 }
 
+/* The form is server-rendered into this slot so it tracks the board. The
+   slot is a flex item of the panel column, so it carries the same
+   `flex: 0 0 auto` the form itself would have. */
+.blockr-stack-menu-form-slot {
+  flex: 0 0 auto;
+}
+
 /* Panel-level form: name + colour + id. The "Stack settings" section
    header above provides the visual break - no background tint, no
    border-box; keep the chrome quiet. */
@@ -125,8 +132,8 @@
 
 /* Inline colour picker: hex preview + text input + hue/lightness
    sliders. The hex `<input>` is the value carrier (a normal Shiny
-   text input); sliders write the hex on input, the JS keeps the
-   preview swatch and slider positions in sync with the hex. */
+   text input); R seeds the swatch and slider positions from it, and
+   the JS keeps the three in sync as the user drags / types. */
 .blockr-stack-menu-color-preview {
   display: flex;
   align-items: center;

--- a/inst/assets/css/sidebar-stack.css
+++ b/inst/assets/css/sidebar-stack.css
@@ -132,8 +132,8 @@
 
 /* Inline colour picker: hex preview + text input + hue/lightness
    sliders. The hex `<input>` is the value carrier (a normal Shiny
-   text input); R seeds the swatch and slider positions from it, and
-   the JS keeps the three in sync as the user drags / types. */
+   text input); sliders write the hex on input, the JS keeps the
+   preview swatch and slider positions in sync with the hex. */
 .blockr-stack-menu-color-preview {
   display: flex;
   align-items: center;

--- a/inst/assets/js/sidebar-stack.js
+++ b/inst/assets/js/sidebar-stack.js
@@ -94,10 +94,15 @@
   // Inline colour picker: hue + lightness sliders + hex text input.
   // The hex `<input>` is the canonical value carrier (a normal Shiny
   // text input). Slider input recomputes HSL -> hex and writes the hex
-  // field, dispatching a native "input" event so Shiny's built-in
+  // field, dispatching a native "change" event so Shiny's built-in
   // text-input binding picks the change up - we never call
   // Shiny.setInputValue ourselves. Typing in the hex field goes the
   // other way: hex -> HSL -> slider positions + preview swatch.
+  //
+  // Both directions are delegated on the panel root, which outlives the
+  // form: the form is server-rendered into a `uiOutput` so it tracks the
+  // board, and per-element listeners would die with each render. Slider
+  // positions and the swatch arrive seeded from R for the same reason.
 
   function clamp(v, lo, hi) {
     return Math.max(lo, Math.min(hi, v));
@@ -161,39 +166,47 @@
     }
   }
 
-  function initColorPicker(root) {
+  function colorFields(root) {
     var hex = root.querySelector(".blockr-stack-menu-hex");
     var hue = root.querySelector(".blockr-stack-menu-hue");
     var lit = root.querySelector(".blockr-stack-menu-lightness");
-    if (!hex || !hue || !lit) return;
+    return hex && hue && lit ? { hex: hex, hue: hue, lit: lit } : null;
+  }
 
-    // Seed slider positions from the initial hex value (so an edit
-    // flow with a pre-filled colour shows the correct slider state).
-    var initial = hexToHsl(hex.value || "");
-    if (initial) {
-      hue.value = String(initial.h);
-      lit.value = String(initial.l);
+  function writeHexFromSliders(root) {
+    var f = colorFields(root);
+    if (!f) return;
+    f.hex.value = hslToHex(
+      parseInt(f.hue.value, 10), parseInt(f.lit.value, 10)
+    );
+    // "change" only: Shiny's text binding sends it immediately, and the
+    // delegated listener below watches "input", so writing the hex here
+    // cannot bounce back and fight the slider the user is dragging.
+    f.hex.dispatchEvent(new Event("change", { bubbles: true }));
+    updatePreview(root);
+  }
+
+  function moveSlidersToHex(root) {
+    var f = colorFields(root);
+    if (!f) return;
+    var parsed = hexToHsl((f.hex.value || "").trim());
+    if (parsed) {
+      f.hue.value = String(parsed.h);
+      f.lit.value = String(parsed.l);
     }
     updatePreview(root);
+  }
 
-    var onSlider = function () {
-      var h = parseInt(hue.value, 10);
-      var l = parseInt(lit.value, 10);
-      hex.value = hslToHex(h, l);
-      hex.dispatchEvent(new Event("input", { bubbles: true }));
-      hex.dispatchEvent(new Event("change", { bubbles: true }));
-      updatePreview(root);
-    };
-    hue.addEventListener("input", onSlider);
-    lit.addEventListener("input", onSlider);
-
-    hex.addEventListener("input", function () {
-      var parsed = hexToHsl((hex.value || "").trim());
-      if (parsed) {
-        hue.value = String(parsed.h);
-        lit.value = String(parsed.l);
+  function initColorPicker(root) {
+    root.addEventListener("input", function (event) {
+      var el = event.target;
+      if (!el || !el.classList) return;
+      if (el.classList.contains("blockr-stack-menu-hue") ||
+          el.classList.contains("blockr-stack-menu-lightness")) {
+        writeHexFromSliders(root);
+      } else if (el.classList.contains("blockr-stack-menu-hex")) {
+        moveSlidersToHex(root);
       }
-      updatePreview(root);
     });
   }
 

--- a/inst/assets/js/sidebar-stack.js
+++ b/inst/assets/js/sidebar-stack.js
@@ -99,10 +99,9 @@
   // Shiny.setInputValue ourselves. Typing in the hex field goes the
   // other way: hex -> HSL -> slider positions + preview swatch.
   //
-  // Both directions are delegated on the panel root, which outlives the
-  // form: the form is server-rendered into a `uiOutput` so it tracks the
-  // board, and per-element listeners would die with each render. Slider
-  // positions and the swatch arrive seeded from R for the same reason.
+  // Everything is delegated on the panel root, which outlives the form:
+  // the form is server-rendered into a `uiOutput` so it tracks the board,
+  // and per-element listeners would die with each render.
 
   function clamp(v, lo, hi) {
     return Math.max(lo, Math.min(hi, v));
@@ -198,6 +197,16 @@
   }
 
   function initColorPicker(root) {
+    // Seed the slider positions and the swatch from the hex whenever the
+    // field is (re-)bound, which covers both the form's first arrival and
+    // every later re-render. Seeding is the same operation a typed hex
+    // triggers, so there is no second copy of it to keep in step.
+    $(root).on("shiny:bound", function (event) {
+      if (event.target.classList.contains("blockr-stack-menu-hex")) {
+        moveSlidersToHex(root);
+      }
+    });
+
     root.addEventListener("input", function (event) {
       var el = event.target;
       if (!el || !el.classList) return;

--- a/tests/testthat/test-action-link.R
+++ b/tests/testthat/test-action-link.R
@@ -403,6 +403,51 @@ test_that("add link action: empty pool still opens the sidebar", {
   )
 })
 
+test_that("add link action: a commit closes an unpinned panel only", {
+  # The connect menu syncs its own cards off the board, so a commit never
+  # re-pushes the panel body - it only closes an unpinned panel.
+  calls <- function(pinned) {
+    seen <- list(show = 0L, hide = 0L)
+    local_mocked_bindings(
+      show_sidebar = function(...) seen$show <<- seen$show + 1L,
+      hide_sidebar = function(...) seen$hide <<- seen$hide + 1L,
+      keep_or_hide_sidebar = function(...) {
+        stop("the panel must not be rebuilt after a commit")
+      },
+      sidebar_state = function(id, ...) list(open = TRUE, pinned = pinned)
+    )
+
+    r_board <- reactiveValues(
+      board = new_board(
+        c(a = new_dataset_block("iris"), b = new_head_block())
+      ),
+      board_id = "b"
+    )
+
+    testServer(
+      function(id, ...) {
+        moduleServer(
+          id,
+          add_link_action(
+            trigger = reactive("a"),
+            board = r_board,
+            update = reactiveVal(list())
+          )
+        )
+      },
+      {
+        session$flushReact()
+        commit_menu(session, source = "a", target = "b", link_id = "ab")
+      }
+    )
+
+    seen
+  }
+
+  expect_identical(calls(pinned = FALSE), list(show = 1L, hide = 1L))
+  expect_identical(calls(pinned = TRUE), list(show = 1L, hide = 0L))
+})
+
 test_that("remove link action", {
 
   r_board <- reactiveValues(
@@ -661,6 +706,46 @@ test_that("edit link action: a self-link is rejected", {
       expect_length(r_update(), 0L)
     }
   )
+})
+
+test_that("edit link action: a commit closes an unpinned panel only", {
+  # The endpoint pickers and the input-slot control are `uiOutput`s on the
+  # board, so a pinned panel refreshes itself instead of being rebuilt.
+  calls <- function(pinned) {
+    seen <- list(show = 0L, hide = 0L)
+    local_mocked_bindings(
+      show_sidebar = function(...) seen$show <<- seen$show + 1L,
+      hide_sidebar = function(...) seen$hide <<- seen$hide + 1L,
+      keep_or_hide_sidebar = function(...) {
+        stop("the panel must not be rebuilt after a commit")
+      },
+      sidebar_state = function(id, ...) list(open = TRUE, pinned = pinned)
+    )
+
+    r_board <- edit_link_env(links(l1 = new_link("a", "h", "data")))
+
+    testServer(
+      function(id, ...) {
+        moduleServer(
+          id,
+          edit_link_action(
+            trigger = reactive("l1"),
+            board = r_board,
+            update = reactiveVal(list())
+          )
+        )
+      },
+      {
+        session$flushReact()
+        edit_link_menu(session, to = "m", input_port = "y")
+      }
+    )
+
+    seen
+  }
+
+  expect_identical(calls(pinned = FALSE), list(show = 1L, hide = 1L))
+  expect_identical(calls(pinned = TRUE), list(show = 1L, hide = 0L))
 })
 
 test_that("edit link action: removing the edited link closes the sidebar", {

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -538,53 +538,6 @@ test_that("stack menu ui defers the form to a server-rendered slot", {
   expect_length(xml2::xml_find_all(doc, "//input[@id='mid-stack_name']"), 0L)
 })
 
-test_that("stack menu seeds the colour picker positions server-side", {
-  # The form is re-rendered on every board change, so the swatch and the
-  # two slider positions ship with the markup rather than being computed
-  # by a client-side init pass that would have to re-run each time.
-  doc <- xml2::read_html(
-    as.character(color_field_tag(NS("mid"), "#66c2a5"))
-  )
-  by_class <- function(tok) {
-    sprintf(
-      "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]", tok
-    )
-  }
-
-  expect_match(
-    xml2::xml_attr(
-      xml2::xml_find_first(doc, by_class("blockr-stack-menu-color-swatch")),
-      "style"
-    ),
-    "#66c2a5"
-  )
-  expect_identical(
-    xml2::xml_attr(
-      xml2::xml_find_first(doc, by_class("blockr-stack-menu-hue")), "value"
-    ),
-    "161"
-  )
-  expect_identical(
-    xml2::xml_attr(
-      xml2::xml_find_first(doc, by_class("blockr-stack-menu-lightness")),
-      "value"
-    ),
-    "58"
-  )
-})
-
-test_that("hex_to_hsl mirrors the picker's hue / lightness model", {
-  expect_identical(hex_to_hsl("#ff0000"), list(hue = 0, lightness = 50))
-  expect_identical(hex_to_hsl("#00ff00"), list(hue = 120, lightness = 50))
-  expect_identical(hex_to_hsl("#0000ff"), list(hue = 240, lightness = 50))
-  expect_identical(hex_to_hsl("#ffffff"), list(hue = 0, lightness = 100))
-
-  # Shorthand expands; an unusable value falls back to the seed colour.
-  expect_identical(hex_to_hsl("#abc"), hex_to_hsl("#aabbcc"))
-  expect_identical(hex_to_hsl("nope"), hex_to_hsl(default_stack_color()))
-  expect_identical(hex_to_hsl(NULL), hex_to_hsl(default_stack_color()))
-})
-
 test_that("remove stack action", {
   r_board <- reactiveValues(
     board = new_dock_board(

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -21,6 +21,23 @@ set_menu <- function(session, blocks, name, color, id, nonce) {
   )
 }
 
+# The form is server-rendered into the menu's `form` slot, so its current
+# state is read off that output rather than off the panel markup.
+form_field <- function(html, key) {
+  doc <- xml2::read_html(as.character(html))
+  node <- xml2::xml_find_first(
+    doc, paste0("//input[contains(@id, 'menu-", key, "')]")
+  )
+  xml2::xml_attr(node, "value")
+}
+
+board_with_stack <- function(board, id, blocks) {
+  new_dock_board(
+    board_blocks(board),
+    stacks = do.call(stacks, set_names(list(blocks), id))
+  )
+}
+
 test_that("add stack action: valid commit creates one stack", {
   local_mocked_sidebar()
   r_board <- reactiveValues(
@@ -300,6 +317,272 @@ test_that("edit stack action: invalid colour / block id short-circuit", {
       expect_length(r_update(), 0L)
     }
   )
+})
+
+test_that("add stack action: a commit re-seeds the id the board just took", {
+  # A pinned panel stays open across creates, so the form has to move off
+  # the id it just used - otherwise the next commit is rejected as a
+  # duplicate. The seed comes from the merged board, which the form reads
+  # by being bound to it rather than rebuilt after the commit.
+  local_mocked_sidebar()
+  r_board <- reactiveValues(
+    board = new_dock_board(
+      c(a = new_dataset_block("iris"), b = new_head_block())
+    ),
+    board_id = "b"
+  )
+  r_update <- reactiveVal(list())
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_stack_action(
+          trigger = reactive(TRUE),
+          board = r_board,
+          update = r_update
+        )
+      )
+    },
+    {
+      session$flushReact()
+      seeded <- form_field(output$`menu-form`$html, "stack_id")
+      seeded_name <- form_field(output$`menu-form`$html, "stack_name")
+      expect_true(nzchar(seeded))
+
+      set_menu(
+        session,
+        blocks = "a", name = seeded_name, color = "#ff0000", id = seeded,
+        nonce = 1L
+      )
+      expect_named(r_update()$stacks$add, seeded)
+
+      r_board$board <- board_with_stack(r_board$board, seeded, "a")
+      session$flushReact()
+
+      # The whole form re-seeds for the next stack: `rand_names()` excludes
+      # what the board already carries, so neither value can repeat.
+      expect_false(
+        form_field(output$`menu-form`$html, "stack_id") %in%
+          board_stack_ids(r_board$board)
+      )
+      expect_false(
+        identical(
+          form_field(output$`menu-form`$html, "stack_name"), seeded_name
+        )
+      )
+    }
+  )
+})
+
+test_that("add stack action: a foreign board change keeps the entered form", {
+  # Create-mode fields are the user's, not the board's: an unrelated board
+  # change must not swap a typed id / name for another random suggestion,
+  # nor a picked colour for the default.
+  local_mocked_sidebar()
+  r_board <- reactiveValues(
+    board = new_dock_board(c(a = new_dataset_block("iris"))),
+    board_id = "b"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        add_stack_action(
+          trigger = reactive(TRUE),
+          board = r_board,
+          update = reactiveVal(list())
+        )
+      )
+    },
+    {
+      session$flushReact()
+      session$setInputs(
+        `menu-stack_id` = "mine",
+        `menu-stack_name` = "My stack",
+        `menu-stack_color` = "#3366cc"
+      )
+
+      # Another action adds a block; the suggested id is still free, so
+      # nothing was created from this form.
+      r_board$board <- new_dock_board(
+        c(a = new_dataset_block("iris"), b = new_head_block())
+      )
+      session$flushReact()
+
+      expect_identical(form_field(output$`menu-form`$html, "stack_id"), "mine")
+      expect_identical(
+        form_field(output$`menu-form`$html, "stack_name"), "My stack"
+      )
+      expect_identical(
+        form_field(output$`menu-form`$html, "stack_color"), "#3366cc"
+      )
+    }
+  )
+})
+
+test_that("edit stack action: the form follows the edited stack", {
+  # In edit mode the fields show board state, so a rename landing from
+  # anywhere refreshes them in place - no id field, since the id is fixed.
+  local_mocked_sidebar()
+  r_board <- reactiveValues(
+    board = new_dock_board(
+      c(a = new_dataset_block("iris")),
+      stacks = stacks(
+        s1 = new_dock_stack("a", name = "First", color = "#ff0000")
+      )
+    ),
+    board_id = "b"
+  )
+
+  testServer(
+    function(id, ...) {
+      moduleServer(
+        id,
+        edit_stack_action(
+          trigger = reactive("s1"),
+          board = r_board,
+          update = reactiveVal(list())
+        )
+      )
+    },
+    {
+      session$flushReact()
+      expect_identical(
+        form_field(output$`menu-form`$html, "stack_name"), "First"
+      )
+      expect_identical(
+        form_field(output$`menu-form`$html, "stack_color"), "#ff0000"
+      )
+      expect_true(is.na(form_field(output$`menu-form`$html, "stack_id")))
+
+      r_board$board <- new_dock_board(
+        board_blocks(r_board$board),
+        stacks = stacks(
+          s1 = new_dock_stack("a", name = "Renamed", color = "#00ff00")
+        )
+      )
+      session$flushReact()
+
+      expect_identical(
+        form_field(output$`menu-form`$html, "stack_name"), "Renamed"
+      )
+      expect_identical(
+        form_field(output$`menu-form`$html, "stack_color"), "#00ff00"
+      )
+    }
+  )
+})
+
+test_that("add stack action: a commit closes an unpinned panel only", {
+  # The panel body is never re-pushed after a commit - the menu tracks the
+  # board itself - so all the action does is close an unpinned panel.
+  calls <- function(pinned) {
+    seen <- list(show = 0L, hide = 0L)
+    local_mocked_bindings(
+      show_sidebar = function(...) seen$show <<- seen$show + 1L,
+      hide_sidebar = function(...) seen$hide <<- seen$hide + 1L,
+      keep_or_hide_sidebar = function(...) {
+        stop("the panel must not be rebuilt after a commit")
+      },
+      sidebar_state = function(id, ...) list(open = TRUE, pinned = pinned)
+    )
+
+    r_board <- reactiveValues(
+      board = new_dock_board(c(a = new_dataset_block("iris"))),
+      board_id = "b"
+    )
+
+    testServer(
+      function(id, ...) {
+        moduleServer(
+          id,
+          add_stack_action(
+            trigger = reactive(TRUE),
+            board = r_board,
+            update = reactiveVal(list())
+          )
+        )
+      },
+      {
+        session$flushReact()
+        set_menu(
+          session,
+          blocks = "a", name = "N", color = "#ffffff", id = "s1", nonce = 1L
+        )
+      }
+    )
+
+    seen
+  }
+
+  expect_identical(calls(pinned = FALSE), list(show = 1L, hide = 1L))
+  expect_identical(calls(pinned = TRUE), list(show = 1L, hide = 0L))
+})
+
+test_that("stack menu ui defers the form to a server-rendered slot", {
+  board <- new_dock_board(c(a = new_dataset_block("iris")))
+  doc <- xml2::read_html(as.character(stack_menu_ui("mid", board)))
+
+  slot <- xml2::xml_find_first(
+    doc,
+    paste0(
+      "//*[contains(concat(' ', normalize-space(@class), ' '),",
+      " ' blockr-stack-menu-form-slot ')]"
+    )
+  )
+  expect_identical(xml2::xml_attr(slot, "id"), "mid-form")
+  # No field is snapshotted into the panel markup, so nothing can go stale.
+  expect_length(xml2::xml_find_all(doc, "//input[@id='mid-stack_id']"), 0L)
+  expect_length(xml2::xml_find_all(doc, "//input[@id='mid-stack_name']"), 0L)
+})
+
+test_that("stack menu seeds the colour picker positions server-side", {
+  # The form is re-rendered on every board change, so the swatch and the
+  # two slider positions ship with the markup rather than being computed
+  # by a client-side init pass that would have to re-run each time.
+  doc <- xml2::read_html(
+    as.character(color_field_tag(NS("mid"), "#66c2a5"))
+  )
+  by_class <- function(tok) {
+    sprintf(
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]", tok
+    )
+  }
+
+  expect_match(
+    xml2::xml_attr(
+      xml2::xml_find_first(doc, by_class("blockr-stack-menu-color-swatch")),
+      "style"
+    ),
+    "#66c2a5"
+  )
+  expect_identical(
+    xml2::xml_attr(
+      xml2::xml_find_first(doc, by_class("blockr-stack-menu-hue")), "value"
+    ),
+    "161"
+  )
+  expect_identical(
+    xml2::xml_attr(
+      xml2::xml_find_first(doc, by_class("blockr-stack-menu-lightness")),
+      "value"
+    ),
+    "58"
+  )
+})
+
+test_that("hex_to_hsl mirrors the picker's hue / lightness model", {
+  expect_identical(hex_to_hsl("#ff0000"), list(hue = 0, lightness = 50))
+  expect_identical(hex_to_hsl("#00ff00"), list(hue = 120, lightness = 50))
+  expect_identical(hex_to_hsl("#0000ff"), list(hue = 240, lightness = 50))
+  expect_identical(hex_to_hsl("#ffffff"), list(hue = 0, lightness = 100))
+
+  # Shorthand expands; an unusable value falls back to the seed colour.
+  expect_identical(hex_to_hsl("#abc"), hex_to_hsl("#aabbcc"))
+  expect_identical(hex_to_hsl("nope"), hex_to_hsl(default_stack_color()))
+  expect_identical(hex_to_hsl(NULL), hex_to_hsl(default_stack_color()))
 })
 
 test_that("remove stack action", {


### PR DESCRIPTION
## Summary

- Four post-commit paths deferred to `session$onFlushed(..., once = TRUE)` so their `keep_or_hide_sidebar()` rebuild would read the merged board rather than the snapshot `menu_ui()` was built from. The deferral existed for the rebuild — so the menus now track the board and there is nothing left to defer.
- `R/sidebar-stack.R` was the actual work: the name / colour / id form moves into a `uiOutput` bound to the board, the way `edit_inputs_menu_ui()` already binds its row list. The other three sites needed no new reactivity — the connect menu already syncs its cards off the board, and the edit-link menu already renders its endpoints and input slot from it.
- Create-mode fields are suggestions, not board state, so a plain re-render would re-roll a random id under the user's cursor. The suggested id is the sentinel: while the board has not taken it nothing was created from this form and every field is kept; once it is taken — which is what creating the stack does — the whole form re-seeds for the next stack.
- The colour picker's slider positions and swatch are now seeded server-side (`hex_to_hsl()`, mirroring the binding's `hexToHsl()`) and its listeners delegated on the panel root, so the form keeps working across re-renders. The slider→hex write drops its redundant synthetic `input` event and keeps `change`, so it cannot bounce back through the delegated listener and fight a slider mid-drag.
- All four sites now share one post-commit step, `hide_unless_pinned()`: a pinned panel is left to refresh itself in place instead of being torn down and rebuilt, so search text, scroll position and unconsumed entries survive a commit.

With no writer left in a deferred callback, every `show_sidebar()` call runs with the action's own module session as its reactive domain rather than the root session — the precondition #391 needs to derive a panel's owner from the calling module's id.

Verified in a browser as well as in tests, since the delegation change and the server-rendered form are a seam no unit test observes: a foreign board change preserves a typed id / name / picked colour and the slider positions; a create re-seeds all three; and the hue↔hex round-trip still works after the form has been re-rendered twice.

Fixes #393