### PR TITLE
Add design tokens for a data mark's radius and supporting weight

### DIFF
--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -27,6 +27,26 @@
   --blockr-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --blockr-shadow-lg: 0 25px 50px -12px rgb(0 0 0 / 0.25);
 
+  /* Data marks - bars, boxes, lanes */
+  /* Cosmetic ONLY. This radius carries no information: it exists so a mark
+     does not read as a raw div, and nothing may ever be inferred from its
+     presence. Two rules keep it honest:
+       - it applies to the SILHOUETTE, never to sub-marks (median ticks,
+         whiskers, fence caps are 1-2px and a radius turns them into dots);
+       - an end stays SQUARE if it sits on an axis (a bar's zero end) or
+         abuts a sibling segment (a stack's inner joins). Rounding a baseline
+         lifts the bar off its axis, and zero is shared structure, not data.
+     It must also never approach half the mark's thickness, because a capsule
+     is a SEPARATE and semantic signal meaning "soft boundary" (the
+     point-range band). Clamp with min(radius, thickness / 4) on thin lanes;
+     at 12-14px the token applies unchanged. */
+  --blockr-mark-radius: 2px;
+
+  /* Weight for a mark that supports a CHOICE rather than carrying the answer:
+     the crossfilter's bars rank options in a picker, they are not the
+     analysis output. Marks that are the content stay at full weight. */
+  --blockr-mark-weight-supporting: 0.6;
+
   /* Font Sizes */
   --blockr-font-size-base: 0.875rem;      /* 14px - base for body/inputs */
   --blockr-font-size-sm: 0.8125rem;       /* 13px - helper text */


### PR DESCRIPTION
## Summary

- Adds `--blockr-mark-radius: 2px` and `--blockr-mark-weight-supporting: 0.6` to `inst/assets/css/blockr-dock.css`, next to the existing `--blockr-*` tokens. The renderers had no shared answer for either, so each invented one — bars are square in blockr.viz, 2px-rounded in blockr.dm's crossfilter, fully rounded on tile meters.
- The rules that keep the radius honest ride along as CSS comments, since neither is inferable from `2px`: it applies to a mark's silhouette and never to sub-marks (a 1-2px median tick or fence cap becomes a dot), an end stays square where it sits on an axis or abuts a sibling segment, and it must stay well under half the mark's thickness because a capsule is a separate, semantic signal for "soft boundary".
- Nothing in blockr.dock consumes either token. They live here because this is where the design system lives; the consumers are blockr.viz and blockr.dm. Happy to move them if you would rather dock only carried tokens its own components use.
- Cherry-picked from e8948e6 with the `Version` bump (0.1.3 -> 0.1.4) dropped, per the issue; authorship preserved. The only edit to the hunk is a lighter section comment, matching the one-line form every other group in `:root` uses.

Fixes #390