### PR TITLE
Absorb the add-block re-seed before staging the next block id

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -669,6 +669,42 @@ wait_gone <- function(app, id, timeout = 30 * 1000) {
   )
 }
 
+# A confirmed add re-seeds the id box with a fresh `rand_names()` suggestion
+# for the next block, and nothing orders that message against a following
+# `set_inputs()`: landing late it overwrites the id the test staged, so the
+# `confirm_add` after it reads the suggestion and the block arrives under a
+# random name -- a wrong-id board, not a slow one, so the panel wait that
+# follows can only time out. Exactly one re-seed is emitted per add and it
+# never repeats an id already on the board, so waiting for the field to leave
+# `added` absorbs it before the next add is staged. The binding applies the
+# value and queues its echo in one synchronous block, so a field that has moved
+# on has already sent it -- and a `set_inputs` issued afterwards is ordered
+# behind that echo.
+wait_reseeded <- function(app, added, timeout = 30 * 1000) {
+
+  target <- nsid("block_id")
+
+  diagnose <- function() {
+    sprintf(
+      "[wait_reseeded] id=%s added=%s value=%s",
+      target, added, field(app, "block_id")
+    )
+  }
+
+  wait_js(
+    app,
+    sprintf(
+      paste0(
+        "(function(){var e=document.getElementById('%s');",
+        "return e !== null && e.value !== '%s';})()"
+      ),
+      target, added
+    ),
+    diagnose,
+    timeout
+  )
+}
+
 set_color <- function(app, id, hex) {
   app$run_js(
     paste0(

--- a/tests/testthat/test-utils-serve.R
+++ b/tests/testthat/test-utils-serve.R
@@ -226,12 +226,16 @@ test_that("adding a second block keeps both block panels (#196)", {
 
   wait_bound(app, "registry_select")
 
+  # Each add leaves the extension's own re-seed of the id box in flight, which
+  # a later one would otherwise stage its id against; take it here so the
+  # helper hands back a field no pending message still writes to.
   add_block <- function(registry, id) {
     app$set_inputs(
       `my_board-ext_edit_board-registry_select` = registry,
       `my_board-ext_edit_board-block_id` = id
     )
     app$click("my_board-ext_edit_board-confirm_add")
+    wait_reseeded(app, id)
   }
 
   add_block("dataset_block", "a")


### PR DESCRIPTION
## Summary

- A confirmed add re-seeds the edit extension's id box with a fresh `rand_names()` suggestion for the next block (`R/ext-edit.R`), and nothing ordered that message against the next `set_inputs()`. The wait between the two adds gates on the dock mounting the first panel — a different settlement — so it can return with the re-seed still in flight.
- Landing after `block_id` has been set to `"b"`, the re-seed overwrites it and the `confirm_add` that follows reads the suggestion. That is a wrong-id board rather than a slow one, so the second panel wait can only run out its budget: the reported failure was `got=[block_panel-a,block_panel-fast_gemsbok]`.
- The new `wait_reseeded()` gate waits for the field to leave the id just added. Exactly one re-seed is emitted per add and it never repeats an id already on the board, so that consumes it before the next add is staged; the binding applies the value and queues its echo in one synchronous block, so a `set_inputs` issued afterwards is ordered behind that echo.
- Verified by holding the message at the client: released between `set_inputs` and the click it reproduces the reported failure verbatim, `fast_gemsbok` included; released 8s late with the gate in place it is absorbed and both blocks land under the requested ids; never delivered, it now fails on a `[wait_reseeded]` diagnostic rather than a wrong-id board.

Fixes #405
