### PR TITLE
Gate edit-board e2e on DOM conditions instead of wait_for_idle()

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -261,6 +261,36 @@ wait_dock_loaded <- function(app, n_blocks, board_id = "my_board") {
   )
 }
 
+# Wait until the view nav has settled to `n` entries. `board_ui` draws the nav
+# statically and the reconcile pass then adds, removes and re-sequences items,
+# so a read taken before that pass lands samples an intermediate nav. Gating on
+# the settled count states the precondition the nav assertions depend on, in
+# place of an idle wait: the app takes several seconds of back-to-back mount
+# round-trips to go quiescent, so it offers no early quiet window to gate on.
+# A permanent miscount never reaches the target, so the wait times out and
+# still catches it, with the nav dumped.
+wait_view_nav <- function(app, n, board_id = "my_board", timeout = 30 * 1000) {
+
+  sel <- sprintf("#%s-view_nav .blockr-view-item", board_id)
+
+  diagnose <- function() {
+    nav <- read_view_nav(app, board_id)
+    sprintf(
+      "[view-nav] want=%d got=%d ids=[%s] labels=[%s]",
+      n, nrow(nav),
+      paste(nav$id, collapse = ","),
+      paste(nav$label, collapse = ",")
+    )
+  }
+
+  wait_js(
+    app,
+    sprintf("document.querySelectorAll('%s').length === %d", sel, n),
+    diagnose,
+    timeout
+  )
+}
+
 # The dock-owned board state observable in server-rendered DOM: the view nav
 # (one row per view, including which is active), and every block's card id. The
 # serialization e2e captures this before and after a save / restore reload to
@@ -422,7 +452,11 @@ set_in <- function(app, id, value) {
   )
 }
 
-click <- function(app, id) app$click(nsid(id))
+# `wait = FALSE` for the same reason as set_in: a staging click drives an
+# `updateActionButton` message, not an output value, so a waiting click spends
+# its whole budget before reporting that nothing changed. Callers that pass it
+# gate on the staged effect themselves (wait_enabled / wait_gone).
+click <- function(app, id, wait = TRUE) app$click(nsid(id), wait_ = wait)
 
 # A DataTables redraw (e.g. after adding a row) re-renders the cell inputs,
 # which the table's `drawCallback` re-binds via `Shiny.bindAll` once the async
