### PR TITLE
Pick a stack colour with a native colour input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # blockr.dock (development version)
 
+* The stack sidebar picks a colour with a native `<input type="color">`
+  beside the hex field, in place of the hand-rolled hue / lightness
+  sliders. The sliders reached only a fixed-saturation slice of the colour
+  space -- no black, no white, nothing muted or fully saturated -- and a
+  hex value typed from outside that slice was accepted but then silently
+  rewritten by the next drag. The native input gives the full gamut, plus
+  the platform's own dialog, eyedropper and keyboard handling (#396).
+
 * New export `sidebar_owned_by()`, which reports whether a given action
   currently holds one of the board's sidebar panels -- `NULL` when it
   does not, otherwise the panel plus whether it is open and pinned. It

--- a/R/sidebar-stack.R
+++ b/R/sidebar-stack.R
@@ -374,14 +374,23 @@ text_field_tag <- function(ns, key, label, value, placeholder) {
   )
 }
 
+# The hex text field is the value carrier - it is what Shiny binds as
+# `input$stack_color`, and what a pasted brand colour goes into. The
+# native colour input beside it carries no id and no binding; the two
+# are rendered from the same value and follow each other client-side.
 color_field_tag <- function(ns, value) {
   hex <- value %||% default_stack_color()
   tags$div(
-    class = "blockr-stack-menu-field blockr-stack-menu-color",
+    class = "blockr-stack-menu-field",
     tags$label(`for` = ns("stack_color"), "Stack color"),
     tags$div(
-      class = "blockr-stack-menu-color-preview",
-      tags$span(class = "blockr-stack-menu-color-swatch"),
+      class = "blockr-stack-menu-color-fields",
+      tags$input(
+        type = "color",
+        class = "blockr-stack-menu-swatch",
+        value = expand_hex_color(hex),
+        `aria-label` = "Stack color picker"
+      ),
       tags$input(
         id = ns("stack_color"),
         type = "text",
@@ -391,24 +400,6 @@ color_field_tag <- function(ns, value) {
         autocomplete = "off",
         `aria-label` = "Hex colour value"
       )
-    ),
-    tags$input(
-      type = "range",
-      class = "blockr-stack-menu-hue",
-      min = "0",
-      max = "360",
-      step = "1",
-      value = "0",
-      `aria-label` = "Hue"
-    ),
-    tags$input(
-      type = "range",
-      class = "blockr-stack-menu-lightness",
-      min = "20",
-      max = "85",
-      step = "1",
-      value = "60",
-      `aria-label` = "Lightness"
     )
   )
 }

--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -73,6 +73,17 @@ is_hex_color <- function(x) {
   is_string(x) && grepl("^#(?:[0-9a-fA-F]{3}){1,2}$", x)
 }
 
+# `<input type="color">` accepts only the 6-digit form: fed the shorthand
+# it silently falls back to black, so expand before handing a colour to
+# one.
+expand_hex_color <- function(x) {
+  if (grepl("^#[0-9a-fA-F]{3}$", x)) {
+    paste0("#", gsub("(.)", "\\1\\1", substring(x, 2L)))
+  } else {
+    x
+  }
+}
+
 create_block_with_name <- function(reg_id, blk_nms, ...) {
   name_fun <- function(nms) {
     function(class) {

--- a/inst/assets/css/sidebar-stack.css
+++ b/inst/assets/css/sidebar-stack.css
@@ -1,8 +1,8 @@
 /* Stack menu: a multi-select card-list block picker for stacks, sharing
    the block-browser's card visuals. Only the bits unique to the stack
    menu live here: the .card-selected visual confirmation, the
-   panel-level form (name / color / id), the inline colour palette, the
-   advanced toggle, and the bottom-pinned confirm button. */
+   panel-level form (name / color / id), the advanced toggle, and the
+   bottom-pinned confirm button. */
 
 .blockr-stack-menu {
   display: flex;
@@ -130,100 +130,48 @@
 }
 
 
-/* Inline colour picker: hex preview + text input + hue/lightness
-   sliders. The hex `<input>` is the value carrier (a normal Shiny
-   text input); sliders write the hex on input, the JS keeps the
-   preview swatch and slider positions in sync with the hex. */
-.blockr-stack-menu-color-preview {
+/* Colour field: native colour input + hex text input, side by side. */
+.blockr-stack-menu-color-fields {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-top: 2px;
 }
 
-.blockr-stack-menu-color-swatch {
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  border: 1px solid rgba(15, 23, 42, 0.15);
-  border-radius: 4px;
-  background: #66c2a5;
-}
-
-.blockr-stack-menu-color-preview input.blockr-stack-menu-hex {
+.blockr-stack-menu-color-fields input.blockr-stack-menu-hex {
   flex: 1 1 auto;
 }
 
-/* Hue + lightness sliders. Styled as CSS-gradient tracks so the user
-   gets the "rainbow" affordance without canvas or extra markup. */
-.blockr-stack-menu-color input[type="range"] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  width: 100%;
-  height: 12px;
-  background: transparent;
-  cursor: pointer;
-  margin: 4px 0 0 0;
-}
-
-.blockr-stack-menu-color input[type="range"]::-webkit-slider-runnable-track {
-  height: 8px;
+.blockr-stack-menu-swatch {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 32px;
+  padding: 2px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
   border-radius: 4px;
-}
-
-.blockr-stack-menu-color input[type="range"]::-moz-range-track {
-  height: 8px;
-  border-radius: 4px;
-}
-
-.blockr-stack-menu-hue::-webkit-slider-runnable-track {
-  background: linear-gradient(
-    to right,
-    #ff5050 0%, #ffdf50 17%, #50ff50 33%, #50ffff 50%,
-    #5050ff 67%, #ff50ff 83%, #ff5050 100%
-  );
-}
-
-.blockr-stack-menu-hue::-moz-range-track {
-  background: linear-gradient(
-    to right,
-    #ff5050 0%, #ffdf50 17%, #50ff50 33%, #50ffff 50%,
-    #5050ff 67%, #ff50ff 83%, #ff5050 100%
-  );
-}
-
-.blockr-stack-menu-lightness::-webkit-slider-runnable-track {
-  background: linear-gradient(to right, #000, #888, #fff);
-}
-
-.blockr-stack-menu-lightness::-moz-range-track {
-  background: linear-gradient(to right, #000, #888, #fff);
-}
-
-.blockr-stack-menu-color input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 14px;
-  height: 14px;
-  margin-top: -3px;
-  border-radius: 50%;
   background: #ffffff;
-  border: 2px solid #2563eb;
   cursor: pointer;
 }
 
-.blockr-stack-menu-color input[type="range"]::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: #ffffff;
-  border: 2px solid #2563eb;
-  cursor: pointer;
+/* The default chrome around the colour well is a thick inset border that
+   leaves the colour a small dot; trim it so the well reads as a swatch. */
+.blockr-stack-menu-swatch::-webkit-color-swatch-wrapper {
+  padding: 0;
 }
 
-.blockr-stack-menu-color input[type="range"]:focus-visible {
+.blockr-stack-menu-swatch::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.blockr-stack-menu-swatch::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.blockr-stack-menu-swatch:focus-visible {
   outline: 2px solid #2563eb;
-  outline-offset: 2px;
+  outline-offset: 1px;
 }
 
 /* Trimmed stack-menu card: drop the description and package badge,

--- a/inst/assets/css/sidebar-stack.css
+++ b/inst/assets/css/sidebar-stack.css
@@ -142,9 +142,15 @@
   flex: 1 1 auto;
 }
 
+/* `height: auto` is load-bearing: WebKit / Blink give `input[type="color"]`
+   a definite height in their UA stylesheet, and `align-self: stretch` only
+   applies to an auto cross-size -- so without it the swatch renders shorter
+   than the hex field beside it there (Gecko sets no such height, which is
+   why it looks right untouched). */
 .blockr-stack-menu-swatch {
   flex: 0 0 auto;
   align-self: stretch;
+  height: auto;
   width: 32px;
   padding: 2px;
   border: 1px solid rgba(15, 23, 42, 0.12);

--- a/inst/assets/js/sidebar-stack.js
+++ b/inst/assets/js/sidebar-stack.js
@@ -91,132 +91,50 @@
     cardSearch.applySearch(root, search ? search.value : "");
   }
 
-  // Inline colour picker: hue + lightness sliders + hex text input.
-  // The hex `<input>` is the canonical value carrier (a normal Shiny
-  // text input). Slider input recomputes HSL -> hex and writes the hex
-  // field, dispatching a native "change" event so Shiny's built-in
-  // text-input binding picks the change up - we never call
-  // Shiny.setInputValue ourselves. Typing in the hex field goes the
-  // other way: hex -> HSL -> slider positions + preview swatch.
+  // Colour field: a hex text input - the canonical value, and the only
+  // one Shiny binds - beside a native `<input type="color">`. R renders
+  // both from the same value, so there is nothing to seed; they only
+  // have to follow each other.
   //
-  // Everything is delegated on the panel root, which outlives the form:
+  // The sync is delegated on the panel root, which outlives the form:
   // the form is server-rendered into a `uiOutput` so it tracks the board,
   // and per-element listeners would die with each render.
 
-  function clamp(v, lo, hi) {
-    return Math.max(lo, Math.min(hi, v));
+  // `<input type="color">` takes only the 6-digit form; the R side
+  // accepts the 3-digit shorthand too. Returns null for anything the
+  // colour input cannot hold.
+  function expandHex(value) {
+    var v = (value || "").trim();
+    if (/^#[0-9a-fA-F]{3}$/.test(v)) {
+      return "#" + v.slice(1).replace(/./g, "$&$&");
+    }
+    return /^#[0-9a-fA-F]{6}$/.test(v) ? v : null;
   }
 
-  // HSL with S fixed at 60% (matches the dock's default chroma feel)
-  // and L variable. h in [0, 360], l in [0, 100].
-  function hslToHex(h, l) {
-    var s = 60;
-    h = ((h % 360) + 360) % 360;
-    l = clamp(l, 0, 100);
-    var sN = s / 100;
-    var lN = l / 100;
-    var c = (1 - Math.abs(2 * lN - 1)) * sN;
-    var x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-    var m = lN - c / 2;
-    var r1 = 0, g1 = 0, b1 = 0;
-    if (h < 60)        { r1 = c; g1 = x; b1 = 0; }
-    else if (h < 120)  { r1 = x; g1 = c; b1 = 0; }
-    else if (h < 180)  { r1 = 0; g1 = c; b1 = x; }
-    else if (h < 240)  { r1 = 0; g1 = x; b1 = c; }
-    else if (h < 300)  { r1 = x; g1 = 0; b1 = c; }
-    else               { r1 = c; g1 = 0; b1 = x; }
-    var to255 = function (v) {
-      var n = Math.round((v + m) * 255);
-      var s = clamp(n, 0, 255).toString(16);
-      return s.length === 1 ? "0" + s : s;
-    };
-    return "#" + to255(r1) + to255(g1) + to255(b1);
-  }
+  function syncColorFields(root, event) {
+    var hex = root.querySelector(".blockr-stack-menu-hex");
+    var swatch = root.querySelector(".blockr-stack-menu-swatch");
+    if (!hex || !swatch) return;
 
-  function hexToHsl(hex) {
-    if (!/^#[0-9a-fA-F]{6}$/.test(hex)) return null;
-    var r = parseInt(hex.slice(1, 3), 16) / 255;
-    var g = parseInt(hex.slice(3, 5), 16) / 255;
-    var b = parseInt(hex.slice(5, 7), 16) / 255;
-    var max = Math.max(r, g, b);
-    var min = Math.min(r, g, b);
-    var l = (max + min) / 2;
-    var h = 0, s = 0;
-    if (max !== min) {
-      var d = max - min;
-      s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-      switch (max) {
-        case r: h = ((g - b) / d) + (g < b ? 6 : 0); break;
-        case g: h = ((b - r) / d) + 2; break;
-        case b: h = ((r - g) / d) + 4; break;
+    if (event.target === swatch) {
+      hex.value = swatch.value;
+      // Only once the picker commits: it fires "input" throughout a drag,
+      // and Shiny's text binding sends "change" immediately.
+      if (event.type === "change") {
+        hex.dispatchEvent(new Event("change", { bubbles: true }));
       }
-      h *= 60;
+    } else if (event.target === hex) {
+      var expanded = expandHex(hex.value);
+      if (expanded) {
+        swatch.value = expanded;
+      }
     }
-    return { h: Math.round(h), s: Math.round(s * 100), l: Math.round(l * 100) };
-  }
-
-  function updatePreview(root) {
-    var hex = root.querySelector(".blockr-stack-menu-hex");
-    var sw = root.querySelector(".blockr-stack-menu-color-swatch");
-    if (!hex || !sw) return;
-    var v = (hex.value || "").trim();
-    if (/^#[0-9a-fA-F]{6}$/.test(v)) {
-      sw.style.background = v;
-    }
-  }
-
-  function colorFields(root) {
-    var hex = root.querySelector(".blockr-stack-menu-hex");
-    var hue = root.querySelector(".blockr-stack-menu-hue");
-    var lit = root.querySelector(".blockr-stack-menu-lightness");
-    return hex && hue && lit ? { hex: hex, hue: hue, lit: lit } : null;
-  }
-
-  function writeHexFromSliders(root) {
-    var f = colorFields(root);
-    if (!f) return;
-    f.hex.value = hslToHex(
-      parseInt(f.hue.value, 10), parseInt(f.lit.value, 10)
-    );
-    // "change" only: Shiny's text binding sends it immediately, and the
-    // delegated listener below watches "input", so writing the hex here
-    // cannot bounce back and fight the slider the user is dragging.
-    f.hex.dispatchEvent(new Event("change", { bubbles: true }));
-    updatePreview(root);
-  }
-
-  function moveSlidersToHex(root) {
-    var f = colorFields(root);
-    if (!f) return;
-    var parsed = hexToHsl((f.hex.value || "").trim());
-    if (parsed) {
-      f.hue.value = String(parsed.h);
-      f.lit.value = String(parsed.l);
-    }
-    updatePreview(root);
   }
 
   function initColorPicker(root) {
-    // Seed the slider positions and the swatch from the hex whenever the
-    // field is (re-)bound, which covers both the form's first arrival and
-    // every later re-render. Seeding is the same operation a typed hex
-    // triggers, so there is no second copy of it to keep in step.
-    $(root).on("shiny:bound", function (event) {
-      if (event.target.classList.contains("blockr-stack-menu-hex")) {
-        moveSlidersToHex(root);
-      }
-    });
-
-    root.addEventListener("input", function (event) {
-      var el = event.target;
-      if (!el || !el.classList) return;
-      if (el.classList.contains("blockr-stack-menu-hue") ||
-          el.classList.contains("blockr-stack-menu-lightness")) {
-        writeHexFromSliders(root);
-      } else if (el.classList.contains("blockr-stack-menu-hex")) {
-        moveSlidersToHex(root);
-      }
-    });
+    var handler = function (event) { syncColorFields(root, event); };
+    root.addEventListener("input", handler);
+    root.addEventListener("change", handler);
   }
 
   // Edit mode caps the cards container so exactly four cards are

--- a/tests/testthat/test-action-stack.R
+++ b/tests/testthat/test-action-stack.R
@@ -618,6 +618,96 @@ test_that("stack menu ui defers the form to a server-rendered slot", {
   expect_length(xml2::xml_find_all(doc, "//input[@id='mid-stack_name']"), 0L)
 })
 
+test_that("the colour field pairs a native picker with the bound hex input", {
+  doc <- xml2::read_html(
+    as.character(color_field_tag(NS("mid"), "#abc"))
+  )
+
+  hex <- xml2::xml_find_first(doc, "//input[@id='mid-stack_color']")
+  expect_identical(xml2::xml_attr(hex, "type"), "text")
+  expect_identical(xml2::xml_attr(hex, "value"), "#abc")
+
+  # The picker carries no id: `input$stack_color` stays the hex field, so
+  # the spec the menu commits is unchanged. It does need the expanded form
+  # of the same colour - `<input type="color">` cannot hold the shorthand.
+  swatch <- xml2::xml_find_first(doc, "//input[@type='color']")
+  expect_identical(xml2::xml_attr(swatch, "value"), "#aabbcc")
+  expect_identical(xml2::xml_attr(swatch, "id"), NA_character_)
+
+  expect_length(xml2::xml_find_all(doc, "//input[@type='range']"), 0L)
+})
+
+# The picker only reports through the hex field beside it, and `type="color"`
+# is not matched by Shiny's text-input binding, so the chain that carries a
+# picked colour to the server -- picker writes the hex field, the hex field's
+# "change" reaches the binding, the binding sends `stack_color` -- exists
+# nowhere but in the browser. A break there is silent: the form still renders
+# and still commits, just never the colour the user picked.
+test_that("a picked colour reaches the server through the hex field", {
+
+  skip_on_cran()
+
+  app <- new_app_driver(
+    system.file("examples", "sidebar-owner", "app.R", package = "blockr.dock"),
+    name = "stack-color",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 30 * 1000
+  )
+  withr::defer(app$stop())
+
+  app$wait_for_idle()
+  app$click("my_board-ext_fire-edit_stack")
+
+  swatch <- ".blockr-stack-menu-swatch"
+  wait_js(
+    app,
+    sprintf("document.querySelector('%s') !== null", swatch),
+    function() paste("sidebar html:", app$get_html("#my_board-actions_sidebar"))
+  )
+
+  doc <- xml2::read_html(
+    app$get_html("#my_board-edit_stack_action-menu-form")
+  )
+  field_value <- function(xpath) {
+    xml2::xml_attr(xml2::xml_find_first(doc, xpath), "value")
+  }
+
+  expect_identical(
+    field_value("//input[@type='color']"),
+    field_value("//input[contains(@id, 'stack_color')]")
+  )
+
+  # Black is the case the sliders could not express at all: saturation was
+  # pinned at 60% and lightness floored at 20.
+  app$run_js(
+    paste0(
+      "var sw = document.querySelector('", swatch, "');",
+      "sw.value = '#000000';",
+      "sw.dispatchEvent(new Event('input', {bubbles: true}));",
+      "sw.dispatchEvent(new Event('change', {bubbles: true}));"
+    )
+  )
+  app$wait_for_idle()
+
+  expect_identical(
+    app$get_value(input = "my_board-edit_stack_action-menu-stack_color"),
+    "#000000"
+  )
+
+  # And back the other way, so a pasted brand colour shows in the picker.
+  app$run_js(
+    "var hex = document.querySelector('.blockr-stack-menu-hex');
+     hex.value = '#abc';
+     hex.dispatchEvent(new Event('input', {bubbles: true}));"
+  )
+
+  expect_identical(
+    app$get_js(paste0("document.querySelector('", swatch, "').value")),
+    "#aabbcc"
+  )
+})
+
 test_that("remove stack action", {
   r_board <- reactiveValues(
     board = new_dock_board(

--- a/tests/testthat/test-utils-misc.R
+++ b/tests/testthat/test-utils-misc.R
@@ -36,3 +36,10 @@ test_that("suggest_new_colors falls back when colorspace is unavailable", {
     pkg_avail = function(...) FALSE
   )
 })
+
+test_that("expand_hex_color", {
+  expect_identical(expand_hex_color("#abc"), "#aabbcc")
+  expect_identical(expand_hex_color("#ABC"), "#AABBCC")
+  expect_identical(expand_hex_color("#66c2a5"), "#66c2a5")
+  expect_identical(expand_hex_color("#66c2a"), "#66c2a")
+})


### PR DESCRIPTION
## Summary

* The stack sidebar's colour field is now a native `<input type="color">` beside the hex text input, replacing the hue + lightness sliders and the preview swatch.

* The sliders could not express most colours. `hslToHex()` hard-coded saturation at 60% and the lightness slider was clamped to 20–85, so black, white, and anything muted or fully saturated were unreachable — and a hex typed from outside that slice was accepted by `validate_stack_spec()` but then silently rewritten by the next drag.

* The hex field stays the value carrier, so `input$stack_color`, `validate_stack_spec()` and the committed spec are unchanged. The colour input carries no id and no binding; both are rendered from the same value, so the `shiny:bound` seeding hook #394 needed is gone too.

* `expand_hex_color()` widens the 3-digit shorthand `is_hex_color()` accepts, which `<input type="color">` would otherwise render as black.

* Net -132 lines of picker code: the HSL conversion pair, the sync handlers and the gradient-track CSS with its `-webkit-`/`-moz-` thumb pseudo-elements are all gone.

* Covered by a markup test for the field's contract (id on the hex input, expanded value on the picker, no range inputs) and one thin e2e test for the seam no unit test sees — picker writes the hex field, its `change` reaches Shiny's text binding, `stack_color` arrives server-side as `#000000`, a colour the old picker could not produce.

Fixes #396