### PR TITLE
Serialize extension state instead of dropping it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.dock (development version)
 
+* Extension state now reaches the saved board. Every extension serialized
+  an empty payload while still writing its object and constructor, so a
+  save looked complete yet carried none of its extensions' state and a
+  restore rebuilt each extension from constructor defaults. An outline
+  came back with no annotations, so every block fell to the
+  `report = TRUE` default -- a board saved with one block in the report
+  came back with all of them in -- and a hand-arranged dag lost its node
+  positions (#386).
+
 * The stack sidebar picks a colour with a native `<input type="color">`
   beside the hex field, in place of the hand-rolled hue / lightness
   sliders. The sliders reached only a fixed-saturation slice of the colour

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -32,8 +32,10 @@ serialize_board.dock_board <- function(x, blocks, id = NULL, dock,
         board_id = id,
         blocks = Map(c, state, visible = lapply(visibility, list)),
         options = opts,
+        # Extension results ride under one `extensions` plugin arg, beside
+        # siblings such as `actions`, so `...` sits a level above them.
         extensions = lapply(
-          list(...),
+          list(...)[["extensions"]],
           function(x) lapply(x[["state"]], reval_if)
         )
       )

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -285,3 +285,111 @@ test_that("layout_panel_ids and panel_obj_ids are inverse-ish", {
   expect_setequal(pids, c("block_panel-a", "block_panel-b"))
   expect_setequal(panel_obj_ids(pids), c("a", "b"))
 })
+
+probe_ext <- function(report = TRUE, title = "Untitled", ...) {
+  new_dock_extension(
+    server = function(id, ...) function(input, output, session) list(),
+    ui = function(id) tagList(),
+    name = "Outline",
+    class = "probe_extension",
+    report = report,
+    title = title,
+    ...
+  )
+}
+
+probe_ext_board <- function() {
+  new_dock_board(
+    blocks = c(a = new_dataset_block()),
+    extensions = list(outline = probe_ext())
+  )
+}
+
+ser_dock_board <- function(board, ...) {
+  serialize_board(
+    board,
+    blocks = list(),
+    id = NULL,
+    dock = NULL,
+    view_data = NULL,
+    ...,
+    session = NULL
+  )
+}
+
+ext_payload <- function(ser, name) {
+  ser[["payload"]][["extensions"]][["payload"]][[name]][["payload"]]
+}
+
+test_that("extension state reaches the serialized board", {
+
+  ser <- ser_dock_board(
+    probe_ext_board(),
+    actions = list(),
+    extensions = list(
+      outline = list(state = list(report = FALSE, title = "Q3"))
+    )
+  )
+
+  expect_identical(
+    ext_payload(ser, "outline"),
+    list(report = FALSE, title = "Q3")
+  )
+})
+
+test_that("sibling plugin arguments are not walked as extensions", {
+
+  ser <- ser_dock_board(
+    probe_ext_board(),
+    actions = list(state = list(title = "not an extension")),
+    extensions = list(outline = list(state = list(title = "mine")))
+  )
+
+  expect_identical(ext_payload(ser, "outline"), list(title = "mine"))
+  expect_null(ser[["payload"]][["extensions"]][["payload"]][["actions"]])
+})
+
+test_that("reactive extension state is evaluated on serialization", {
+
+  isolate({
+    ser <- ser_dock_board(
+      probe_ext_board(),
+      actions = list(),
+      extensions = list(
+        outline = list(state = list(title = reactiveVal("live")))
+      )
+    )
+    expect_identical(ext_payload(ser, "outline"), list(title = "live"))
+  })
+})
+
+test_that("extension state round-trips back into a restored extension", {
+
+  ser <- ser_dock_board(
+    probe_ext_board(),
+    actions = list(),
+    extensions = list(
+      outline = list(state = list(report = FALSE, title = "Q3"))
+    )
+  )
+
+  des <- blockr_deser(ser[["payload"]][["extensions"]])
+
+  expect_s3_class(des[["outline"]], "probe_extension")
+  expect_false(des[["outline"]][["report"]])
+  expect_identical(des[["outline"]][["title"]], "Q3")
+})
+
+test_that("a stateless extension still serializes its constructor", {
+
+  brd <- probe_ext_board()
+
+  expect_ctor_only <- function(ser) {
+    node <- ser[["payload"]][["extensions"]][["payload"]][["outline"]]
+    expect_length(node[["payload"]], 0L)
+    expect_false(is.null(node[["constructor"]]))
+  }
+
+  expect_ctor_only(ser_dock_board(brd, actions = list(), extensions = list()))
+  expect_ctor_only(ser_dock_board(brd, actions = list()))
+})


### PR DESCRIPTION
## Summary

- Walk `list(...)[["extensions"]]` in `serialize_board.dock_board()`. Extension results arrive as one named plugin argument holding all of them — `board_server` returns `extensions = ext_res` and core flattens that into the plugin args by a single level, so `...` carries `actions` and `extensions`, not `dag` and `outline`. Mapping over `list(...)` walked a level too high, so every `x[["state"]]` was `NULL`.
- Each extension therefore wrote an empty payload while still writing its object and constructor: a saved board looked complete and carried none of its extensions' state, with nothing surfaced to the user.
- Restores rebuilt each extension from constructor defaults. The outline came back with no annotations, so every block fell to the `report = TRUE` default — a board saved with one block in the report came back with all of them in — and descriptions, title, block order and heading levels were gone. The dag lost its node positions, so hand-arranged layouts never survived a save.
- Four regression tests in `test-utils-serdes.R`, all failing against the unfixed code. One pins the cause: `actions` sits in the same `...` and must not be walked as though it were an extension. Another covers the restore side, where the payload feeds the constructor.

Fixes #386