@@ -468,6 +502,60 @@ wait_bound <- function(app, id, timeout = 30 * 1000) {
   wait_js(
     app,
     "window.__blockrWaitBound && window.__blockrWaitBound.done === true",
+    diagnose,
+    timeout
+  )
+}
+
+# The extension gates its controls on staged state through
+# `updateActionButton(disabled = )`: `rm_link` / `rm_stack` follow the
+# DataTable's row selection, `apply_changes` follows whether anything is
+# staged. Clicking a disabled button is a silent no-op that leaves the test
+# asserting against an unchanged board, so a driver has to wait for the
+# enabling round-trip -- the precondition it actually depends on.
+wait_enabled <- function(app, id, timeout = 30 * 1000) {
+
+  target <- nsid(id)
+
+  probe <- sprintf(
+    paste0(
+      "(function(){var e=document.getElementById('%s');",
+      "return {present: e !== null, disabled: e ? e.disabled : null};})()"
+    ),
+    target
+  )
+
+  diagnose <- function() {
+    sprintf(
+      "[wait_enabled] id=%s state=%s",
+      target,
+      app$get_js(paste0("JSON.stringify(", probe, ")"))
+    )
+  }
+
+  wait_js(app, paste0(probe, ".disabled === false"), diagnose, timeout)
+}
+
+# The mirror of wait_bound: an applied removal drops the link / stack row from
+# the DataTable, taking its cell inputs out of the DOM. That travels board
+# update -> DT re-render -> rebind, several round-trips the app does not
+# quiesce between, so gate the assertion on the element leaving rather than on
+# an idle wait that samples a lull partway through.
+wait_gone <- function(app, id, timeout = 30 * 1000) {
+
+  target <- nsid(id)
+
+  diagnose <- function() {
+    sprintf(
+      "[wait_gone] id=%s tables=%s",
+      target,
+      app$get_js("document.querySelectorAll('table.dataTable').length")
+    )
+  }
+
+  wait_js(
+    app,
+    sprintf("document.getElementById('%s') === null", target),
     diagnose,
     timeout
   )

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -224,7 +224,7 @@ test_that("adding a second block keeps both block panels (#196)", {
   )
   withr::defer(app$stop())
 
-  app$wait_for_idle()
+  wait_bound(app, "registry_select")
 
   add_block <- function(registry, id) {
     app$set_inputs(
@@ -232,7 +232,6 @@ test_that("adding a second block keeps both block panels (#196)", {
       `my_board-ext_edit_board-block_id` = id
     )
     app$click("my_board-ext_edit_board-confirm_add")
-    app$wait_for_idle()
   }
 
   add_block("dataset_block", "a")
@@ -311,7 +310,7 @@ test_that("multi-view nav renders one labelled entry per view (#189)", {
   )
   withr::defer(app$stop())
 
-  app$wait_for_idle()
+  wait_view_nav(app, 2)
 
   # The bug rendered 2N entries: board_ui drew N items statically and the
   # reconcile pass re-added each as a blank-labelled duplicate sharing the
@@ -332,7 +331,7 @@ test_that("multi-view nav renders one labelled entry per view (#189)", {
 
   app$set_inputs(`my_board-view_new_name` = "Third")
   app$click("my_board-confirm_view_add")
-  app$wait_for_idle()
+  wait_view_nav(app, 3)
 
   nav <- read_view_nav(app)
 
@@ -482,9 +481,11 @@ test_that("deleting a block via its card menu drops the panel and its link", {
   )
   withr::defer(app$stop())
 
-  app$wait_for_idle()
-
+  # Two independent client settlements: dockview mounts the panel tabs, and the
+  # extension's links table renders and binds its cell inputs. Neither implies
+  # the other, so gate on both before reading them.
   wait_block_panel_tabs(app, c("block_panel-a", "block_panel-b"))
+  wait_bound(app, "ab_from")
   expect_identical(block_panel_tabs(app), c("block_panel-a", "block_panel-b"))
   expect_identical(field(app, "ab_from"), "a")
 
@@ -497,14 +498,14 @@ test_that("deleting a block via its card menu drops the panel and its link", {
       "'my_board-block_b-edit_block-delete_block', 1, {priority: 'event'});"
     )
   )
-  app$wait_for_idle()
 
   # The board update removes b's dock panel and cascade-removes the dependent
-  # link, whose row then leaves the extension's links table. Gate on the panel
-  # actually dropping (client-confirmed) before asserting the strip and reading
-  # the link field: the same board update has cleared both by the time the tab
-  # is gone.
+  # link, whose row then leaves the extension's links table. One update, but
+  # again two settlements landing on their own schedules -- the panel drop is
+  # client-confirmed by the tab going, the row removal by the cell input
+  # leaving the DOM.
   wait_block_panel_tabs(app, "block_panel-a")
+  wait_gone(app, "ab_from")
   expect_identical(block_panel_tabs(app), "block_panel-a")
   expect_null(field(app, "ab_from"))
 })
@@ -521,7 +522,7 @@ test_that("removing a link via the edit extension updates the board", {
   )
   withr::defer(app$stop())
 
-  app$wait_for_idle()
+  wait_bound(app, "ab_from")
   expect_identical(field(app, "ab_from"), "a")
 
   app$run_js(
@@ -530,12 +531,12 @@ test_that("removing a link via the edit extension updates the board", {
       "', [1], {priority: 'event'});"
     )
   )
-  app$wait_for_idle()
+  wait_enabled(app, "rm_link")
 
-  click(app, "rm_link")
-  app$wait_for_idle()
+  click(app, "rm_link", wait = FALSE)
+  wait_enabled(app, "apply_changes")
   click(app, "apply_changes")
-  app$wait_for_idle()
+  wait_gone(app, "ab_from")
 
   expect_null(field(app, "ab_from"))
 })
@@ -552,7 +553,7 @@ test_that("removing a stack via the edit extension updates the board", {
   )
   withr::defer(app$stop())
 
-  app$wait_for_idle()
+  wait_bound(app, "grp_name")
   expect_identical(field(app, "grp_name"), "Group A")
 
   app$run_js(
@@ -561,12 +562,12 @@ test_that("removing a stack via the edit extension updates the board", {
       "', [1], {priority: 'event'});"
     )
   )
-  app$wait_for_idle()
+  wait_enabled(app, "rm_stack")
 
-  click(app, "rm_stack")
-  app$wait_for_idle()
+  click(app, "rm_stack", wait = FALSE)
+  wait_enabled(app, "apply_changes")
   click(app, "apply_changes")
-  app$wait_for_idle()
+  wait_gone(app, "grp_name")
 
   expect_null(field(app, "grp_name"))
 })
@@ -684,7 +685,7 @@ test_that("a view moves down via the nav reorder control (#351)", {
   )
   withr::defer(app$stop())
 
-  app$wait_for_idle()
+  wait_view_nav(app, 2)
 
   # Two seeded views, First active and on top.
   nav <- read_view_nav(app)


### PR DESCRIPTION
## Summary

- `wait_for_idle()` cannot gate the `edit-board` e2e: the app needs several seconds of back-to-back mount round-trips before it offers the 500ms quiet window, so the two removal tests failed deterministically at their first idle call on shinytest2's 4s default. No timeout is raised anywhere — the mount cost itself is #397.
- Idle is also unsound here rather than merely slow. Driving the same app from a plain script it returned after 0.5s, having caught an early lull while the app was still churning; a test that then asserts is sampling a race. Each converted gate waits for the condition the test actually depends on: the DataTable cell input being bound (`wait_bound`), the staged-state button having been enabled by the server (`wait_enabled`), the removed row's cell input leaving the DOM (`wait_gone`), the view nav settling to N entries (`wait_view_nav`).
- Two gates turned out to cover a *conjunction* of independent client settlements that idle had papered over, and the tests now state both. `deleting a block via its card menu` depends on the dockview panel drop and the DataTable redraw landing separately — dropping the idle waits surfaced that as two real failures before this landed.
- `click()` grows a `wait` argument, mirroring `set_in()`: a staging click drives an `updateActionButton` message, not an output value, so a waiting click spends its whole budget before reporting that nothing changed.
- The `view lifecycle` test deliberately keeps its idle waits. Its switch / rename / remove chain needs a further chain of gates (the dock container insert, the dock's active class, the nav's own active marker, then rename and remove) and is its own piece of work; noted on #397 rather than half-converted here.

Fixes #395