### PR TITLE
Write block card status and title without an HTML output

### DIFF
--- a/R/board-ui.R
+++ b/R/board-ui.R
@@ -21,6 +21,7 @@ board_ui.dock_board <- function(
 
   tagList(
     show_block_dep(),
+    attr_output_dep(),
     blockr_dock_dep(),
     off_canvas(
       id = NS(id, "blocks_offcanvas"),

--- a/R/plugin-block.R
+++ b/R/plugin-block.R
@@ -14,7 +14,7 @@ edit_block_ui <- function(id, blk, blk_id, expr_ui, block_ui,
           title = blk_info$description,
           blk_icon_data_uri(blk_info$icon, blk_info$color, mode = "inline")
         ),
-        uiOutput(ns("status_indicator"), inline = TRUE)
+        block_status_dot(ns)
       ),
       div(
         class = paste(
@@ -80,7 +80,7 @@ block_card_title <- function(block, id, info) {
             ),
             ns("title_edit")
           ),
-          uiOutput(ns("block_name_out"), inline = TRUE),
+          tags$span(class = "blockr-title", block_name(block)),
           icon(
             "pen-to-square",
             class = "edit-icon",
@@ -102,7 +102,10 @@ block_card_title <- function(block, id, info) {
             label = NULL,
             value = block_name(block)
           ),
-          # JS to handle blur and enter key
+          # The displayed title mirrors this input, so it is kept in sync here
+          # rather than by a server-rendered output: `updateTextInput()` fires
+          # 'change', so a rename decided by the board lands the same way a
+          # keystroke does, with no render round-trip.
           tags$script(HTML(sprintf(
             "$(document).ready(function() {
               var input = $('#%s');
@@ -116,6 +119,9 @@ block_card_title <- function(block, id, info) {
                 if (e.key === 'Enter') {
                   $(this).blur();
                 }
+              });
+              input.on('input change', function() {
+                display.find('.blockr-title').text($(this).val());
               });
             });",
             input_id, ns("title_display"), ns("title_edit")
@@ -363,7 +369,7 @@ block_card_content <- function(ns, expr_ui, block_ui, ctrl_ui = NULL) {
     title = "Block output(s)",
     value = "outputs",
     block_ui,
-    uiOutput(ns("status_note")),
+    block_status_notes(ns),
     block_issues_ui(ns)
   )
 
@@ -457,13 +463,6 @@ edit_block_server <- function(callbacks = list()) {
           }
         )
 
-        output$block_name_out <- renderUI(
-          span(
-            input$block_name_in,
-            class = "blockr-title"
-          )
-        )
-
         blk_status <- reactive(reval_if(board$eval[[block_id]]))
 
         conds <- reactive(
@@ -473,12 +472,12 @@ edit_block_server <- function(callbacks = list()) {
           }
         )
 
-        output$status_indicator <- renderUI(
-          block_status_indicator(blk_status(), sum(lengths(conds()$error)))
+        output$status_indicator <- render_attrs(
+          block_status_dot_attrs(blk_status(), sum(lengths(conds()$error)))
         )
 
-        output$status_note <- renderUI(
-          block_status_note(blk_status())
+        output$status_note <- render_attrs(
+          block_status_note_attrs(blk_status())
         )
 
         observeEvent(
@@ -724,16 +723,22 @@ block_status_badge <- function(status, error_count = 0L) {
   block_status_style(status)
 }
 
-block_status_indicator <- function(status, error_count = 0L) {
+block_status_dot <- function(ns) {
+  tags$span(
+    id = ns("status_indicator"),
+    class = "blockr-status-dot blockr-attr-output"
+  )
+}
+
+block_status_dot_attrs <- function(status, error_count = 0L) {
 
   spec <- block_status_badge(status, error_count)
 
   if (!is.list(spec)) {
-    return(NULL)
+    return(list(style = "", title = "", role = "", `aria-label` = ""))
   }
 
-  tags$span(
-    class = "blockr-status-dot",
+  list(
     style = htmltools::css(
       width = paste0(spec$size, "px"),
       height = paste0(spec$size, "px"),
@@ -746,26 +751,51 @@ block_status_indicator <- function(status, error_count = 0L) {
   )
 }
 
+block_status_note_icons <- c(waiting = "diagram-3", unset = "sliders")
+
+block_status_notes <- function(ns) {
+  div(
+    id = ns("status_note"),
+    class = "blockr-status-note-slot blockr-attr-output",
+    lapply(names(block_status_note_icons), block_status_note)
+  )
+}
+
+block_status_note_attrs <- function(status) {
+  list(
+    `data-status` = if (is_string(status)) status else ""
+  )
+}
+
 block_status_note <- function(status) {
 
-  if (!is_string(status)) {
-    return(NULL)
-  }
-
-  icon <- switch(
-    status,
-    waiting = "diagram-3",
-    unset = "sliders"
-  )
-
-  if (is.null(icon)) {
+  if (!is_string(status) || !status %in% names(block_status_note_icons)) {
     return(NULL)
   }
 
   div(
     class = "blockr-status-note",
-    bsicons::bs_icon(icon, class = "blockr-status-note-icon"),
+    `data-status` = status,
+    bsicons::bs_icon(
+      block_status_note_icons[[status]],
+      class = "blockr-status-note-icon"
+    ),
     tags$span(block_status_style(status)$label)
+  )
+}
+
+render_attrs <- function(expr, env = parent.frame(), quoted = FALSE) {
+  createRenderFunction(
+    installExprFunction(expr, "func", env, quoted)
+  )
+}
+
+attr_output_dep <- function() {
+  htmltools::htmlDependency(
+    "blockr-attr-output",
+    pkg_version(),
+    src = pkg_file("assets", "js"),
+    script = "attr-output.js"
   )
 }
 

--- a/inst/assets/css/blockr-dock.css
+++ b/inst/assets/css/blockr-dock.css
@@ -198,17 +198,17 @@
   transform: rotate(180deg);
 }
 
-/* Block eval status: on-icon status dot + empty-output placeholder.
+/* Block eval status: on-icon status dot.
    The dot is layered onto the block icon's lower-right corner (iOS badge
    style), matching blockr.dag's node badge placement. Its size and colour are
-   set inline from `block_status_style()` -- the source of truth both
-   front-ends share -- so only structure lives here. `size` is the coloured
-   dot's diameter; the 2px white ring is drawn *outside* it (box-shadow, not a
-   border) so the dot matches the DAG node badge, which rings its fill the same
-   way. The dot output must stay in flow when empty (never display:none) so it
-   is not suspended while hidden and left stuck ".recalculating", which would
-   trip the navbar busy-spinner scope; an empty inline output takes no space on
-   its own. */
+   written onto this element as a `style` attribute from `block_status_style()`
+   -- the source of truth both front-ends share -- so only structure lives
+   here. `size` is the coloured dot's diameter; the 2px white ring is drawn
+   *outside* it (box-shadow, not a border) so the dot matches the DAG node
+   badge, which rings its fill the same way. The dot must stay in flow when it
+   carries no status (never display:none) so it is not suspended while hidden
+   and left stuck ".recalculating", which would trip the navbar busy-spinner
+   scope; with no size written it takes no space on its own. */
 .blockr-block-icon {
   position: relative;
   display: inline-flex;
@@ -223,13 +223,21 @@
   border-radius: 50%;
 }
 
+/* Both notes are built into every card and the active one is revealed by the
+   slot's `data-status`, so a status change writes one attribute instead of
+   sending markup through an HTML output. */
 .blockr-status-note {
-  display: flex;
+  display: none;
   align-items: center;
   gap: 8px;
   padding: 16px;
   color: var(--blockr-color-text-muted);
   font-size: var(--blockr-font-size-base);
+}
+
+.blockr-status-note-slot[data-status="waiting"] > [data-status="waiting"],
+.blockr-status-note-slot[data-status="unset"] > [data-status="unset"] {
+  display: flex;
 }
 
 .blockr-status-note-icon {

--- a/inst/assets/js/attr-output.js
+++ b/inst/assets/js/attr-output.js
@@ -1,0 +1,31 @@
+$(function () {
+  // An output whose value is a set of attributes to stamp onto its own
+  // element. Shiny's HTML output path (`renderContent`) unbinds, initializes
+  // and re-binds the rendered scope, and the unbind and the bind each book a
+  // clientdata walk of every bound output on the page -- so a card that only
+  // needs a `style` or a `data-status` written pays for two of those. Writing
+  // the attributes directly costs nothing beyond the write, while the element
+  // stays a real Shiny output: it suspends while hidden and re-renders when a
+  // deferred card is inserted, which a custom message would not.
+  var attrOutput = new Shiny.OutputBinding();
+
+  $.extend(attrOutput, {
+    find: function (scope) {
+      return $(scope).find('.blockr-attr-output');
+    },
+
+    // An empty value clears the attribute rather than writing an empty one,
+    // so the "no status" state leaves the element as bare as it was built.
+    renderValue: function (el, attrs) {
+      $.each(attrs || {}, function (name, value) {
+        if (value === null || value === '') {
+          el.removeAttribute(name);
+        } else {
+          el.setAttribute(name, value);
+        }
+      });
+    }
+  });
+
+  Shiny.outputBindings.register(attrOutput, 'blockr.dock.attrOutput');
+});

--- a/inst/examples/block-status/app.R
+++ b/inst/examples/block-status/app.R
@@ -1,0 +1,27 @@
+library(blockr.core)
+library(blockr.dock)
+
+# Two blocks in separate groups so both cards render: `a` evaluates and carries
+# no status affordance, while `b` has no data input and settles on `waiting` --
+# the one status that draws both a status dot and a status note. Tabbed panels
+# would leave the background one `dormant`, which draws neither, so the grid
+# splits them. The second view holds a third waiting block, whose card is built
+# only on first visit -- the deferred case a card's status has to survive.
+serve(
+  new_dock_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_head_block(),
+      c = new_head_block()
+    ),
+    views = list(
+      main = dock_view(c("a", "b"), name = "Main"),
+      later = dock_view("c", name = "Later")
+    ),
+    grids = list(
+      main = dock_grid("block_panel-a", "block_panel-b", sizes = c(0.5, 0.5))
+    ),
+    active = "main"
+  ),
+  "my_board"
+)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -686,3 +686,11 @@ field <- function(app, id) {
     )
   )
 }
+
+# An xpath predicate matching one class token exactly. The xml2 package has no
+# CSS selector, and a bare `contains(@class, 'x')` would also match a class
+# that merely starts with the token (`blockr-view-item` inside
+# `blockr-view-item-name`), so pad both sides and match the padded token.
+has_class <- function(token) {
+  sprintf("contains(concat(' ', normalize-space(@class), ' '), ' %s ')", token)
+}

--- a/tests/testthat/test-board-ui.R
+++ b/tests/testthat/test-board-ui.R
@@ -6,9 +6,9 @@ test_that("dummy board ui test", {
   )
 
   expect_s3_class(ui, "shiny.tag.list")
-  # 8 base elements + the two pre-rendered block-browser sidebars
+  # 9 base elements + the two pre-rendered block-browser sidebars
   # (add_block_sidebar, append_block_sidebar).
-  expect_length(ui, 10L)
+  expect_length(ui, 11L)
 })
 
 # Settings sidebar is mounted with pre-rendered content + a JS-trigger gear

--- a/tests/testthat/test-plugin-block.R
+++ b/tests/testthat/test-plugin-block.R
@@ -241,13 +241,6 @@ test_that("locked dock keeps block_card_toggles hidden (#122)", {
 
 test_that("block card sections carry the css-styling contract (#214)", {
 
-  has_class <- function(token) {
-    sprintf(
-      "contains(concat(' ', normalize-space(@class), ' '), ' %s ')",
-      token
-    )
-  }
-
   card <- block_card_content(
     NS("blk"),
     expr_ui = div(id = "blk-expr"),
@@ -285,6 +278,209 @@ test_that("block card sections carry the css-styling contract (#214)", {
   )
   expect_true(is.na(xml2::xml_attr(header, "style")))
   expect_true(is.na(xml2::xml_attr(body, "style")))
+})
+
+test_that("block card carries no html output (#403)", {
+
+  blk <- new_dataset_block()
+
+  card <- edit_block_ui(
+    "blk",
+    blk,
+    "a",
+    expr_ui = div(id = "blk-expr"),
+    block_ui = div(id = "blk-out")
+  )
+
+  root <- xml2::read_html(as.character(htmltools::tagList(card)))
+
+  # Each html output value costs a rebind of its scope plus two whole-page
+  # clientdata walks, and the card's status dot, status note and title were
+  # three of them per card. All three are written in place instead.
+  expect_length(
+    xml2::xml_find_all(
+      root,
+      paste0("//*[", has_class("shiny-html-output"), "]")
+    ),
+    0L
+  )
+
+  dot <- xml2::xml_find_all(
+    root,
+    paste0(
+      "//span[", has_class("blockr-status-dot"),
+      " and ", has_class("blockr-attr-output"), "]"
+    )
+  )
+  expect_length(dot, 1L)
+  expect_identical(xml2::xml_attr(dot, "id"), "blk-status_indicator")
+
+  slot <- xml2::xml_find_all(
+    root,
+    paste0(
+      "//div[", has_class("blockr-status-note-slot"),
+      " and ", has_class("blockr-attr-output"), "]"
+    )
+  )
+  expect_length(slot, 1L)
+  expect_identical(xml2::xml_attr(slot, "id"), "blk-status_note")
+
+  # Both notes ship with the card and the stylesheet reveals the one the slot's
+  # data-status names, so a status change writes an attribute rather than
+  # sending markup.
+  notes <- xml2::xml_find_all(
+    slot,
+    paste0("./div[", has_class("blockr-status-note"), "]")
+  )
+  expect_setequal(xml2::xml_attr(notes, "data-status"), c("waiting", "unset"))
+
+  # The title is seeded from the block and kept in sync client-side off the
+  # rename input, so it needs no output of its own.
+  title <- xml2::xml_find_all(
+    root,
+    paste0("//span[", has_class("blockr-title"), "]")
+  )
+  expect_length(title, 1L)
+  expect_identical(xml2::xml_text(title), block_name(blk))
+})
+
+test_that("card status and title land in the browser (e2e, #403)", {
+
+  skip_on_cran()
+
+  # The fixture renders both cards, with `b` waiting on a data input it has no
+  # link for and `a` evaluating.
+  app <- new_app_driver(
+    system.file("examples", "block-status", "app.R", package = "blockr.dock"),
+    name = "card-status",
+    seed = 42,
+    load_timeout = 30 * 1000,
+    timeout = 30 * 1000
+  )
+  withr::defer(app$stop())
+
+  wait_dock_loaded(app, 2)
+
+  el <- function(blk, part) {
+    sprintf("my_board-block_%s-edit_block-%s", blk, part)
+  }
+
+  attr_js <- function(id, name) {
+    sprintf("document.getElementById('%s').getAttribute('%s')", id, name)
+  }
+
+  read <- function(js) coal(app$get_js(js), "<null>", fail_all = FALSE)
+
+  diagnose <- function() {
+    sprintf(
+      "[card-status] b dot style=%s note=%s title=%s",
+      read(attr_js(el("b", "status_indicator"), "style")),
+      read(attr_js(el("b", "status_note"), "data-status")),
+      read(
+        sprintf(
+          "document.querySelector('#%s .blockr-title').textContent",
+          el("a", "title_display")
+        )
+      )
+    )
+  }
+
+  # The binding writes the shared spec straight onto the dot, so the colour and
+  # the tooltip arrive without any markup travelling.
+  wait_js(
+    app,
+    paste0(attr_js(el("b", "status_indicator"), "style"), " !== null"),
+    diagnose
+  )
+
+  expect_match(
+    app$get_js(attr_js(el("b", "status_indicator"), "style")),
+    "#f59e0b",
+    fixed = TRUE
+  )
+  expect_identical(
+    app$get_js(attr_js(el("b", "status_indicator"), "title")),
+    "Waiting for a data input"
+  )
+
+  # An evaluated block clears the attributes rather than keeping a stale spec.
+  # Its note slot naming `ready` is what says the value landed at all, so the
+  # bare dot below is a cleared one and not an unrendered one.
+  wait_js(
+    app,
+    paste0(attr_js(el("a", "status_note"), "data-status"), " === 'ready'"),
+    diagnose
+  )
+  expect_null(app$get_js(attr_js(el("a", "status_indicator"), "style")))
+  expect_null(app$get_js(attr_js(el("a", "status_indicator"), "title")))
+
+  # Both notes ship with the card and the stylesheet reveals exactly the one
+  # the slot's data-status names.
+  expect_identical(
+    app$get_js(attr_js(el("b", "status_note"), "data-status")),
+    "waiting"
+  )
+  expect_identical(
+    app$get_js(
+      sprintf(
+        paste0(
+          "Array.from(document.querySelectorAll('#%s > .blockr-status-note'))",
+          ".filter((n) => getComputedStyle(n).display !== 'none')",
+          ".map((n) => n.dataset.status).join(',')"
+        ),
+        el("b", "status_note")
+      )
+    ),
+    "waiting"
+  )
+
+  # A card built only on first visit still ends up with its status. These stay
+  # Shiny outputs precisely for that: they suspend while off screen and render
+  # when the card is inserted, where a custom message sent before the insert
+  # would simply be dropped.
+  expect_false(
+    app$get_js(
+      sprintf(
+        "document.getElementById('%s') !== null",
+        el("c", "status_indicator")
+      )
+    )
+  )
+
+  app$run_js(
+    paste0(
+      "document.querySelector('#my_board-view_nav ",
+      ".blockr-view-item[data-view-id=\"later\"]').click()"
+    )
+  )
+
+  wait_js(
+    app,
+    sprintf(
+      paste(
+        "document.getElementById('%s') !== null &&",
+        "%s === 'Waiting for a data input'"
+      ),
+      el("c", "status_indicator"),
+      attr_js(el("c", "status_indicator"), "title")
+    ),
+    diagnose
+  )
+
+  # Renaming drives the displayed title from the rename input itself, so no
+  # output sits between the two.
+  title_js <- sprintf(
+    "document.querySelector('#%s .blockr-title').textContent",
+    el("a", "title_display")
+  )
+  expect_identical(app$get_js(title_js), "Dataset")
+
+  do.call(
+    app$set_inputs,
+    set_names(list("Renamed"), el("a", "block_name_in"))
+  )
+
+  wait_js(app, paste0(title_js, " === 'Renamed'"), diagnose)
 })
 
 test_that("block_cond_buckets drops status-phase rows from warnings (#290)", {
@@ -369,11 +565,7 @@ test_that("a stale block carries a muted badge (#408)", {
   # badge", which is what made it indistinguishable from a healthy one.
   expect_type(block_status_badge("stale"), "list")
   expect_identical(block_status_badge("stale"), stale)
-  expect_match(
-    as.character(block_status_indicator("stale")),
-    "#6b7280",
-    fixed = TRUE
-  )
+  expect_match(block_status_dot_attrs("stale")$style, "#6b7280", fixed = TRUE)
 
   # Recorded errors do not survive the input change that made the block stale:
   # they were raised against inputs it no longer has, and it has not re-run, so
@@ -393,33 +585,24 @@ test_that("a stale block carries a muted badge (#408)", {
 
 test_that("block status indicator + note reflect eval status (#290)", {
 
-  waiting_dot <- block_status_indicator("waiting")
-  expect_s3_class(waiting_dot, "shiny.tag")
-  expect_match(as.character(waiting_dot), "blockr-status-dot", fixed = TRUE)
-  expect_match(as.character(waiting_dot), "#f59e0b", fixed = TRUE)
-  expect_match(as.character(waiting_dot), "Waiting for a data input")
-  # The white ring is carried inline from the shared spec, not the CSS.
-  expect_match(as.character(waiting_dot), "0 0 0 2px #ffffff", fixed = TRUE)
+  waiting_dot <- block_status_dot_attrs("waiting")
+  expect_match(waiting_dot$style, "#f59e0b", fixed = TRUE)
+  expect_identical(waiting_dot$title, "Waiting for a data input")
+  expect_identical(waiting_dot[["aria-label"]], "Waiting for a data input")
+  # The white ring is carried in the written style from the shared spec, not
+  # the CSS.
+  expect_match(waiting_dot$style, "0 0 0 2px #ffffff", fixed = TRUE)
 
   # An error condition reddens the dot even when the eval status is `ready`,
   # matching the DAG node badge.
   expect_match(
-    as.character(block_status_indicator("ready", 2L)),
+    block_status_dot_attrs("ready", 2L)$style,
     "#dc2626",
     fixed = TRUE
   )
-  expect_null(block_status_indicator("ready"))
 
-  expect_match(
-    as.character(block_status_indicator("unset")),
-    "#eab308",
-    fixed = TRUE
-  )
-  expect_match(
-    as.character(block_status_indicator("failed")),
-    "#dc2626",
-    fixed = TRUE
-  )
+  expect_match(block_status_dot_attrs("unset")$style, "#eab308", fixed = TRUE)
+  expect_match(block_status_dot_attrs("failed")$style, "#dc2626", fixed = TRUE)
 
   expect_match(
     as.character(block_status_note("waiting")),
@@ -434,11 +617,23 @@ test_that("block status indicator + note reflect eval status (#290)", {
   # `failed` keeps the error styling, so no placeholder note.
   expect_null(block_status_note("failed"))
 
-  # `ready`, `dormant` and an absent status carry no affordance.
+  # A `ready` or `dormant` block, and an absent status, carry no affordance:
+  # the dot's attributes are all cleared rather than left stale from the last
+  # status.
+  blank <- list(style = "", title = "", role = "", `aria-label` = "")
+
   for (st in list("ready", "dormant", NULL, character(), c("a", "b"))) {
-    expect_null(block_status_indicator(st))
+    expect_identical(block_status_dot_attrs(st), blank)
     expect_null(block_status_note(st))
   }
+
+  # The slot keys on the raw status and the stylesheet reveals a note only for
+  # the two that have one, so a status without a note matches nothing.
+  expect_identical(
+    block_status_note_attrs("ready"),
+    list(`data-status` = "ready")
+  )
+  expect_identical(block_status_note_attrs(NULL), list(`data-status` = ""))
 })
 
 test_that("edit block server surfaces eval status reactively (#290)", {
@@ -460,33 +655,31 @@ test_that("edit block server surfaces eval status reactively (#290)", {
   testServer(
     edit_block_server(),
     {
-      html <- function(out) paste0(as.character(out$html), collapse = "")
-
       session$flushReact()
 
       expect_identical(blk_status(), "waiting")
-      expect_match(html(output$status_indicator), "#f59e0b", fixed = TRUE)
-      expect_match(html(output$status_note), "Waiting for a data input")
+      expect_match(output$status_indicator$style, "#f59e0b", fixed = TRUE)
+      expect_identical(output$status_note, list(`data-status` = "waiting"))
 
       status("failed")
       session$flushReact()
 
-      # `failed` shows the dot but leaves the note empty -- the raised error
+      # A `failed` block shows the dot but reveals no note -- the raised error
       # uses the error styling instead of a status placeholder.
       expect_identical(blk_status(), "failed")
-      expect_match(html(output$status_indicator), "#dc2626", fixed = TRUE)
-      expect_identical(html(output$status_note), "")
+      expect_match(output$status_indicator$style, "#dc2626", fixed = TRUE)
+      expect_identical(output$status_note, list(`data-status` = "failed"))
 
       status("ready")
       session$flushReact()
 
       # A ready block with no conditions carries no status affordance at all.
       expect_identical(blk_status(), "ready")
-      expect_identical(html(output$status_indicator), "")
-      expect_identical(html(output$status_note), "")
+      expect_identical(output$status_indicator$style, "")
+      expect_identical(output$status_indicator$title, "")
 
       # A render-phase error leaves the eval status `ready` but still reddens
-      # the dot, matching the DAG node badge (the note stays empty).
+      # the dot, matching the DAG node badge (the note stays hidden).
       block_conds(
         data.frame(
           block = "a", phase = "render", severity = "error",
@@ -496,8 +689,8 @@ test_that("edit block server surfaces eval status reactively (#290)", {
       session$flushReact()
 
       expect_identical(blk_status(), "ready")
-      expect_match(html(output$status_indicator), "#dc2626", fixed = TRUE)
-      expect_identical(html(output$status_note), "")
+      expect_match(output$status_indicator$style, "#dc2626", fixed = TRUE)
+      expect_identical(output$status_note, list(`data-status` = "ready"))
     },
     args = list(
       block_id = "a",


### PR DESCRIPTION
## Summary

- Each of the block card's three `uiOutput`s put its value through `renderContent()`, which unbinds, initializes and re-binds the rendered scope — and the unbind and the bind each book a clientdata walk of every bound output on the page. None of the three markup fragments contains an input or an output for that rebind to find.
- The status dot is now a static span whose `style`, `title`, `role` and `aria-label` a small `blockr.dock.attrOutput` binding writes in place. The spec still comes from `block_status_style()` rather than moving into the stylesheet: that function is the source of truth the dock card and the blockr.dag node badge share, as the comment above the dot's rule in `blockr-dock.css` already states, and splitting the palette across R and CSS would let the two front-ends drift.
- Both status notes now ship with the card and the slot's `data-status` reveals the matching one from the stylesheet, so a status change sends a status string rather than markup. The title is seeded from the block and synced client-side off the rename input — `updateTextInput()` fires `change`, so a rename decided by the board lands the same way a keystroke does — and needs no output at all.
- These two stay Shiny **outputs** rather than becoming custom messages because cards are inserted lazily (`build_block_ui`). An output with no element on the client counts as hidden, so it suspends and re-renders when the card is inserted; a custom message sent before that insert is simply dropped. The e2e test pins this by asserting a deferred view's card picks up its full status on first visit.

Measured on a board of 8 blocks plus the edit-board extension, wrapping the three entry points at page load and reading the counters after settle. Identical across three runs on each side:

| | `main` (2a8f17d) | this branch |
| --- | --- | --- |
| `Shiny.bindAll` | 28 | 4 |
| `Shiny.unbindAll` | 31 | 7 |
| `Shiny.initializeInputs` | 26 | 2 |
| `.shiny-html-output` elements on the page | 25 | 1 |

The 85 entry-point calls on `main` match the count #403 reported for a comparable board.

Fixes #403
