### PR TITLE
Flag a stale block with a muted status badge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # blockr.dock (development version)
 
+* A block whose inputs changed while it was dormant now carries a muted
+  grey status badge instead of none. Core's sixth eval status, `stale`,
+  fell through `block_status_badge()` to "no badge", so a block holding
+  an out-of-date result looked identical to a healthy one on both the
+  dock card icon and the blockr.dag node. Error conditions still take
+  precedence, so a stale block that raised errors reads `failed` (#408).
+
 * New export `sidebar_owned_by()`, which reports whether a given action
   currently holds one of the board's sidebar panels -- `NULL` when it
   does not, otherwise the panel plus whether it is open and pinned. It

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,11 @@
   grey status badge instead of none. Core's sixth eval status, `stale`,
   fell through `block_status_badge()` to "no badge", so a block holding
   an out-of-date result looked identical to a healthy one on both the
-  dock card icon and the blockr.dag node. Error conditions still take
-  precedence, so a stale block that raised errors reads `failed` (#408).
+  dock card icon and the blockr.dag node. A stale block also drops the
+  red `failed` badge it would otherwise keep from error conditions
+  recorded before the change: those describe inputs it no longer has,
+  and it has not re-run since, so the upstream edit may equally have
+  fixed the failure as caused it (#408).
 
 * New export `sidebar_owned_by()`, which reports whether a given action
   currently holds one of the board's sidebar panels -- `NULL` when it

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -674,6 +674,10 @@ block_status_style <- function(status) {
 
   spec <- switch(
     status,
+    stale = list(
+      color = "#6b7280",
+      label = "Inputs changed since this block last ran"
+    ),
     waiting = list(color = "#f59e0b", label = "Waiting for a data input"),
     unset = list(color = "#eab308", label = "Set this block's inputs"),
     failed = list(color = "#dc2626", label = "Evaluation failed")
@@ -686,11 +690,11 @@ block_status_style <- function(status) {
   c(spec, list(size = 8L, ring = 2L, ring_color = "#ffffff"))
 }
 
-#' @param status A block eval status. `waiting`, `unset` and `failed` carry a
-#'   badge; `ready` carries none; `dormant` is indeterminate; any other value
-#'   yields no badge. `size` is the coloured dot's pixel diameter and `ring`
-#'   its white outline width, both shared so the dock card icon and the DAG
-#'   node badge render identically.
+#' @param status A block eval status: `stale`, `waiting`, `unset` and `failed`
+#'   carry a badge; `ready` carries none; `dormant` is indeterminate; any other
+#'   value yields no badge. The `size` field is the coloured dot's pixel
+#'   diameter and `ring` its white outline width, both shared so the dock card
+#'   icon and the DAG node badge render identically.
 #' @param error_count Number of error conditions the block has raised. A
 #'   positive count promotes the badge to `failed`, catching render-phase
 #'   errors that leave the eval status `ready`.

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -697,10 +697,18 @@ block_status_style <- function(status) {
 #'   icon and the DAG node badge render identically.
 #' @param error_count Number of error conditions the block has raised. A
 #'   positive count promotes the badge to `failed`, catching render-phase
-#'   errors that leave the eval status `ready`.
+#'   errors that leave the eval status `ready`. A `stale` block is exempt:
+#'   its conditions were raised against inputs it no longer has.
 #' @rdname meta
 #' @export
 block_status_badge <- function(status, error_count = 0L) {
+
+  # A stale block's conditions predate the upstream change that made it stale,
+  # and it has not re-run since, so they say nothing about whether it would
+  # still fail on its current inputs.
+  if (isTRUE(status == "stale")) {
+    return(block_status_style("stale"))
+  }
 
   if (error_count > 0L) {
     status <- "failed"

--- a/man/meta.Rd
+++ b/man/meta.Rd
@@ -36,7 +36,8 @@ icon and the DAG node badge render identically.}
 
 \item{error_count}{Number of error conditions the block has raised. A
 positive count promotes the badge to \code{failed}, catching render-phase
-errors that leave the eval status \code{ready}.}
+errors that leave the eval status \code{ready}. A \code{stale} block is exempt:
+its conditions were raised against inputs it no longer has.}
 }
 \value{
 Metadata is returned from \code{blks_metadata()} as a \code{data.frame} with

--- a/man/meta.Rd
+++ b/man/meta.Rd
@@ -28,11 +28,11 @@ block_status_badge(status, error_count = 0L)
 
 \item{mode}{Switch between URI and inline HTML mode}
 
-\item{status}{A block eval status. \code{waiting}, \code{unset} and \code{failed} carry a
-badge; \code{ready} carries none; \code{dormant} is indeterminate; any other value
-yields no badge. \code{size} is the coloured dot's pixel diameter and \code{ring}
-its white outline width, both shared so the dock card icon and the DAG
-node badge render identically.}
+\item{status}{A block eval status: \code{stale}, \code{waiting}, \code{unset} and \code{failed}
+carry a badge; \code{ready} carries none; \code{dormant} is indeterminate; any other
+value yields no badge. The \code{size} field is the coloured dot's pixel
+diameter and \code{ring} its white outline width, both shared so the dock card
+icon and the DAG node badge render identically.}
 
 \item{error_count}{Number of error conditions the block has raised. A
 positive count promotes the badge to \code{failed}, catching render-phase

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -351,6 +351,40 @@ test_that("block_status_badge is the shared badge derivation (#314)", {
   expect_identical(block_status_badge("dormant"), NA)
 })
 
+test_that("a stale block carries a muted badge (#408)", {
+
+  stale <- block_status_style("stale")
+
+  expect_identical(stale$color, "#6b7280")
+  expect_identical(stale$label, "Inputs changed since this block last ran")
+  expect_identical(stale$size, 8L)
+  expect_identical(stale$ring, 2L)
+  expect_identical(stale$ring_color, "#ffffff")
+
+  # The muted treatment is its own, not a reuse of an attention colour.
+  attention <- lapply(c("waiting", "unset", "failed"), block_status_style)
+  expect_false(stale$color %in% chr_xtr(attention, "color"))
+
+  # A stale block flags as out of date rather than falling through to "no
+  # badge", which is what made it indistinguishable from a healthy one.
+  expect_type(block_status_badge("stale"), "list")
+  expect_identical(block_status_badge("stale"), stale)
+  expect_match(
+    as.character(block_status_indicator("stale")),
+    "#6b7280",
+    fixed = TRUE
+  )
+
+  # Error conditions still win: a stale block that raised errors reads `failed`.
+  expect_identical(
+    block_status_badge("stale", 2L),
+    block_status_style("failed")
+  )
+
+  # The body keeps its last-known output, so no placeholder note replaces it.
+  expect_null(block_status_note("stale"))
+})
+
 test_that("block status indicator + note reflect eval status (#290)", {
 
   waiting_dot <- block_status_indicator("waiting")

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -375,9 +375,15 @@ test_that("a stale block carries a muted badge (#408)", {
     fixed = TRUE
   )
 
-  # Error conditions still win: a stale block that raised errors reads `failed`.
+  # Recorded errors do not survive the input change that made the block stale:
+  # they were raised against inputs it no longer has, and it has not re-run, so
+  # a red dot would assert a failure nobody has observed on the current inputs.
+  expect_identical(block_status_badge("stale", 2L), stale)
+
+  # A dormant block keeps its error badge -- nothing about its inputs changed,
+  # so the last-known failure still describes them.
   expect_identical(
-    block_status_badge("stale", 2L),
+    block_status_badge("dormant", 2L),
     block_status_style("failed")
   )
 


### PR DESCRIPTION
## Summary

- The `stale` arm added to `block_status_style()` returns a muted grey spec (`#6b7280`, the package's own `--blockr-grey-500`) labelled "Inputs changed since this block last ran", so `block_status_badge("stale", 0L)` yields a spec instead of `NULL`.
- Core's sixth status fell through the switch, and both consumers read `NULL` as "no badge" — `block_status_indicator()` returns `NULL` for a non-list spec, and blockr.dag's node renderer maps it to an empty badge list. A block holding an out-of-date result therefore rendered identically to a healthy one.
- Grey rather than a fourth warm colour keeps it distinct from the amber `waiting` and yellow `unset`, which ask the user to act; a stale block only reports that its cached result no longer reflects its inputs. Core's own status docs suggest a muted node badge.
- The second commit lets `stale` outrank the `error_count > 0L` promotion, so a block that failed and then went stale drops its red dot. The `dormant` arm still returns `NA`, and a dormant block with recorded errors still reads `failed`.

## Why stale outranks a recorded failure

A block's conditions survive dormancy, so a block that failed and then went stale carried `error_count > 0L`, which promoted the badge to `failed` before the status was ever consulted — it stayed red. Verified against a board with `s1 -> a -> r` where `r`'s expression raises, parking `r` and then re-routing `a` to a different source:

| `r` | eval status | error conds | badge |
|---|---|---|---|
| after first eval | `failed` | 1 | `#dc2626` |
| parked off-screen | `dormant` | 1 | `#dc2626` |
| upstream re-routed | `stale` | 1 | `#dc2626` → now `#6b7280` |

Those conditions were raised against inputs the block no longer has, and it does not re-run while dormant (`r re-evaluated: FALSE` in the probe), so every recorded error predates the input change. Red asserts a failure nobody has observed on the current inputs, when the upstream edit may as easily have fixed it as caused it. Grey — "out of date, we don't know" — is the honest badge, and no current information is lost.

A `dormant` block is the opposite case and keeps its red: nothing about its inputs changed, so its last-known failure still describes them.

One consequence worth naming: on a persistent renderer like the DAG node, a `stale` spec *replaces* the last-known badge, where `dormant`'s `NA` preserved it. That is the intended trade for the same reason — a computed "out of date" beats a badge derived from inputs that have since changed.

Fixes #408
