### PR TITLE
Retry the Chrome launch, and report why it failed

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -13,15 +13,101 @@ retry_download <- function(app, output, .attempts = 6L) {
   stop(res)
 }
 
+# Chrome's own account of why it never announced its debugging port. The
+# launcher writes the browser's stderr to a `tempdir()` scratch file and reads
+# it back only on the `!p$is_alive()` branch; the port-open timeout aborts
+# without ever touching it, so the one artifact that says what went wrong dies
+# with the R session. That is why the CI failure carries no reason. Recover it
+# by diffing the scratch dir across the attempt.
+#
+# The three outcomes separate the candidate causes. No `DevTools listening`
+# line at all means Chrome never got that far -- a cold first start, or a
+# debugging port it could not bind, which the head of the log names. That line
+# present but on another port is the launcher's `output_port != port` mismatch.
+# Present on the right port leaves the HTTP probe of `/json/protocol` as what
+# actually failed. Startup errors are written first, so report the head.
+chrome_stderr <- function(before, n = 20L) {
+
+  logs <- setdiff(
+    list.files(tempdir(), pattern = "^chrome-.*-stderr\\.log$",
+               full.names = TRUE),
+    before
+  )
+
+  if (!length(logs)) {
+    return("[e2e-chrome] no chrome stderr log for this attempt")
+  }
+
+  txt <- readLines(logs[[1L]], warn = FALSE)
+
+  if (!length(txt)) {
+    return("[e2e-chrome] chrome stderr is empty -- it announced nothing")
+  }
+
+  announced <- grep("^DevTools listening on ws://", txt, value = TRUE)
+
+  paste(
+    c(
+      sprintf("[e2e-chrome] chrome stderr (%d lines, first %d):", length(txt),
+              min(n, length(txt))),
+      head(txt, n),
+      if (length(announced)) {
+        paste("[e2e-chrome] announced:", announced)
+      } else {
+        "[e2e-chrome] no 'DevTools listening' line was ever written"
+      }
+    ),
+    collapse = "\n"
+  )
+}
+
+# The chromote package launches the shared browser lazily, inside the first
+# `default_chromote_object()`, and on a loaded runner (Windows especially)
+# Chrome can miss the `chromote.timeout` window for opening its debugging port
+# -- an `error_stop_port_search` abort raised before `AppDriver$new()` is
+# reached, so retrying the driver never sees it. Retry the launch instead. The
+# failure observed in CI was the run's first launch, with two later launches in
+# the same job succeeding, so a second attempt is what the evidence supports;
+# it also re-samples the random debugging port, which a longer timeout cannot.
+# Each failure reports Chrome's stderr, since which of those two it was is
+# still unestablished. A timed-out attempt leaves its process running
+# (`launch_chrome_impl()` aborts without killing it) and processx only reaps it
+# from the `cleanup = TRUE` finalizer, so collect between attempts rather than
+# leaking a browser -- and the `$TMPDIR` scratch it holds -- per retry.
+retry_chrome_launch <- function(attempts = 3L) {
+
+  pat <- "^chrome-.*-stderr\\.log$"
+
+  for (i in seq_len(attempts)) {
+
+    before <- list.files(tempdir(), pattern = pat, full.names = TRUE)
+    res <- tryCatch(chromote::default_chromote_object(), error = function(e) e)
+
+    if (!inherits(res, "error")) {
+      return(res)
+    }
+
+    message(
+      "[e2e-chrome] launch ", i, "/", attempts, " failed: ",
+      conditionMessage(res), "\n", chrome_stderr(before)
+    )
+
+    gc()
+    Sys.sleep(1)
+  }
+  stop(res)
+}
+
 # Every e2e AppDriver goes through here so the chromote command timeout is
 # hardened in one place. A loaded CI runner (Windows especially) can take longer
 # than chromote's 10s default to bind the app's port, so AppDriver's first
 # `Page.navigate` times out at init (rstudio/shinytest2#448). The chromote
 # session inherits its command timeout from the default chromote object, so
-# raise that before the session is spawned -- via `default_chromote_object()`,
-# the same object AppDriver draws its session from.
+# raise that before the session is spawned -- on the object
+# `retry_chrome_launch()` returns, the same one AppDriver draws its session
+# from.
 new_app_driver <- function(...) {
-  chrome <- chromote::default_chromote_object()
+  chrome <- retry_chrome_launch()
   chrome$default_timeout <- 60
   shinytest2::AppDriver$new(...)
 }

--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -3,8 +3,13 @@
 # Give Chrome longer to open its remote-debugging port. chromote's default is
 # 10s (`getOption("chromote.timeout", 10)` in launch_chrome_impl), too short on
 # loaded CI runners -- Windows especially -- where launch intermittently aborts
-# with "Chrome debugging port not open after 10 seconds".
-options(chromote.timeout = 30)
+# with "Chrome debugging port not open after 10 seconds". Scoped to the suite
+# so the option is restored when testing finishes. A launch that misses even
+# this window is retried by `retry_chrome_launch()`.
+withr::local_options(
+  chromote.timeout = 30,
+  .local_envir = teardown_env()
+)
 
 # Chrome leaves scratch dirs (com.google.Chrome.* / org.chromium.Chromium.*,
 # scoped_dir variants included) in the session temp parent (`$TMPDIR`), which
@@ -12,25 +17,44 @@ options(chromote.timeout = 30)
 # gate fails on. `app$stop()` only ends the shinytest2 session; the shared
 # browser stays alive until R exits, so its scratch is never reclaimed. At the
 # end of the suite, close the browser (a clean shutdown reclaims its scratch),
