### PR TITLE
Redirect Chrome's TMPDIR instead of sweeping its scratch dirs

### DIFF
--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -12,52 +12,35 @@ withr::local_options(
 )
 
 # Chrome leaves scratch dirs (com.google.Chrome.* / org.chromium.Chromium.*,
-# scoped_dir variants included) in the session temp parent (`$TMPDIR`), which
-# R CMD check then flags as "detritus in the temp directory" -- a NOTE the CI
-# gate fails on. `app$stop()` only ends the shinytest2 session; the shared
-# browser stays alive until R exits, so its scratch is never reclaimed. At the
-# end of the suite, close the browser (a clean shutdown reclaims its scratch),
-# then sweep anything that still leaked.
+# scoped_dir variants included) wherever `$TMPDIR` pointed when it was spawned,
+# and R CMD check flags leftovers in the temp directory it hands to subprocesses
+# as "detritus in the temp directory" -- a NOTE the CI gate fails on. Sweeping
+# those dirs at the end of the suite races a Chrome helper (crashpad, zygote)
+# dropping a fresh one afterwards, and never reaches an abandoned launch
+# attempt's scratch at all.
 #
-# On CI the sweep is unconditional. Closing the browser waits for its main
-# process, but a Chrome helper (crashpad, zygote) can drop a fresh scratch dir
-# a moment later -- past a snapshot taken here -- so settle first, then remove
-# every match. An abandoned launch attempt leaves scratch behind too, which no
-# `$close()` reaches. A throwaway runner has no unrelated dirs to protect.
-# Locally, keep the conservative `setdiff(before)` so a shared `$TMPDIR`
-# retains its own.
+# Keep them out of the inspected directory instead. Chrome reads `TMPDIR` at
+# spawn while R fixes `tempdir()` at startup, so pointing it at a suite-owned
+# directory below the session temp dir puts the scratch one level down from
+# what check lists -- it looks at that top level only, and skips the `Rtmp*`
+# directory holding this one.
 local({
 
-  pat <- "^(com\\.google\\.Chrome|org\\.chromium\\.Chromium)"
-  tmp_parent <- dirname(tempdir())
-  before <- list.files(tmp_parent, pattern = pat)
-  on_ci <- nzchar(Sys.getenv("CI"))
+  chrome_tmp <- withr::local_tempdir(
+    "chrome",
+    .local_envir = teardown_env()
+  )
 
+  withr::local_envvar(
+    TMPDIR = chrome_tmp,
+    .local_envir = teardown_env()
+  )
+
+  # Close the browser so it does not outlive the suite: `app$stop()` only ends
+  # the shinytest2 session, leaving the shared browser to R's exit.
   withr::defer(
-    {
-      had_browser <- isTRUE(chromote::has_default_chromote_object())
-
-      if (had_browser) {
-        try(chromote::default_chromote_object()$close(), silent = TRUE)
-      }
-
-      if (on_ci) {
-
-        if (had_browser) {
-          Sys.sleep(2)
-        }
-
-        leaked <- list.files(tmp_parent, pattern = pat)
-
-      } else {
-        leaked <- setdiff(list.files(tmp_parent, pattern = pat), before)
-      }
-
-      unlink(
-        file.path(tmp_parent, leaked),
-        recursive = TRUE,
-        force = TRUE
-      )
+    if (isTRUE(chromote::has_default_chromote_object())) {
+      try(chromote::default_chromote_object()$close(), silent = TRUE)
     },
     teardown_env()
   )


### PR DESCRIPTION
## Summary

* Chrome's scratch dirs now land in a suite-owned directory below the session `tempdir()`, pointed to through `TMPDIR` before the browser launches. The check code lists only the top level of the directory it hands subprocesses and skips `Rtmp*`, so the scratch sits one level below what it inspects. The sweep, its settle and the `CI` gate come out with it.

* Nothing timing-based can close that NOTE, which is why the sweep goes rather than getting hardened again: closing the browser waits for Chrome's main process, but a helper (crashpad, zygote) can drop a fresh scratch dir past any listing teardown has already taken. The redirect also reaches an abandoned launch attempt — the one `retry_chrome_launch()` leaves running until processx reaps it — which no `$close()` does, since every Chrome spawned after this file inherits it.

* Measured here with the check setup reproduced exactly: an empty directory standing in for `sessdir`, `TMPDIR` pointed at it, sampled while the browser was alive. Before, that directory's top level held `org.chromium.Chromium.eyYzCE` and `org.chromium.Chromium.scoped_dir.PlA5TC`. After, it holds only `RtmpT4wYqs`, with the scratch at `RtmpT4wYqs/chrome18b6b3774a36c7/`. It was still empty once the run exited with Chrome `SIGKILL`ed, so nothing was ever reclaimed.

* Same change as the one merged in blockr.core#330, whose merge-queue run reported `checking for detritus in the temp directory ... OK` and `Status: OK` on `ci / check (ubuntu-latest, oldrel-1)` — the job that had been ejecting PRs.

Fixes #414
