### PR TITLE
Batch a card sweep into one move-element message

### DIFF
--- a/R/block-ui.R
+++ b/R/block-ui.R
@@ -115,8 +115,12 @@ insert_block_ui.dock_board <- function(id, x, blocks, dock, ...,
   )
 
   for (i in names(blocks)) {
-    show_block_panel(blocks[i], determine_panel_pos(dock), dock)
+    add_block_panel(blocks[i], position = determine_panel_pos(dock),
+                    dock = dock)
   }
+
+  show_block_ui(names(blocks), dock$proxy$session,
+                board_ns = dock_board_ns(dock))
 
   invisible(x)
 }
@@ -254,25 +258,40 @@ hide_block_panel <- function(id, rm_panel = TRUE, dock, ...) {
   invisible(NULL)
 }
 
-hide_block_ui <- function(id, session, board_ns = session$ns) {
+hide_block_ui <- function(ids, session, board_ns = session$ns) {
 
-  bid <- board_ns(as_block_handle_id(id))
+  hid <- as_block_handle_id(ids)
+
+  if (!length(hid)) {
+    return(invisible(NULL))
+  }
+
+  bid <- board_ns(hid)
   oid <- paste0(board_ns("blocks_offcanvas"), " .offcanvas-body")
 
-  log_debug("hiding block {bid} in {oid}")
+  log_debug("hiding {cli::qty(length(bid))}block{?s} {bid} in {oid}")
 
-  move_dom_element(paste0("#", bid), paste0("#", oid), session)
+  move_dom_elements(paste0("#", bid), paste0("#", oid), session)
 }
 
-show_block_ui <- function(id, session, board_ns = session$ns) {
+show_block_ui <- function(ids, session, board_ns = session$ns) {
+
+  hid <- as_block_handle_id(ids)
+
+  if (!length(hid)) {
+    return(invisible(NULL))
+  }
 
   # board_ns: board-level namespace for DOM element IDs (handles, offcanvas).
   # session$ns: dock-module namespace for dock panel IDs.
   # These differ when called from a nested dock module (views).
-  bid <- board_ns(as_block_handle_id(id))
-  pid <- paste(dock_id(session$ns), as_block_panel_id(id), sep = "-")
+  bid <- board_ns(hid)
+  pid <- paste(dock_id(session$ns), as_block_panel_id(ids), sep = "-")
 
-  log_debug("showing block {bid} in panel {pid}")
+  log_debug(
+    "showing {cli::qty(length(bid))}block{?s} {bid} in ",
+    "{cli::qty(length(pid))}panel{?s} {pid}"
+  )
 
-  move_dom_element(paste0("#", bid), paste0("#", pid), session)
+  move_dom_elements(paste0("#", bid), paste0("#", pid), session)
 }

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -438,50 +438,36 @@ live_view_membership <- function(grid, view) {
   new_dock_view(layout_panel_ids(grid), view_name(view))
 }
 
-#' Hide all block and extension UI for a view.
-#'
-#' Moves block/extension cards off-screen (back to offcanvas) so they are
-#' not visible while the view is inactive.
-#'
-#' @param view_id View id (string).
-#' @param docks `reactiveValues` of dock module results, keyed by view id.
-#'
-#' @noRd
 hide_view_ui <- function(view_id, docks) {
+
   if (is.null(view_id) || !(view_id %in% names(docks))) {
     return()
   }
+
   dock <- docks[[view_id]]
   bns <- dock_board_ns(dock)
-  for (bid in as_obj_id(block_panel_ids(dock$proxy))) {
-    hide_block_ui(bid, dock$proxy$session, board_ns = bns)
-  }
-  for (eid in as_obj_id(ext_panel_ids(dock$proxy))) {
-    hide_ext_ui(eid, dock$proxy$session, board_ns = bns)
-  }
+
+  hide_block_ui(as_obj_id(block_panel_ids(dock$proxy)), dock$proxy$session,
+                board_ns = bns)
+
+  hide_ext_ui(as_obj_id(ext_panel_ids(dock$proxy)), dock$proxy$session,
+              board_ns = bns)
 }
 
-#' Show all block and extension UI for a view.
-#'
-#' Restores block/extension cards into the viewport when a view
-#' becomes active.
-#'
-#' @param view_id View id (string).
-#' @param docks `reactiveValues` of dock module results, keyed by view id.
-#'
-#' @noRd
 show_view_ui <- function(view_id, docks) {
+
   if (is.null(view_id) || !(view_id %in% names(docks))) {
     return()
   }
+
   dock <- docks[[view_id]]
   bns <- dock_board_ns(dock)
-  for (bid in as_obj_id(block_panel_ids(dock$proxy))) {
-    show_block_ui(bid, dock$proxy$session, board_ns = bns)
-  }
-  for (eid in as_obj_id(ext_panel_ids(dock$proxy))) {
-    show_ext_ui(eid, dock$proxy$session, board_ns = bns)
-  }
+
+  show_block_ui(as_obj_id(block_panel_ids(dock$proxy)), dock$proxy$session,
+                board_ns = bns)
+
+  show_ext_ui(as_obj_id(ext_panel_ids(dock$proxy)), dock$proxy$session,
+              board_ns = bns)
 }
 
 # Insert a view's dock container, start its manage_dock module, and register
@@ -789,18 +775,15 @@ manage_dock <- function(
         restore_layout(init_layout, dock$proxy,
                        blocks = init_blocks, extensions = init_exts)
 
-        for (pid in panels) {
-          if (is_block_panel_id(pid)) {
-            show_block_ui(pid, session, board_ns = board_ns)
-          } else if (is_ext_panel_id(pid)) {
-            show_ext_ui(pid, session, board_ns = board_ns)
-          } else {
-            blockr_abort(
-              "Unknown panel type {class(pid)}.",
-              class = "dock_panel_invalid"
-            )
-          }
-        }
+        show_block_ui(
+          as_obj_id(Filter(is_block_panel_id, panels)), session,
+          board_ns = board_ns
+        )
+
+        show_ext_ui(
+          as_obj_id(Filter(is_ext_panel_id, panels)), session,
+          board_ns = board_ns
+        )
       },
       once = TRUE
     )

--- a/R/ext-ui.R
+++ b/R/ext-ui.R
@@ -26,25 +26,40 @@ hide_ext_panel <- function(id, rm_panel = TRUE, dock, ...) {
   invisible(NULL)
 }
 
-hide_ext_ui <- function(id, session, board_ns = session$ns) {
+hide_ext_ui <- function(ids, session, board_ns = session$ns) {
 
-  eid <- board_ns(as_ext_handle_id(id))
+  hid <- as_ext_handle_id(ids)
+
+  if (!length(hid)) {
+    return(invisible(NULL))
+  }
+
+  eid <- board_ns(hid)
   oid <- paste0(board_ns("exts_offcanvas"), " .offcanvas-body")
 
-  log_debug("hiding extension {eid} in {oid}")
+  log_debug("hiding {cli::qty(length(eid))}extension{?s} {eid} in {oid}")
 
-  move_dom_element(paste0("#", eid), paste0("#", oid), session)
+  move_dom_elements(paste0("#", eid), paste0("#", oid), session)
 }
 
-show_ext_ui <- function(id, session, board_ns = session$ns) {
+show_ext_ui <- function(ids, session, board_ns = session$ns) {
+
+  hid <- as_ext_handle_id(ids)
+
+  if (!length(hid)) {
+    return(invisible(NULL))
+  }
 
   # board_ns: board-level namespace for DOM element IDs (handles, offcanvas).
   # session$ns: dock-module namespace for dock panel IDs.
   # These differ when called from a nested dock module (views).
-  eid <- board_ns(as_ext_handle_id(id))
-  pid <- paste(dock_id(session$ns), as_ext_panel_id(id), sep = "-")
+  eid <- board_ns(hid)
+  pid <- paste(dock_id(session$ns), as_ext_panel_id(ids), sep = "-")
 
-  log_debug("showing extension {eid} in panel {pid}")
+  log_debug(
+    "showing {cli::qty(length(eid))}extension{?s} {eid} in ",
+    "{cli::qty(length(pid))}panel{?s} {pid}"
+  )
 
-  move_dom_element(paste0("#", eid), paste0("#", pid), session)
+  move_dom_elements(paste0("#", eid), paste0("#", pid), session)
 }

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -34,13 +34,21 @@ collapse_container <- function(id, ...) {
   tags$div(class = "collapse", id = id, ...)
 }
 
-move_dom_element <- function(from, to, session = get_session()) {
+# One message per sweep, not one per card: `sendCustomMessage()` writes a
+# websocket frame per call, so N cards would arrive as N frames in N client
+# tasks, each relocating DOM that re-fires the moved outputs' resize and
+# intersection observers, whose clientdata writes then go up in their own input
+# batch. Batched, a sweep is one frame and one batch however many cards it
+# moves. `to` is recycled: a sweep into the offcanvas shares one target.
+move_dom_elements <- function(from, to, session = get_session()) {
+
+  if (!length(from)) {
+    return(invisible(NULL))
+  }
+
   session$sendCustomMessage(
     "move-element",
-    list(
-      from = from,
-      to = to
-    )
+    map(list, from = from, to = to)
   )
 }
 

--- a/inst/assets/js/show-block.js
+++ b/inst/assets/js/show-block.js
@@ -39,12 +39,17 @@ $(function () {
     return true;
   }
 
+  // A whole sweep arrives as one message, so every append lands in this task
+  // and the moved outputs' observer callbacks share one debounce window --
+  // one clientdata batch for the sweep rather than one per card.
   Shiny.addCustomMessageHandler(
-    'move-element', (m) => {
+    'move-element', (moves) => {
       pending = pending.filter(alive);
-      if (!applyMove(m)) {
-        pending.push(m);
-      }
+      moves.forEach((m) => {
+        if (!applyMove(m)) {
+          pending.push(m);
+        }
+      });
     }
   )
 

--- a/tests/testthat/test-block-ui.R
+++ b/tests/testthat/test-block-ui.R
@@ -20,7 +20,7 @@ test_that("insert/remove panel test", {
         session$flushReact(),
         determine_panel_pos = function(dock) {
           expect_s3_class(dock$proxy, "dock_view_proxy")
-          TRUE
+          list(direction = "right")
         }
       )
 
@@ -355,4 +355,43 @@ test_that("remove_block_ui removes the card, leaving the slot to core", {
   # (dropping it from the ledger); the dock must not touch the channel.
   expect_length(removed, 1L)
   expect_setequal(built_cards(vis), c("a", "b"))
+})
+
+test_that("a card sweep is one move-element message, not one per card (#397)", {
+
+  sent <- list()
+  session <- list(
+    ns = NS("my_board"),
+    sendCustomMessage = function(type, message) {
+      sent[[length(sent) + 1L]] <<- message
+      invisible()
+    }
+  )
+
+  show_block_ui(c("a", "b", "c"), session)
+
+  expect_length(sent, 1L)
+  expect_identical(
+    chr_xtr(sent[[1L]], "from"),
+    paste0("#my_board-block_handle-", c("a", "b", "c"))
+  )
+  expect_identical(
+    chr_xtr(sent[[1L]], "to"),
+    paste0("#my_board-dock-block_panel-", c("a", "b", "c"))
+  )
+
+  sent <- list()
+  hide_block_ui(c("a", "b", "c"), session)
+
+  expect_length(sent, 1L)
+  expect_identical(
+    chr_xtr(sent[[1L]], "to"),
+    rep("#my_board-blocks_offcanvas .offcanvas-body", 3L)
+  )
+
+  sent <- list()
+  show_block_ui(character(), session)
+  hide_block_ui(character(), session)
+
+  expect_length(sent, 0L)
 })

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1848,3 +1848,37 @@ test_that("a locked board still wires the render path (#339)", {
   # paints the front tab must not be -- gating it would blank a locked board.
   expect_identical(render_wired, 1L)
 })
+
+test_that("a view sweep sends one move-element message per card kind (#397)", {
+
+  sent <- list()
+  session <- list(
+    ns = NS("my_board"),
+    sendCustomMessage = function(type, message) {
+      sent[[length(sent) + 1L]] <<- message
+      invisible()
+    }
+  )
+
+  local_mocked_bindings(
+    block_panel_ids = function(...) as_block_panel_id(c("a", "b", "c")),
+    ext_panel_ids = function(...) as_ext_panel_id("edit_board")
+  )
+
+  docks <- list(v1 = list(proxy = list(session = session)))
+
+  show_view_ui("v1", docks)
+
+  # Three block cards and one extension card cross over as two messages, not
+  # four: each card relocated in its own message would be its own client task.
+  expect_length(sent, 2L)
+  expect_length(sent[[1L]], 3L)
+  expect_length(sent[[2L]], 1L)
+
+  sent <- list()
+  hide_view_ui("v1", docks)
+
+  expect_length(sent, 2L)
+  expect_length(sent[[1L]], 3L)
+  expect_length(sent[[2L]], 1L)
+})

--- a/tests/testthat/test-utils-ui.R
+++ b/tests/testthat/test-utils-ui.R
@@ -107,3 +107,44 @@ test_that("empty_dock_prompt offers no add control when locked (#136)", {
   expect_false(grepl("empty_dock_add", locked, fixed = TRUE))
   expect_match(locked, "lock-fill", fixed = TRUE)
 })
+
+test_that("move_dom_elements batches a sweep into one message", {
+
+  sent <- list()
+  session <- list(
+    sendCustomMessage = function(type, message) {
+      sent[[length(sent) + 1L]] <<- list(type = type, message = message)
+      invisible()
+    }
+  )
+
+  move_dom_elements(c("#a", "#b", "#c"), "#off", session)
+
+  expect_length(sent, 1L)
+  expect_identical(sent[[1L]]$type, "move-element")
+  expect_identical(
+    sent[[1L]]$message,
+    list(
+      list(from = "#a", to = "#off"),
+      list(from = "#b", to = "#off"),
+      list(from = "#c", to = "#off")
+    )
+  )
+
+  sent <- list()
+  move_dom_elements(c("#a", "#b"), c("#p-a", "#p-b"), session)
+
+  expect_length(sent, 1L)
+  expect_identical(
+    sent[[1L]]$message,
+    list(
+      list(from = "#a", to = "#p-a"),
+      list(from = "#b", to = "#p-b")
+    )
+  )
+
+  sent <- list()
+  move_dom_elements(character(), "#off", session)
+
+  expect_length(sent, 0L)
+})


### PR DESCRIPTION
## Summary

- `move_dom_element()` became `move_dom_elements()`, vectorised over from / to pairs and sending one `move-element` message carrying the whole sweep. `sendCustomMessage()` writes one websocket frame per call, so relocating a view's cards one at a time put N frames into N client tasks, each firing the moved outputs' resize and intersection observers into a clientdata batch of its own.
- `show_block_ui()` / `hide_block_ui()` / `show_ext_ui()` / `hide_ext_ui()` take a vector of ids and send one message each, so the mount observer, `show_view_ui()` / `hide_view_ui()` and `insert_block_ui()` no longer loop a message per card. A view switch is 4 frames instead of 2N.
- The mount observer's per-panel `if / else if / blockr_abort` dispatch is replaced by two kind-filtered calls. Its `dock_panel_invalid` branch was unreachable — `as_dock_panel_id()` already aborts on an id that is neither a block nor an extension panel — and goes with the loop.

## Measured

On a scratch board of 8 blocks plus an extension panel, a mount goes from **9 `move-element` frames to 2**. Settle time is unchanged (`wait_for_idle` ~9s either way, 3 runs each, high variance).

That is deliberate framing: this is a wire / task-count reduction, not a latency fix. Instrumenting the page (wrapping `Shiny.bindAll` / `unbindAll` / `initializeInputs` and counting `.clientdata_output_*` writes) puts the mount's whole-page clientdata refreshes elsewhere — of the 85 bind calls that board makes while starting up, exactly 1 comes from `dockview.js`, and the rest are Shiny's `renderContent` cycle over each block card's three `uiOutput`s. Roughly half the settle window is server compute rather than round-trips at all.

## Not closing #397

#397 lists two candidate items; this is the blockr.dock one. Its headline cost — the ~6s before the app goes quiescent — is untouched, and measurement puts it in a third place the issue does not name. Closing #397 here would claim a fix that was not made, so the trailer is deliberately `Refs`, not `Fixes`. Follow-ups are filed separately and linked from #397.

Refs #397