-# then sweep anything that still leaked -- but only what this run created, so a
-# shared `$TMPDIR` on a developer machine keeps its other dirs.
+# then sweep anything that still leaked.
+#
+# On CI the sweep is unconditional. Closing the browser waits for its main
+# process, but a Chrome helper (crashpad, zygote) can drop a fresh scratch dir
+# a moment later -- past a snapshot taken here -- so settle first, then remove
+# every match. An abandoned launch attempt leaves scratch behind too, which no
+# `$close()` reaches. A throwaway runner has no unrelated dirs to protect.
+# Locally, keep the conservative `setdiff(before)` so a shared `$TMPDIR`
+# retains its own.
 local({
 
   pat <- "^(com\\.google\\.Chrome|org\\.chromium\\.Chromium)"
   tmp_parent <- dirname(tempdir())
   before <- list.files(tmp_parent, pattern = pat)
+  on_ci <- nzchar(Sys.getenv("CI"))
 
   withr::defer(
     {
-      if (isTRUE(chromote::has_default_chromote_object())) {
+      had_browser <- isTRUE(chromote::has_default_chromote_object())
+
+      if (had_browser) {
         try(chromote::default_chromote_object()$close(), silent = TRUE)
       }
 
+      if (on_ci) {
+
+        if (had_browser) {
+          Sys.sleep(2)
+        }
+
+        leaked <- list.files(tmp_parent, pattern = pat)
+
+      } else {
+        leaked <- setdiff(list.files(tmp_parent, pattern = pat), before)
+      }
+
       unlink(
-        file.path(
-          tmp_parent,
-          setdiff(list.files(tmp_parent, pattern = pat), before)
-        ),
+        file.path(tmp_parent, leaked),
         recursive = TRUE,
         force = TRUE
       )


### PR DESCRIPTION
## What the artifact shows

Pulling `Windows-X64-rrelease-1-results` from the ejected run narrows this considerably.

The failure was the **first** Chrome launch of the job. In run order, `test-commit-sentinel.R` is the first e2e file, while `test-sidebar-server.R` and `test-utils-serve.R` come later, both launch Chrome, and both passed — the leg ended `[ FAIL 1 | WARN 0 | SKIP 0 | PASS 7743 ]`, so the only failure was that first launch. Chrome also stayed alive through the whole 30s, otherwise the launcher would have raised its `Failed to start chrome` error with the log dumped instead of the port-open timeout.

So Chrome works on that runner, and a launch a minute later worked. That is what makes a second attempt the evidence-backed move rather than a guess: the job already demonstrated the retry semantics accidentally, spread across test files. A retry also re-samples the random debugging port, which raising the timeout cannot do — and note the launcher raises `error_stop_port_search`, the class that tells `with_random_port()` to **stop** trying the other nine ports it sampled.

## What is still unknown, and why the artifact cannot say

Why that first launch missed the window is not established. The candidates are a cold first start on a runner where nothing installs or warms Chrome (the Windows leg has no Chrome setup step; chromote uses the image's preinstalled one), a debugging port Chrome could not bind, or the announcement not being readable in time.

The evidence that would settle it is discarded: the launcher writes Chrome's stderr to a `tempdir()` scratch file and reads it back **only** on the `!p$is_alive()` branch, so the port-open timeout aborts without ever touching it and the file dies with the R session. That is why the CI failure carries a backtrace but no reason.

So this recovers that log and reports it on every failed attempt, which splits the candidates:

| What the log shows | What it means |
| --- | --- |
| No `DevTools listening` line | Chrome never got there — the head of the log names a bind failure if that is the cause |
| The line, on another port | The launcher's `output_port != port` mismatch |
| The line, on the requested port | The HTTP probe of `/json/protocol` is what failed |

The next occurrence therefore diagnoses itself instead of ejecting a PR with nothing to go on. If it turns out to be the port, that is an upstream chromote bug worth filing — the launcher conflating "Chrome was slow" with "this port is unusable" is what disables its own port search — but that is a claim for after the log says so, not before.

## The rest

- The new `retry_chrome_launch()` wraps the launch, bounded at three attempts, called from the existing `new_app_driver()` funnel. The `chromote.timeout` option stays at 30; raising it is the move already made twice.
- A timed-out attempt leaves its Chrome running — the launcher aborts without killing it, and processx only reaps it from the `cleanup = TRUE` finalizer. Hence the `gc()` between attempts, measured: a failed launch leaves up to 6 processes descended from the R session, and `gc()` plus a settle takes that to 0, every round.
- The teardown picks up the two fixes blockr.core made after this file was copied from it: `chromote.timeout` restored when the suite finishes, and on CI a settle before sweeping every Chrome scratch dir rather than diffing against a snapshot a late arrival races — the mechanism this issue's second comment diagnosed. This package was the last in the stack on the old version.

## Verification

CI cannot exercise the failure path, so it was injected: a tracer on `chromote:::launch_chrome_impl` forces the first launch of a run to abort, and gives the second a workable timeout.

Against `main`, `test-commit-sentinel.R` under that injection reproduces the queue failure — same test, same line, same condition class, and a backtrace whose frames match the artifact's, with the abort at `helpers.R:24` inside `new_app_driver()` — ending `error: 1, passed: 1`. On this branch the same injection logs the failed attempt with Chrome's stderr, relaunches, and passes: `error: 0, passed: 5`.

The three reporting branches are covered directly (no log, empty log, log with content), including a synthetic `bind() failed` line to confirm a port failure would surface. Exhausting the attempt budget re-raises the original condition unchanged, so a genuinely broken Chrome still fails loudly.

Fixes #266
